### PR TITLE
run codemodder on pygoat in CI

### DIFF
--- a/.github/workflows/codemod_pygoat.yml
+++ b/.github/workflows/codemod_pygoat.yml
@@ -1,0 +1,37 @@
+name: Codemod Pygoat
+
+on:
+  push:
+    branches:
+      - main
+      - develop
+  pull_request:
+    branches:
+      - main
+      - develop
+
+concurrency:
+  group: (${{ github.workflow }}-${{ github.event.inputs.branch || github.event.pull_request.head.ref }})
+  cancel-in-progress: true
+
+jobs:
+  test:
+    name: Run Codemod on Pygoat
+    runs-on: ubuntu-20.04
+    timeout-minutes: 10
+    steps:
+      - name: Set Up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.11'
+      - name: Check out codemodder
+        uses: actions/checkout@v3
+      - name: Install Dependencies
+        run: pip install -r requirements/codemodder.txt
+      - name: Check out Pygoat
+        uses: actions/checkout@v3
+        with:
+          repository: pixee/pygoat
+          path: pygoat
+      - name: Run Codemodder
+        run: python -m codemodder --output output.codetf pygoat


### PR DESCRIPTION
## Overview
*this PR adds a ci workflow that will clone pygoat and run codemodder on it*

## Description

* we discovered a codemodder traceback when running it on pygoat, so it seemed like a great idea to start this type of testing.
* right now, CI will fail if the status code of `python -m codemodder....` is anything other than 0. I tested the failure by reintroducing the issue that brought the traceback [here](https://github.com/pixee/codemodder-python/actions/runs/5963751090/job/16177555610)
* Later on we can add more testing on top of this, such as to assert specific changes to files or codetf output or even get to doing something like Pylint does, called Primer.


## Describe your testing approach

* a few CI runs

## Additional Details
* I considered running against a docker container but decided for the simplest solution

