### PR TITLE
Add CODEOWNERS, update PR template

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @drdavella @clavedeluna @andrecsilva

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -3,30 +3,8 @@
 
 ## Description
 
-* what/WHY/how these changes are needed.
-
-* Architectural changes: Focus on high-level concepts programmers of any language can understand AND specifics of this implementation.
-
-* Did you use any [design patterns or best practices](https://www.tutorialspoint.com/design_pattern/design_pattern_overview.htm)? (single responsibility, inheritance, command pattern)
-
-* Animated GIF via LICEcap or similar
-
-## Documentation
-* Does the README need to be updated?
-* Do customer docs need to beg updated?
-* Did you create any documentation related to this work?
-
-## Describe your testing approach
-
-* Happy/sad paths, Edge cases, Bad inputs
-* Explanation of manual testing with any TS screenshots
-* Or, an explanation of why this change does not need tests
-
-
-## Performance
-
-* How do you expect this PR to affect performance?
+* What/WHY/how these changes are needed
 
 ## Additional Details
-* any follow up tickets or discussion
+* Any follow up tickets or discussion
 * Any specific merge / deploy details


### PR DESCRIPTION
## Overview
*Add `CODEOWNERS` file; update PR template*

## Description

* Add `CODEOWNERS` file. Hopefully this should enable default reviewers
* Made the PR template a little more concise. I'm not sure we need all those details at this phase of the project
  * This might change if/when we start getting external contributors