### PR TITLE
Remove unused imports format fix

### DIFF
--- a/codemodder/codemods/transformations/remove_unused_imports.py
+++ b/codemodder/codemods/transformations/remove_unused_imports.py
@@ -37,9 +37,11 @@ class RemoveUnusedImportsTransformer(cst.CSTTransformer):
         names_to_keep = []
         for ia in original_node.names:
             if (ia, original_node) not in self.unused_imports:
-                names_to_keep.append(ia.with_changes(comma=cst.MaybeSentinel.DEFAULT))
+                names_to_keep.append(ia)
         if len(names_to_keep) == 0:
             return cst.RemoveFromParent()
+        if len(names_to_keep) != len(original_node.names):
+            names_to_keep[-1] = names_to_keep[-1].with_changes(comma=cst.MaybeSentinel.DEFAULT)
         return updated_node.with_changes(names=names_to_keep)
 
     def leave_Import(

--- a/codemodder/codemods/transformations/remove_unused_imports.py
+++ b/codemodder/codemods/transformations/remove_unused_imports.py
@@ -34,15 +34,21 @@ class RemoveUnusedImportsTransformer(cst.CSTTransformer):
         original_node: Union[cst.Import, cst.ImportFrom],
         updated_node: Union[cst.Import, cst.ImportFrom],
     ) -> Union[cst.Import, cst.ImportFrom, cst.RemovalSentinel]:
-        names_to_keep = []
-        for ia in original_node.names:
-            if (ia, original_node) not in self.unused_imports:
-                names_to_keep.append(ia)
-        if len(names_to_keep) == 0:
+        new_aliases = [
+            ia
+            for ia in original_node.names
+            if (ia, original_node) not in self.unused_imports
+        ]
+        if len(new_aliases) == 0:
             return cst.RemoveFromParent()
-        if len(names_to_keep) != len(original_node.names):
-            names_to_keep[-1] = names_to_keep[-1].with_changes(comma=cst.MaybeSentinel.DEFAULT)
-        return updated_node.with_changes(names=names_to_keep)
+        if len(new_aliases) != len(original_node.names):
+            # make no changes if all the aliases are there
+            # make sure the last one has no comma
+            new_aliases[-1] = new_aliases[-1].with_changes(
+                comma=cst.MaybeSentinel.DEFAULT
+            )
+            return updated_node.with_changes(names=new_aliases)
+        return updated_node
 
     def leave_Import(
         self, original_node: cst.Import, updated_node: cst.Import

--- a/tests/codemods/test_remove_unused_imports.py
+++ b/tests/codemods/test_remove_unused_imports.py
@@ -73,3 +73,9 @@ from b import *
 a.something
 """
         self.run_and_assert(tmpdir, before, before)
+
+    def test_keep_format(self, tmpdir):
+        before = "from a import b,c,d   \nprint(b)\nprint(d)"
+        after = "from a import b,d   \nprint(b)\nprint(d)"
+        self.run_and_assert(tmpdir, before, after)
+        assert len(self.codemod.CHANGES_IN_FILE) == 1


### PR DESCRIPTION
## Overview
Fixes for the `RemoveUnusedImports` codemod

## Description

Will now keep the format as much as possible to avoid unnecessary changes.

## Describe your testing approach

Some extra tests to cover those cases