### PR TITLE
Codemod to check verify flag in requests

### DIFF
--- a/integration_tests/base_test.py
+++ b/integration_tests/base_test.py
@@ -45,6 +45,7 @@ class BaseIntegrationTest(DependencyTestMixin, CleanRepoMixin):
     output_path = "test-codetf.txt"
     num_changes = 1
     _lines = []
+    num_changed_files = 1
 
     def _assert_run_fields(self, run, output_path):
         assert run["vendor"] == "pixee"
@@ -62,8 +63,13 @@ class BaseIntegrationTest(DependencyTestMixin, CleanRepoMixin):
         assert len(results) == 1
         result = results[0]
         assert result["codemod"] == self.codemod.full_name()
-        assert len(result["changeset"]) == 1
-        change = result["changeset"][0]
+        assert len(result["changeset"]) == self.num_changed_files
+
+        # A codemod may change multiple files. For now we will
+        # assert the resulting data for one file only.
+        change = [
+            result for result in result["changeset"] if result["path"] == output_path
+        ][0]
         assert change["path"] == output_path
         assert change["diff"] == self.expected_diff
 

--- a/integration_tests/semgrep/test_semgrep.py
+++ b/integration_tests/semgrep/test_semgrep.py
@@ -41,6 +41,7 @@ class TestSemgrep:
         assert sorted(results_by_path_and_id.keys()) == [
             "tests/samples/insecure_random.py",
             "tests/samples/make_request.py",
+            "tests/samples/unverified_request.py",
         ]
 
         url_sandbox_results = results_by_path_and_id["tests/samples/make_request.py"][

--- a/integration_tests/test_request_verify.py
+++ b/integration_tests/test_request_verify.py
@@ -1,0 +1,24 @@
+from codemodder.codemods.requests_verify import RequestsVerify
+from integration_tests.base_test import (
+    BaseIntegrationTest,
+    original_and_expected_from_code_path,
+)
+
+
+class TestRequestsVerify(BaseIntegrationTest):
+    codemod = RequestsVerify
+    code_path = "tests/samples/unverified_request.py"
+    original_code, expected_new_code = original_and_expected_from_code_path(
+        code_path,
+        [
+            (2, """requests.get("www.google.com", verify=True)\n"""),
+            (
+                3,
+                """requests.post("https/some-api/", json={"id": 1234, "price": 18}, verify=True)\n""",
+            ),
+        ],
+    )
+    expected_diff = '--- \n+++ \n@@ -1,5 +1,5 @@\n import requests\n \n-requests.get("www.google.com", verify=False)\n-requests.post("https/some-api/", json={"id": 1234, "price": 18}, verify=False)\n+requests.get("www.google.com", verify=True)\n+requests.post("https/some-api/", json={"id": 1234, "price": 18}, verify=True)\n var = "hello"\n'
+    expected_line_change = "3"
+    num_changes = 2
+    change_description = RequestsVerify.CHANGE_DESCRIPTION

--- a/integration_tests/test_url_sandbox.py
+++ b/integration_tests/test_url_sandbox.py
@@ -19,6 +19,7 @@ class TestUrlSandbox(BaseIntegrationTest):
     expected_diff = '--- \n+++ \n@@ -1,4 +1,4 @@\n-import requests\n+from security import safe_requests\n \n-requests.get("www.google.com")\n+safe_requests.get("www.google.com")\n var = "hello"\n'
     expected_line_change = "3"
     change_description = UrlSandbox.CHANGE_DESCRIPTION
+    num_changed_files = 2
 
     requirements_path = "tests/samples/requirements.txt"
     original_requirements = "# file used to test dependency management\nrequests==2.31.0\nblack==23.7.*\nmypy~=1.4\npylint>1\n"

--- a/src/codemodder/__main__.py
+++ b/src/codemodder/__main__.py
@@ -76,7 +76,7 @@ def run_codemods_for_file(
                 ChangeSet(
                     str(file_context.file_path),
                     diff,
-                    changes=codemod_kls.CHANGES_IN_FILE,
+                    changes=file_context.codemod_changes,
                 ).to_json()
             )
             if file_context.dry_run:

--- a/src/codemodder/codemods/__init__.py
+++ b/src/codemodder/codemods/__init__.py
@@ -13,6 +13,7 @@ from codemodder.codemods.url_sandbox import UrlSandbox
 from codemodder.codemods.process_creation_sandbox import ProcessSandbox
 from codemodder.codemods.remove_unnecessary_f_str import RemoveUnnecessaryFStr
 from codemodder.codemods.tempfile_mktemp import TempfileMktemp
+from codemodder.codemods.requests_verify import RequestsVerify
 
 DEFAULT_CODEMODS = {
     DjangoDebugFlagOn,
@@ -28,6 +29,7 @@ DEFAULT_CODEMODS = {
     UpgradeSSLContextTLS,
     UrlSandbox,
     TempfileMktemp,
+    RequestsVerify,
 }
 ALL_CODEMODS = DEFAULT_CODEMODS
 

--- a/src/codemodder/codemods/api/__init__.py
+++ b/src/codemodder/codemods/api/__init__.py
@@ -70,11 +70,10 @@ class BaseCodemod(
     Helpers,
 ):
     CHANGESET_ALL_FILES: list = []
-    CHANGES_IN_FILE: list = []
 
     def report_change(self, original_node):
         line_number = self.lineno_for_node(original_node)
-        self.CHANGES_IN_FILE.append(
+        self.file_context.codemod_changes.append(
             Change(str(line_number), self.CHANGE_DESCRIPTION).to_json()
         )
 

--- a/src/codemodder/codemods/base_codemod.py
+++ b/src/codemodder/codemods/base_codemod.py
@@ -26,7 +26,6 @@ class BaseCodemod:
     def __init_subclass__(cls, **kwargs):
         super().__init_subclass__(**kwargs)
         cls.CHANGESET_ALL_FILES: list = []
-        cls.CHANGES_IN_FILE: list = []
 
         if "codemodder.codemods.base_codemod.SemgrepCodemod" in str(cls):
             # hack: SemgrepCodemod won't NotImplementedError but all other child

--- a/src/codemodder/codemods/django_debug_flag_on.py
+++ b/src/codemodder/codemods/django_debug_flag_on.py
@@ -38,7 +38,9 @@ class DjangoDebugFlagOn(SemgrepCodemod, Codemod):
             )
             new_tree = debug_flag_transformer.transform_module(tree)
             if debug_flag_transformer.changes_in_file:
-                self.CHANGES_IN_FILE.extend(debug_flag_transformer.changes_in_file)
+                self.file_context.codemod_changes.extend(
+                    debug_flag_transformer.changes_in_file
+                )
                 return new_tree
         return tree
 

--- a/src/codemodder/codemods/django_session_cookie_secure_off.py
+++ b/src/codemodder/codemods/django_session_cookie_secure_off.py
@@ -37,7 +37,7 @@ class DjangoSessionCookieSecureOff(SemgrepCodemod, Codemod):
             )
             new_tree = transformer.transform_module(tree)
             if transformer.changes_in_file:
-                self.CHANGES_IN_FILE.extend(transformer.changes_in_file)
+                self.file_context.codemod_changes.extend(transformer.changes_in_file)
             return new_tree
         return tree
 

--- a/src/codemodder/codemods/order_imports.py
+++ b/src/codemodder/codemods/order_imports.py
@@ -54,7 +54,7 @@ class OrderImports(BaseCodemod, Codemod):
                     line_number = self.node_position(
                         top_imports_visitor.top_imports_blocks[i][0]
                     ).start.line
-                    self.CHANGES_IN_FILE.append(
+                    self.file_context.codemod_changes.append(
                         Change(str(line_number), self.CHANGE_DESCRIPTION).to_json()
                     )
             return result_tree

--- a/src/codemodder/codemods/remove_unused_imports.py
+++ b/src/codemodder/codemods/remove_unused_imports.py
@@ -38,7 +38,7 @@ class RemoveUnusedImports(BaseCodemod, Codemod):
         for import_alias, importt in gather_unused_visitor.unused_imports:
             pos = self.get_metadata(PositionProvider, import_alias)
             if self.filter_by_path_includes_or_excludes(pos):
-                RemoveUnusedImports.CHANGES_IN_FILE.append(
+                self.file_context.codemod_changes.append(
                     Change(pos.start.line, self.CHANGE_DESCRIPTION).to_json()
                 )
                 filtered_unused_imports.add((import_alias, importt))

--- a/src/codemodder/codemods/requests_verify.py
+++ b/src/codemodder/codemods/requests_verify.py
@@ -1,0 +1,25 @@
+from codemodder.codemods.base_codemod import ReviewGuidance
+from codemodder.codemods.api import SemgrepCodemod
+
+
+class RequestsVerify(SemgrepCodemod):
+    NAME = "requests-verify"
+    REVIEW_GUIDANCE = ReviewGuidance.MERGE_AFTER_CURSORY_REVIEW
+    DESCRIPTION = (
+        "Makes any calls to requests.{func} with `verify=False` to `verify=True`"
+    )
+
+    @classmethod
+    def rule(cls):
+        return """
+        rules:
+          - patterns:
+            - pattern: requests.$F(..., verify=False, ...)
+            - pattern-inside: |
+                import requests
+                ...
+        """
+
+    def on_result_found(self, original_node, updated_node):
+        new_args = self.replace_arg(original_node, "verify", "True")
+        return self.update_arg_target(updated_node, new_args)

--- a/src/codemodder/codemods/upgrade_sslcontext_tls.py
+++ b/src/codemodder/codemods/upgrade_sslcontext_tls.py
@@ -58,7 +58,7 @@ class UpgradeSSLContextTLS(SemgrepCodemod, BaseTransformer):
             pos_to_match
         ) and self.filter_by_path_includes_or_excludes(pos_to_match):
             line_number = pos_to_match.start.line
-            self.CHANGES_IN_FILE.append(
+            self.file_context.codemod_changes.append(
                 Change(str(line_number), self.CHANGE_DESCRIPTION).to_json()
             )
 

--- a/src/codemodder/codemods/url_sandbox.py
+++ b/src/codemodder/codemods/url_sandbox.py
@@ -49,7 +49,9 @@ class UrlSandbox(SemgrepCodemod, Codemod):
         )
         tree.visit(find_requests_visitor)
         if find_requests_visitor.nodes_to_change:
-            UrlSandbox.CHANGES_IN_FILE.extend(find_requests_visitor.changes_in_file)
+            self.file_context.codemod_changes.extend(
+                find_requests_visitor.changes_in_file
+            )
             new_tree = tree.visit(ReplaceNodes(find_requests_visitor.nodes_to_change))
             DependencyManager().add(["security==1.0.1"])
             # if it finds any request.get(...), try to remove the imports

--- a/src/codemodder/file_context.py
+++ b/src/codemodder/file_context.py
@@ -20,3 +20,4 @@ class FileContext:
             self.line_include = []
         if self.line_exclude is None:
             self.line_exclude = []
+        self.codemod_changes = []

--- a/tests/codemods/test_order_imports.py
+++ b/tests/codemods/test_order_imports.py
@@ -10,7 +10,7 @@ class TestOrderImports(BaseCodemodTest):
 from b import c
 """
         self.run_and_assert(tmpdir, before, before)
-        assert len(self.codemod.CHANGES_IN_FILE) == 0
+        assert len(self.file_context.codemod_changes) == 0
 
     def test_separate_from_imports_and_regular(self, tmpdir):
         before = r"""import y
@@ -21,7 +21,7 @@ import x"""
 import y
 from a import c"""
         self.run_and_assert(tmpdir, before, after)
-        assert len(self.codemod.CHANGES_IN_FILE) == 1
+        assert len(self.file_context.codemod_changes) == 1
 
     def test_consolidate_from_imports(self, tmpdir):
         before = r"""from a import a1
@@ -30,7 +30,7 @@ from a import a2"""
 
         after = r"""from a import a1, a2, a3"""
         self.run_and_assert(tmpdir, before, after)
-        assert len(self.codemod.CHANGES_IN_FILE) == 1
+        assert len(self.file_context.codemod_changes) == 1
 
     def test_order_blocks_separately(self, tmpdir):
         before = r"""import x
@@ -46,7 +46,7 @@ import b
 import y"""
 
         self.run_and_assert(tmpdir, before, after)
-        assert len(self.codemod.CHANGES_IN_FILE) == 2
+        assert len(self.file_context.codemod_changes) == 2
 
     def test_preserve_comments(self, tmpdir):
         before = r"""# do not move
@@ -69,7 +69,7 @@ from b import b1, b2
 """
 
         self.run_and_assert(tmpdir, before, after)
-        assert len(self.codemod.CHANGES_IN_FILE) == 1
+        assert len(self.file_context.codemod_changes) == 1
 
     def test_handle_star_imports(self, tmpdir):
         before = r"""from a import x
@@ -82,7 +82,7 @@ from a import *
 from a import b, x"""
 
         self.run_and_assert(tmpdir, before, after)
-        assert len(self.codemod.CHANGES_IN_FILE) == 1
+        assert len(self.file_context.codemod_changes) == 1
 
     def test_handle_composite_and_relative_imports(self, tmpdir):
         before = r"""from . import a
@@ -93,7 +93,7 @@ import a.b.c.d"""
 from . import a"""
 
         self.run_and_assert(tmpdir, before, after)
-        assert len(self.codemod.CHANGES_IN_FILE) == 1
+        assert len(self.file_context.codemod_changes) == 1
 
     def test_natural_order(self, tmpdir):
         before = """from a import Object11
@@ -104,7 +104,7 @@ from a import Object1
 """
 
         self.run_and_assert(tmpdir, before, after)
-        assert len(self.codemod.CHANGES_IN_FILE) == 1
+        assert len(self.file_context.codemod_changes) == 1
 
     def test_wont_remove_unused_future(self, tmpdir):
         before = """from __future__ import absolute_import
@@ -113,7 +113,7 @@ from a import Object1
         after = before
 
         self.run_and_assert(tmpdir, before, after)
-        assert len(self.codemod.CHANGES_IN_FILE) == 0
+        assert len(self.file_context.codemod_changes) == 0
 
     def test_organize_by_sections(self, tmpdir):
         before = """from codemodder.codemods.transformations.clean_imports import CleanImports
@@ -134,7 +134,7 @@ from .local import Object2
 """
 
         self.run_and_assert(tmpdir, before, after)
-        assert len(self.codemod.CHANGES_IN_FILE) == 1
+        assert len(self.file_context.codemod_changes) == 1
 
     def test_will_ignore_non_top_level(self, tmpdir):
         before = """import global2
@@ -159,7 +159,7 @@ if True:
     import global3
 """
         self.run_and_assert(tmpdir, before, after)
-        assert len(self.codemod.CHANGES_IN_FILE) == 1
+        assert len(self.file_context.codemod_changes) == 1
 
     def test_it_can_change_behavior(self, tmpdir):
         # note that c will change from b to e due to the sort
@@ -175,4 +175,4 @@ from d import e as c
 c()
 """
         self.run_and_assert(tmpdir, before, after)
-        assert len(self.codemod.CHANGES_IN_FILE) == 1
+        assert len(self.file_context.codemod_changes) == 1

--- a/tests/codemods/test_remove_unnecessary_f_str.py
+++ b/tests/codemods/test_remove_unnecessary_f_str.py
@@ -17,7 +17,7 @@ good = rf"good\d+{bar}"
 good = f"wow i don't have args but don't mess my braces {{ up }}"
 """
         self.run_and_assert(tmpdir, before, before)
-        assert len(self.codemod.CHANGES_IN_FILE) == 0
+        assert len(self.file_context.codemod_changes) == 0
 
     def test_change(self, tmpdir):
         before = r"""
@@ -31,4 +31,4 @@ bad: str = 'bad'
 bad: str = r'bad\d+'
 """
         self.run_and_assert(tmpdir, before, after)
-        assert len(self.codemod.CHANGES_IN_FILE) == 3
+        assert len(self.file_context.codemod_changes) == 3

--- a/tests/codemods/test_remove_unused_imports.py
+++ b/tests/codemods/test_remove_unused_imports.py
@@ -12,7 +12,7 @@ a
 c
 """
         self.run_and_assert(tmpdir, before, before)
-        assert len(self.codemod.CHANGES_IN_FILE) == 0
+        assert len(self.file_context.codemod_changes) == 0
 
     def test_change(self, tmpdir):
         before = r"""import a
@@ -20,7 +20,7 @@ c
         after = r"""
 """
         self.run_and_assert(tmpdir, before, after)
-        assert len(self.codemod.CHANGES_IN_FILE) == 1
+        assert len(self.file_context.codemod_changes) == 1
 
     def test_remove_import(self, tmpdir):
         before = r"""import a
@@ -32,7 +32,7 @@ a
 """
 
         self.run_and_assert(tmpdir, before, after)
-        assert len(self.codemod.CHANGES_IN_FILE) == 1
+        assert len(self.file_context.codemod_changes) == 1
 
     def test_remove_single_from_import(self, tmpdir):
         before = r"""from b import c, d
@@ -43,7 +43,7 @@ c
 c
 """
         self.run_and_assert(tmpdir, before, after)
-        assert len(self.codemod.CHANGES_IN_FILE) == 1
+        assert len(self.file_context.codemod_changes) == 1
 
     def test_remove_from_import(self, tmpdir):
         before = r"""from b import c
@@ -51,7 +51,7 @@ c
 
         after = "\n"
         self.run_and_assert(tmpdir, before, after)
-        assert len(self.codemod.CHANGES_IN_FILE) == 1
+        assert len(self.file_context.codemod_changes) == 1
 
     def test_remove_inner_import(self, tmpdir):
         before = r"""import a
@@ -65,7 +65,7 @@ def something():
 """
 
         self.run_and_assert(tmpdir, before, after)
-        assert len(self.codemod.CHANGES_IN_FILE) == 1
+        assert len(self.file_context.codemod_changes) == 1
 
     def test_no_import_star_removal(self, tmpdir):
         before = r"""import a
@@ -78,4 +78,4 @@ a.something
         before = "from a import b,c,d   \nprint(b)\nprint(d)"
         after = "from a import b,d   \nprint(b)\nprint(d)"
         self.run_and_assert(tmpdir, before, after)
-        assert len(self.codemod.CHANGES_IN_FILE) == 1
+        assert len(self.file_context.codemod_changes) == 1

--- a/tests/codemods/test_request_verify.py
+++ b/tests/codemods/test_request_verify.py
@@ -1,0 +1,103 @@
+import pytest
+from codemodder.codemods.requests_verify import RequestsVerify
+from tests.codemods.base_codemod_test import BaseSemgrepCodemodTest
+
+REQUEST_FUNCS = ["get", "post", "request"]
+
+
+class TestRequestsVerify(BaseSemgrepCodemodTest):
+    codemod = RequestsVerify
+
+    def test_rule_ids(self):
+        assert self.codemod.RULE_IDS == ["requests-verify"]
+
+    @pytest.mark.parametrize("func", REQUEST_FUNCS)
+    def test_default_verify(self, tmpdir, func):
+        input_code = f"""import requests
+
+requests.{func}("www.google.com")
+var = "hello"
+"""
+        self.run_and_assert(tmpdir, input_code, input_code)
+
+    @pytest.mark.parametrize("func", REQUEST_FUNCS)
+    @pytest.mark.parametrize("verify_val", ["True", "'/some/path'"])
+    def test_verify(self, tmpdir, verify_val, func):
+        input_code = f"""import requests
+
+requests.{func}("www.google.com", verify={verify_val})
+var = "hello"
+"""
+        self.run_and_assert(tmpdir, input_code, input_code)
+
+    @pytest.mark.parametrize("func", REQUEST_FUNCS)
+    def test_import(self, tmpdir, func):
+        input_code = f"""import requests
+
+requests.{func}("www.google.com", verify=False)
+var = "hello"
+"""
+        expected = f"""import requests
+
+requests.{func}("www.google.com", verify=True)
+var = "hello"
+"""
+        self.run_and_assert(tmpdir, input_code, expected)
+
+    @pytest.mark.parametrize("func", REQUEST_FUNCS)
+    def test_from_import(self, tmpdir, func):
+        input_code = f"""from requests import {func}
+
+{func}("www.google.com", verify=False)
+var = "hello"
+"""
+        expected = f"""from requests import {func}
+
+{func}("www.google.com", verify=True)
+var = "hello"
+"""
+        self.run_and_assert(tmpdir, input_code, expected)
+
+    @pytest.mark.parametrize("func", REQUEST_FUNCS)
+    def test_multifunctions(self, tmpdir, func):
+        input_code = f"""import requests
+
+requests.{func}("www.google.com", verify=False)
+requests.HTTPError()
+var = "hello"
+"""
+        expected = f"""import requests
+
+requests.{func}("www.google.com", verify=True)
+requests.HTTPError()
+var = "hello"
+"""
+        self.run_and_assert(tmpdir, input_code, expected)
+
+    @pytest.mark.parametrize("func", REQUEST_FUNCS)
+    def test_import_alias(self, tmpdir, func):
+        input_code = f"""import requests as req_mod
+
+req_mod.{func}("www.google.com", verify=False)
+var = "hello"
+"""
+        expected = f"""import requests as req_mod
+
+req_mod.{func}("www.google.com", verify=True)
+var = "hello"
+"""
+        self.run_and_assert(tmpdir, input_code, expected)
+
+    @pytest.mark.parametrize("func", REQUEST_FUNCS)
+    def test_multiple_kwargs(self, tmpdir, func):
+        input_code = f"""import requests
+
+requests.{func}("www.google.com", headers={{"Content-Type":"text"}}, verify=False)
+var = "hello"
+"""
+        expected = f"""import requests
+
+requests.{func}("www.google.com", headers={{"Content-Type":"text"}}, verify=True)
+var = "hello"
+"""
+        self.run_and_assert(tmpdir, input_code, expected)

--- a/tests/samples/unverified_request.py
+++ b/tests/samples/unverified_request.py
@@ -1,0 +1,5 @@
+import requests
+
+requests.get("www.google.com", verify=False)
+requests.post("https/some-api/", json={"id": 1234, "price": 18}, verify=False)
+var = "hello"

--- a/tests/shared.py
+++ b/tests/shared.py
@@ -19,4 +19,3 @@ def reset_global_state():
     RESULTS_BY_CODEMOD.clear()
     for codemod_kls in ALL_CODEMODS:
         codemod_kls.CHANGESET_ALL_FILES = []
-        codemod_kls.CHANGES_IN_FILE = []


### PR DESCRIPTION
## Overview
*This PR adds a codemod to check (and flip, if needed) the `verify` flag passed to `requests.func_that_uses_this_flag` and some important changes to codemodder, too*

## Description

* docs for codemod are [here](https://www.notion.so/pixee/Set-request-s-verify-flag-to-True-2470dd4e52de47a695f0cf3706817052)

* while this codemod could've instead been done within the url-sandbox codemod instead of on its own, we decided that we're uncertain how users will react to url-sandbox in the first place. So it made sense to have it separate for now.
* Since this new codemod changes `requests.FUNC`, it was the first time I saw one codemod changing multiple files. This showed that we were mistaken in storing changes to each file as a global for the codemod, as this made the results be shared for all files. Instead, I moved these results to file context and things work as expected now.

## Documentation
* Does the README need to be updated?
* Do customer docs need to beg updated?
* Did you create any documentation related to this work?

## Describe your testing approach

* necessary changes to integration tests to allow flexibility for codemodder to change more than one file. But we just assert the data for the first one.
* for this new codemod, I tested cases when verify is the default value, when it's True or a string, and when it's False.


## Performance

* How do you expect this PR to affect performance?

## Additional Details
* any follow up tickets or discussion
* Any specific merge / deploy details
