### PR TITLE
new tempfile.mktemp codemod

### DIFF
--- a/codemodder/codemods/__init__.py
+++ b/codemodder/codemods/__init__.py
@@ -11,6 +11,7 @@ from codemodder.codemods.upgrade_sslcontext_tls import UpgradeSSLContextTLS
 from codemodder.codemods.url_sandbox import UrlSandbox
 from codemodder.codemods.process_creation_sandbox import ProcessSandbox
 from codemodder.codemods.remove_unnecessary_f_str import RemoveUnnecessaryFStr
+from codemodder.codemods.tempfile_mktemp import TempfileMktemp
 
 DEFAULT_CODEMODS = {
     DjangoDebugFlagOn,
@@ -24,6 +25,7 @@ DEFAULT_CODEMODS = {
     SecureRandom,
     UpgradeSSLContextTLS,
     UrlSandbox,
+    TempfileMktemp,
 }
 ALL_CODEMODS = DEFAULT_CODEMODS
 

--- a/codemodder/codemods/api/helpers.py
+++ b/codemodder/codemods/api/helpers.py
@@ -15,14 +15,22 @@ class Helpers:
             self.context, module, obj  # pylint: disable=no-member
         )
 
-    def update_call_target(self, original_node, new_target, replacement_args=None):
+    def update_call_target(
+        self, original_node, new_target, new_func=None, replacement_args=None
+    ):
         # TODO: is an assertion the best way to handle this?
         # Or should we just return the original node if it's not a Call?
         assert isinstance(original_node, cst.Call)
+
+        attr = (
+            cst.parse_expression(new_func)
+            if new_func
+            else cst.Name(value=get_call_name(original_node))
+        )
         return cst.Call(
             func=cst.Attribute(
                 value=cst.parse_expression(new_target),
-                attr=cst.Name(value=get_call_name(original_node)),
+                attr=attr,
             ),
             args=replacement_args if replacement_args else original_node.args,
         )

--- a/codemodder/codemods/tempfile_mktemp.py
+++ b/codemodder/codemods/tempfile_mktemp.py
@@ -1,0 +1,24 @@
+from codemodder.codemods.base_codemod import ReviewGuidance
+from codemodder.codemods.api import SemgrepCodemod
+
+
+class TempfileMktemp(SemgrepCodemod):
+    NAME = "secure-tempfile"
+    REVIEW_GUIDANCE = ReviewGuidance.MERGE_WITHOUT_REVIEW
+    DESCRIPTION = "Replaces `tempfile.mktemp` with `tempfile.mkstemp`."
+
+    @classmethod
+    def rule(cls):
+        return """
+        rules:
+          - patterns:
+            - pattern: tempfile.mktemp(...)
+            - pattern-inside: |
+                import tempfile
+                ...
+        """
+
+    def on_result_found(self, original_node, updated_node):
+        self.remove_unused_import(original_node)
+        self.add_needed_import("tempfile")
+        return self.update_call_target(updated_node, "tempfile", "mkstemp")

--- a/integration_tests/test_tempfile_mktemp.py
+++ b/integration_tests/test_tempfile_mktemp.py
@@ -1,0 +1,16 @@
+from codemodder.codemods.tempfile_mktemp import TempfileMktemp
+from integration_tests.base_test import (
+    BaseIntegrationTest,
+    original_and_expected_from_code_path,
+)
+
+
+class TestTempfileMktemp(BaseIntegrationTest):
+    codemod = TempfileMktemp
+    code_path = "tests/samples/tempfile_mktemp.py"
+    original_code, expected_new_code = original_and_expected_from_code_path(
+        code_path, [(2, "tempfile.mkstemp()\n")]
+    )
+    expected_diff = '--- \n+++ \n@@ -1,4 +1,4 @@\n import tempfile\n \n-tempfile.mktemp()\n+tempfile.mkstemp()\n var = "hello"\n'
+    expected_line_change = "3"
+    change_description = TempfileMktemp.CHANGE_DESCRIPTION

--- a/tests/codemods/test_tempfile_mktemp.py
+++ b/tests/codemods/test_tempfile_mktemp.py
@@ -1,0 +1,82 @@
+import pytest
+from codemodder.codemods.tempfile_mktemp import TempfileMktemp
+from tests.codemods.base_codemod_test import BaseSemgrepCodemodTest
+
+
+class TestTempfileMktemp(BaseSemgrepCodemodTest):
+    codemod = TempfileMktemp
+
+    def test_rule_ids(self):
+        assert self.codemod.RULE_IDS == ["secure-tempfile"]
+
+    def test_import(self, tmpdir):
+        input_code = """import tempfile
+
+tempfile.mktemp()
+var = "hello"
+"""
+        expexted_output = """import tempfile
+
+tempfile.mkstemp()
+var = "hello"
+"""
+
+        self.run_and_assert(tmpdir, input_code, expexted_output)
+
+    def test_import_with_arg(self, tmpdir):
+        input_code = """import tempfile
+
+tempfile.mktemp('something')
+var = "hello"
+"""
+        expexted_output = """import tempfile
+
+tempfile.mkstemp('something')
+var = "hello"
+"""
+
+        self.run_and_assert(tmpdir, input_code, expexted_output)
+
+    def test_from_import(self, tmpdir):
+        input_code = """from tempfile import mktemp
+
+mktemp()
+var = "hello"
+"""
+        expexted_output = """import tempfile
+
+tempfile.mkstemp()
+var = "hello"
+"""
+        self.run_and_assert(tmpdir, input_code, expexted_output)
+
+    @pytest.mark.skip()
+    def test_import_alias(self, tmpdir):
+        input_code = """import tempfile as _tempfile
+
+_tempfile.mktemp()
+var = "hello"
+"""
+        expexted_output = """import tempfile as _tempfile
+
+_tempfile.mkstemp()
+var = "hello"
+"""
+        self.run_and_assert(tmpdir, input_code, expexted_output)
+
+    def test_random_multifunctions(self, tmpdir):
+        input_code = """from tempfile import mktemp, TemporaryFile
+
+mktemp()
+TemporaryFile()
+var = "hello"
+"""
+        expexted_output = """from tempfile import TemporaryFile
+import tempfile
+
+tempfile.mkstemp()
+TemporaryFile()
+var = "hello"
+"""
+
+        self.run_and_assert(tmpdir, input_code, expexted_output)

--- a/tests/samples/tempfile_mktemp.py
+++ b/tests/samples/tempfile_mktemp.py
@@ -1,0 +1,4 @@
+import tempfile
+
+tempfile.mktemp()
+var = "hello"


### PR DESCRIPTION
## Overview
*Adding a new codemod to replace `mktemp` with `mkstemp`*

## Description

* see [doc](https://www.notion.so/pixee/Make-secure-tempfiles-5f461c5e3ae14d32bb02e5d2b31117e9)

* I'm following the new api as much as possible. The only important highlight here is the way I decided to handle the from import case. I made the decision to convert `from tempfile import mktemp` to `import tempfile` and the call to be used accordingly. I recognize ideally we would keep the from import, but doing so required work akin to what's happening in url_sandbox, and we're not there yet. Instead, I decided that this is sufficient and works. I'm starting to think this is a good approach to keep a simple api. It's better to have a codemod that makes a good change with a simple API than to have a super complex API that will make a "perfect" codemod.

## Documentation
* Does the README need to be updated?
* Do customer docs need to beg updated?
* Did you create any documentation related to this work?

## Describe your testing approach

* Happy/sad paths, Edge cases, Bad inputs
* Explanation of manual testing with any TS screenshots
* Or, an explanation of why this change does not need tests


## Performance

* How do you expect this PR to affect performance?

## Additional Details
* any follow up tickets or discussion
* Any specific merge / deploy details
