### PR TITLE
Implement codemod for sslcontext-minimum-version

### DIFF
--- a/integration_tests/test_upgrade_sslcontext_minimum_version.py
+++ b/integration_tests/test_upgrade_sslcontext_minimum_version.py
@@ -1,0 +1,23 @@
+from codemodder.codemods.upgrade_sslcontext_minimum_version import (
+    UpgradeSSLContextMinimumVersion,
+)
+from integration_tests.base_test import (
+    BaseIntegrationTest,
+    original_and_expected_from_code_path,
+)
+
+
+class TestUpgradeSSLContextMininumVersion(BaseIntegrationTest):
+    codemod = UpgradeSSLContextMinimumVersion
+    code_path = "tests/samples/upgrade_sslcontext_minimum_version.py"
+    original_code, expected_new_code = original_and_expected_from_code_path(
+        code_path,
+        [
+            (1, "import ssl\n\n"),
+            (7, "my_ctx.minimum_version = ssl.TLSVersion.TLSv1_2\n"),
+        ],
+    )
+
+    expected_diff = '--- \n+++ \n@@ -1,8 +1,9 @@\n from ssl import PROTOCOL_TLS_CLIENT, SSLContext, TLSVersion\n+import ssl\n \n my_ctx = SSLContext(protocol=PROTOCOL_TLS_CLIENT)\n \n print("FOO")\n \n my_ctx.maximum_version = TLSVersion.MAXIMUM_SUPPORTED\n-my_ctx.minimum_version = TLSVersion.TLSv1_1\n+my_ctx.minimum_version = ssl.TLSVersion.TLSv1_2\n'
+    expected_line_change = "8"
+    change_description = UpgradeSSLContextMinimumVersion.CHANGE_DESCRIPTION

--- a/src/codemodder/codemods/__init__.py
+++ b/src/codemodder/codemods/__init__.py
@@ -9,6 +9,9 @@ from codemodder.codemods.harden_ruamel import HardenRuamel
 from codemodder.codemods.limit_readline import LimitReadline
 from codemodder.codemods.secure_random import SecureRandom
 from codemodder.codemods.upgrade_sslcontext_tls import UpgradeSSLContextTLS
+from codemodder.codemods.upgrade_sslcontext_minimum_version import (
+    UpgradeSSLContextMinimumVersion,
+)
 from codemodder.codemods.url_sandbox import UrlSandbox
 from codemodder.codemods.process_creation_sandbox import ProcessSandbox
 from codemodder.codemods.remove_unnecessary_f_str import RemoveUnnecessaryFStr
@@ -27,6 +30,7 @@ DEFAULT_CODEMODS = {
     RemoveUnusedImports,
     SecureRandom,
     UpgradeSSLContextTLS,
+    UpgradeSSLContextMinimumVersion,
     UrlSandbox,
     TempfileMktemp,
     RequestsVerify,

--- a/src/codemodder/codemods/api/__init__.py
+++ b/src/codemodder/codemods/api/__init__.py
@@ -121,3 +121,16 @@ class SemgrepCodemod(
                 return new_node
 
         return updated_node
+
+    def leave_Assign(self, original_node, updated_node):
+        pos_to_match = self.node_position(original_node)
+        if self.filter_by_result(
+            pos_to_match
+        ) and self.filter_by_path_includes_or_excludes(pos_to_match):
+            self.report_change(original_node)
+            if (attr := getattr(self, "on_result_found", None)) is not None:
+                # pylint: disable=not-callable
+                new_node = attr(original_node, updated_node)
+                return new_node
+
+        return updated_node

--- a/src/codemodder/codemods/api/helpers.py
+++ b/src/codemodder/codemods/api/helpers.py
@@ -40,6 +40,10 @@ class Helpers:
             args=[new if isinstance(new, cst.Arg) else cst.Arg(new) for new in new_args]
         )
 
+    def update_assign_rhs(self, updated_node: cst.Assign, rhs: str):
+        value = cst.parse_expression(rhs)
+        return updated_node.with_changes(value=value)
+
     def parse_expression(self, expression: str):
         return cst.parse_expression(expression)
 

--- a/src/codemodder/codemods/upgrade_sslcontext_minimum_version.py
+++ b/src/codemodder/codemods/upgrade_sslcontext_minimum_version.py
@@ -11,23 +11,25 @@ class UpgradeSSLContextMinimumVersion(SemgrepCodemod):
     def rule(cls):
         return """
         rules:
-          - patterns:
-            - pattern: |
-                $CONTEXT.minimum_version = ssl.TLSVersion.$VERSION
-            - pattern-inside: |
-                import ssl
-                ...
-                $CONTEXT = ssl.SSLContext(...)
-                ...
-            - metavariable-pattern:
-                metavariable: $VERSION
-                patterns:
-                  - pattern-either:
-                    - pattern: SSLv2
-                    - pattern: SSLv3
-                    - pattern: TLSv1
-                    - pattern: TLSv1_1
-                    - pattern: MINIMUM_SUPPORTED
+          - mode: taint
+            pattern-sources:
+              - patterns:
+                - pattern: ssl.SSLContext(...)
+                - pattern-inside: |
+                    import ssl
+                    ...
+            pattern-sinks:
+              - patterns:
+                - pattern: $SINK.minimum_version = ssl.TLSVersion.$VERSION
+                - metavariable-pattern:
+                    metavariable: $VERSION
+                    patterns:
+                      - pattern-either:
+                        - pattern: SSLv2
+                        - pattern: SSLv3
+                        - pattern: TLSv1
+                        - pattern: TLSv1_1
+                        - pattern: MINIMUM_SUPPORTED
         """
 
     def on_result_found(self, original_node, updated_node):

--- a/src/codemodder/codemods/upgrade_sslcontext_minimum_version.py
+++ b/src/codemodder/codemods/upgrade_sslcontext_minimum_version.py
@@ -1,0 +1,36 @@
+from codemodder.codemods.base_codemod import ReviewGuidance
+from codemodder.codemods.api import SemgrepCodemod
+
+
+class UpgradeSSLContextMinimumVersion(SemgrepCodemod):
+    NAME = "upgrade-sslcontext-minimum-version"
+    REVIEW_GUIDANCE = ReviewGuidance.MERGE_WITHOUT_REVIEW
+    DESCRIPTION = "Replaces minimum SSL/TLS version for SSLContext"
+
+    @classmethod
+    def rule(cls):
+        return """
+        rules:
+          - patterns:
+            - pattern: |
+                $CONTEXT.minimum_version = ssl.TLSVersion.$VERSION
+            - pattern-inside: |
+                import ssl
+                ...
+                $CONTEXT = ssl.SSLContext(...)
+                ...
+            - metavariable-pattern:
+                metavariable: $VERSION
+                patterns:
+                  - pattern-either:
+                    - pattern: SSLv2
+                    - pattern: SSLv3
+                    - pattern: TLSv1
+                    - pattern: TLSv1_1
+                    - pattern: MINIMUM_SUPPORTED
+        """
+
+    def on_result_found(self, original_node, updated_node):
+        self.remove_unused_import(original_node)
+        self.add_needed_import("ssl")
+        return self.update_assign_rhs(updated_node, "ssl.TLSVersion.TLSv1_2")

--- a/tests/codemods/test_upgrade_sslcontext_minimum_version.py
+++ b/tests/codemods/test_upgrade_sslcontext_minimum_version.py
@@ -70,3 +70,18 @@ context = whatever.SSLContext()
 context.minimum_version = ssl.TLSVersion.TLSv1_2
 """
         self.run_and_assert(tmpdir, input_code, expexted_output)
+
+    def test_with_dataflow(self, tmpdir):
+        input_code = """import ssl
+
+context = ssl.SSLContext()
+alias = context
+alias.minimum_version = ssl.TLSVersion.SSLv3
+"""
+        expexted_output = """import ssl
+
+context = ssl.SSLContext()
+alias = context
+alias.minimum_version = ssl.TLSVersion.TLSv1_2
+"""
+        self.run_and_assert(tmpdir, input_code, expexted_output)

--- a/tests/codemods/test_upgrade_sslcontext_minimum_version.py
+++ b/tests/codemods/test_upgrade_sslcontext_minimum_version.py
@@ -1,0 +1,72 @@
+import pytest
+from codemodder.codemods.upgrade_sslcontext_minimum_version import (
+    UpgradeSSLContextMinimumVersion,
+)
+from tests.codemods.base_codemod_test import BaseSemgrepCodemodTest
+
+INSECURE_VERSIONS = [
+    "TLSv1",
+    "TLSv1_1",
+    "SSLv2",
+    "SSLv3",
+    "MINIMUM_SUPPORTED",
+]
+
+
+class TestUpgradeSSLContextMininumVersion(BaseSemgrepCodemodTest):
+    codemod = UpgradeSSLContextMinimumVersion
+
+    @pytest.mark.parametrize("version", INSECURE_VERSIONS)
+    def test_upgrade_minimum_version(self, tmpdir, version):
+        input_code = f"""import ssl
+
+context = ssl.SSLContext()
+context.minimum_version = ssl.TLSVersion.{version}
+"""
+        expexted_output = """import ssl
+
+context = ssl.SSLContext()
+context.minimum_version = ssl.TLSVersion.TLSv1_2
+"""
+        self.run_and_assert(tmpdir, input_code, expexted_output)
+
+    def test_upgrade_minimum_version_add_import(self, tmpdir):
+        input_code = """from ssl import SSLContext, TLSVersion
+
+context = SSLContext()
+context.minimum_version = TLSVersion.TLSv1
+"""
+        expexted_output = """from ssl import SSLContext
+import ssl
+
+context = SSLContext()
+context.minimum_version = ssl.TLSVersion.TLSv1_2
+"""
+        self.run_and_assert(tmpdir, input_code, expexted_output)
+
+    def test_bad_maximum_dont_update(self, tmpdir):
+        """
+        This codemod should not update maximum_version
+
+        (Maybe that should be a job for a separate codemod)
+        """
+        input_code = """from ssl import SSLContext, TLSVersion
+
+context = SSLContext()
+context.maximum_version = TLSVersion.TLSv1
+"""
+        self.run_and_assert(tmpdir, input_code, input_code)
+
+    def test_import_with_alias(self, tmpdir):
+        input_code = """import ssl as whatever
+
+context = whatever.SSLContext()
+context.minimum_version = whatever.TLSVersion.SSLv3
+"""
+        expexted_output = """import ssl as whatever
+import ssl
+
+context = whatever.SSLContext()
+context.minimum_version = ssl.TLSVersion.TLSv1_2
+"""
+        self.run_and_assert(tmpdir, input_code, expexted_output)

--- a/tests/samples/upgrade_sslcontext_minimum_version.py
+++ b/tests/samples/upgrade_sslcontext_minimum_version.py
@@ -1,0 +1,8 @@
+from ssl import PROTOCOL_TLS_CLIENT, SSLContext, TLSVersion
+
+my_ctx = SSLContext(protocol=PROTOCOL_TLS_CLIENT)
+
+print("FOO")
+
+my_ctx.maximum_version = TLSVersion.MAXIMUM_SUPPORTED
+my_ctx.minimum_version = TLSVersion.TLSv1_1


### PR DESCRIPTION
## Overview
*Implement new codemod for `sslcontext-minimum-version`*

## Description

* This fixes the case where `SSLContext.minimum_version` is set to an insecure version of SSL/TLS
* In theory the `maximum_version` could also be set to a bad version. This is a bit of a philosophical question but it feels like that should be handled by a separate codemod