### PR TITLE
Cli fix

### DIFF
--- a/integration_tests/base_test.py
+++ b/integration_tests/base_test.py
@@ -54,7 +54,7 @@ class BaseIntegrationTest(DependencyTestMixin, CleanRepoMixin):
         assert run["elapsed"] != ""
         assert (
             run["commandLine"]
-            == f"python -m codemodder tests/samples/ --output {output_path} --codemod-include={self.codemod.METADATA.NAME}"
+            == f"python -m codemodder tests/samples/ --output {output_path} --codemod-include={self.codemod.name()}"
         )
         assert run["directory"] == os.path.abspath("tests/samples/")
         assert run["sarifs"] == []
@@ -62,7 +62,7 @@ class BaseIntegrationTest(DependencyTestMixin, CleanRepoMixin):
     def _assert_results_fields(self, results, output_path):
         assert len(results) == 1
         result = results[0]
-        assert result["codemod"] == self.codemod.full_name()
+        assert result["codemod"] == self.codemod.id()
         assert len(result["changeset"]) == self.num_changed_files
 
         # A codemod may change multiple files. For now we will
@@ -116,7 +116,7 @@ class BaseIntegrationTest(DependencyTestMixin, CleanRepoMixin):
             "tests/samples/",
             "--output",
             self.output_path,
-            f"--codemod-include={self.codemod.METADATA.NAME}",
+            f"--codemod-include={self.codemod.name()}",
         ]
 
         self.check_code_before()

--- a/src/codemodder/cli.py
+++ b/src/codemodder/cli.py
@@ -20,7 +20,7 @@ class ListAction(argparse.Action):
 
     def _print_codemods(self):
         for codemod in DEFAULT_CODEMODS:
-            print(f"pixee:python/{codemod.full_name()}")
+            print(codemod.full_name())
 
     def __call__(self, parser, *args, **kwargs):
         """
@@ -57,8 +57,11 @@ class ValidatedCodmods(CsvListAction):
     """
 
     def validate_items(self, items):
+        codemod_ids = [codemod.full_name() for codemod in DEFAULT_CODEMODS]
         codemod_names = [codemod.METADATA.NAME for codemod in DEFAULT_CODEMODS]
-        unrecognized_codemods = [name for name in items if name not in codemod_names]
+
+        potential_names = codemod_ids + codemod_names
+        unrecognized_codemods = [name for name in items if name not in potential_names]
 
         if unrecognized_codemods:
             args = {

--- a/src/codemodder/cli.py
+++ b/src/codemodder/cli.py
@@ -20,7 +20,7 @@ class ListAction(argparse.Action):
 
     def _print_codemods(self):
         for codemod in DEFAULT_CODEMODS:
-            print(codemod.full_name())
+            print(codemod.id())
 
     def __call__(self, parser, *args, **kwargs):
         """
@@ -57,8 +57,8 @@ class ValidatedCodmods(CsvListAction):
     """
 
     def validate_items(self, items):
-        codemod_ids = [codemod.full_name() for codemod in DEFAULT_CODEMODS]
-        codemod_names = [codemod.METADATA.NAME for codemod in DEFAULT_CODEMODS]
+        codemod_ids = [codemod.id() for codemod in DEFAULT_CODEMODS]
+        codemod_names = [codemod.name() for codemod in DEFAULT_CODEMODS]
 
         potential_names = codemod_ids + codemod_names
         unrecognized_codemods = [name for name in items if name not in potential_names]

--- a/src/codemodder/cli.py
+++ b/src/codemodder/cli.py
@@ -2,7 +2,7 @@ import argparse
 import sys
 
 from codemodder import __VERSION__
-from codemodder.codemods import DEFAULT_CODEMODS
+from codemodder.codemods import DEFAULT_CODEMODS, CODEMOD_NAMES, CODEMOD_IDS
 from codemodder.logging import logger
 
 
@@ -57,16 +57,13 @@ class ValidatedCodmods(CsvListAction):
     """
 
     def validate_items(self, items):
-        codemod_ids = [codemod.id() for codemod in DEFAULT_CODEMODS]
-        codemod_names = [codemod.name() for codemod in DEFAULT_CODEMODS]
-
-        potential_names = codemod_ids + codemod_names
+        potential_names = CODEMOD_IDS + CODEMOD_NAMES
         unrecognized_codemods = [name for name in items if name not in potential_names]
 
         if unrecognized_codemods:
             args = {
                 "values": unrecognized_codemods,
-                "choices": ", ".join(map(repr, codemod_names)),
+                "choices": ", ".join(map(repr, CODEMOD_NAMES)),
             }
             msg = "invalid choice(s): %(values)r (choose from %(choices)s)"
             raise argparse.ArgumentError(self, msg % args)

--- a/src/codemodder/codemods/__init__.py
+++ b/src/codemodder/codemods/__init__.py
@@ -33,6 +33,9 @@ DEFAULT_CODEMODS = {
 }
 ALL_CODEMODS = DEFAULT_CODEMODS
 
+CODEMOD_IDS = [codemod.id() for codemod in DEFAULT_CODEMODS]
+CODEMOD_NAMES = [codemod.name() for codemod in DEFAULT_CODEMODS]
+
 
 def match_codemods(codemod_include: list, codemod_exclude: list) -> dict:
     if not codemod_include and not codemod_exclude:

--- a/src/codemodder/codemods/__init__.py
+++ b/src/codemodder/codemods/__init__.py
@@ -36,7 +36,7 @@ ALL_CODEMODS = DEFAULT_CODEMODS
 
 def match_codemods(codemod_include: list, codemod_exclude: list) -> dict:
     if not codemod_include and not codemod_exclude:
-        return {codemod.METADATA.NAME: codemod for codemod in DEFAULT_CODEMODS}
+        return {codemod.name(): codemod for codemod in DEFAULT_CODEMODS}
 
     # cli should've already prevented both include/exclude from being set.
     assert codemod_include or codemod_exclude
@@ -45,11 +45,11 @@ def match_codemods(codemod_include: list, codemod_exclude: list) -> dict:
         return {
             name: codemod
             for codemod in DEFAULT_CODEMODS
-            if (name := codemod.METADATA.NAME) not in codemod_exclude
+            if (name := codemod.name()) not in codemod_exclude
         }
 
     return {
         name: codemod
         for codemod in DEFAULT_CODEMODS
-        if (name := codemod.METADATA.NAME) in codemod_include
+        if (name := codemod.name()) in codemod_include
     }

--- a/src/codemodder/codemods/base_codemod.py
+++ b/src/codemodder/codemods/base_codemod.py
@@ -44,9 +44,14 @@ class BaseCodemod:
         self.file_context = file_context
 
     @classmethod
-    def full_name(cls):
+    def name(cls):
         # pylint: disable=no-member
-        return f"pixee:python/{cls.METADATA.NAME}"
+        return cls.METADATA.NAME
+
+    @classmethod
+    def id(cls):
+        # pylint: disable=no-member
+        return f"pixee:python/{cls.name()}"
 
     @property
     def should_transform(self):

--- a/tests/codemods/base_codemod_test.py
+++ b/tests/codemods/base_codemod_test.py
@@ -40,7 +40,7 @@ class BaseSemgrepCodemodTest(BaseCodemodTest):
             tmp_file.write(input_code)
 
         return semgrep_run(
-            find_all_yaml_files({self.codemod.METADATA.NAME: self.codemod}), root
+            find_all_yaml_files({self.codemod.name(): self.codemod}), root
         )
 
     def run_and_assert_filepath(self, root, file_path, input_code, expected):

--- a/tests/codemods/test_include_exclude.py
+++ b/tests/codemods/test_include_exclude.py
@@ -1,7 +1,7 @@
 import pytest
 from codemodder.codemods import DEFAULT_CODEMODS, match_codemods
 
-CODEMODS = {codemod.METADATA.NAME: codemod for codemod in DEFAULT_CODEMODS}
+CODEMODS = {codemod.name(): codemod for codemod in DEFAULT_CODEMODS}
 
 
 class TestMatchCodemods:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,7 +3,7 @@ import mock
 from codemodder.codemods import DEFAULT_CODEMODS
 from tests.shared import reset_global_state  # pylint: disable=unused-import
 
-CODEMOD_NAMES = tuple(codemod.METADATA.NAME for codemod in DEFAULT_CODEMODS)
+CODEMOD_NAMES = tuple(codemod.name() for codemod in DEFAULT_CODEMODS)
 
 
 @pytest.fixture(autouse=True, scope="module")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,9 +1,6 @@
 import pytest
 import mock
-from codemodder.codemods import DEFAULT_CODEMODS
 from tests.shared import reset_global_state  # pylint: disable=unused-import
-
-CODEMOD_NAMES = tuple(codemod.name() for codemod in DEFAULT_CODEMODS)
 
 
 @pytest.fixture(autouse=True, scope="module")

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -6,7 +6,7 @@ from codemodder import __VERSION__
 # from .conftest import CODEMOD_NAMES
 from codemodder.codemods import DEFAULT_CODEMODS
 
-CODEMOD_FULL_NAMES = tuple(codemod.full_name() for codemod in DEFAULT_CODEMODS)
+CODEMOD_FULL_NAMES = tuple(codemod.id() for codemod in DEFAULT_CODEMODS)
 
 
 class TestParseArgs:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -3,10 +3,7 @@ import pytest
 from codemodder.cli import parse_args
 from codemodder import __VERSION__
 
-# from .conftest import CODEMOD_NAMES
-from codemodder.codemods import DEFAULT_CODEMODS
-
-CODEMOD_FULL_NAMES = tuple(codemod.id() for codemod in DEFAULT_CODEMODS)
+from codemodder.codemods import CODEMOD_IDS
 
 
 class TestParseArgs:
@@ -80,10 +77,10 @@ class TestParseArgs:
         with pytest.raises(SystemExit) as err:
             parse_args(cli_args)
 
-        assert len(mock_print.call_args_list) == len(CODEMOD_FULL_NAMES)
+        assert len(mock_print.call_args_list) == len(CODEMOD_IDS)
 
         printed_names = [call[0][0] for call in mock_print.call_args_list]
-        assert sorted(CODEMOD_FULL_NAMES) == sorted(printed_names)
+        assert sorted(CODEMOD_IDS) == sorted(printed_names)
 
         assert err.value.args[0] == 0
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -2,7 +2,11 @@ import mock
 import pytest
 from codemodder.cli import parse_args
 from codemodder import __VERSION__
-from .conftest import CODEMOD_NAMES
+
+# from .conftest import CODEMOD_NAMES
+from codemodder.codemods import DEFAULT_CODEMODS
+
+CODEMOD_FULL_NAMES = tuple(codemod.full_name() for codemod in DEFAULT_CODEMODS)
 
 
 class TestParseArgs:
@@ -76,9 +80,10 @@ class TestParseArgs:
         with pytest.raises(SystemExit) as err:
             parse_args(cli_args)
 
-        for print_call in mock_print.call_args_list:
-            assert print_call[0][0].startswith("pixee:python/")
-            assert print_call[0][0].endswith(CODEMOD_NAMES)
+        assert len(mock_print.call_args_list) == len(CODEMOD_FULL_NAMES)
+
+        printed_names = [call[0][0] for call in mock_print.call_args_list]
+        assert sorted(CODEMOD_FULL_NAMES) == sorted(printed_names)
 
         assert err.value.args[0] == 0
 
@@ -119,4 +124,15 @@ class TestParseArgs:
         assert error_logger.call_args_list[0][0] == (
             "CLI error: %s",
             "ambiguous option: --codemod=url-sandbox could match --codemod-exclude, --codemod-include",
+        )
+
+    @pytest.mark.parametrize("codemod", ["secure-random", "pixee:python/secure-random"])
+    def test_codemod_name_or_id(self, codemod):
+        parse_args(
+            [
+                "tests/samples/",
+                "--output",
+                "here.txt",
+                f"--codemod-include={codemod}",
+            ]
         )

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -5,7 +5,7 @@ from codemodder.__main__ import run
 from codemodder import global_state
 from codemodder.semgrep import run as semgrep_run
 from codemodder.cli import parse_args
-from .conftest import CODEMOD_NAMES
+from codemodder.codemods import CODEMOD_NAMES
 
 
 class TestRun:


### PR DESCRIPTION
## Overview
*Fix to CLI to prevent suffix from printing twice, and allow users to pass in codemod id*

## Description

* codemod lists was printing as:
```
python -m codemodder --list
pixee:python/pixee:python/secure-tempfile
...
```

* now allow users to pass codemod name `secure-tempfile` OR id `pixee:python/secure-tempfile`.
* created proper classmethods for base codemod to distinguish name versus id
* centralize list of codemod names and ids for use everywhere

## Additional Details
* Any follow up tickets or discussion
* Any specific merge / deploy details
