### PR TITLE
Run tests separately in CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -33,10 +33,10 @@ jobs:
         run: pip install .
       - name: Install Dependencies
         run: pip install -r requirements/test.txt
-      - name: Run pytest
-        run: pytest -v --cov=codemodder
-      - name: Report coverage
-        run: coverage report -m --fail-under=95
+      - name: Run unit tests
+        run: pytest -v --cov-fail-under=95 --cov=codemodder tests --numprocesses auto
+      - name: Run integration tests
+        run: pytest -v integration_tests
       - name: Upload coverage reports to Codecov
         uses: codecov/codecov-action@v3
         env:

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -4,4 +4,5 @@ mock==5.1.*
 pre-commit<4
 pytest==7.4.*
 pytest-cov~=4.1.0
+pytest-xdist==3.*
 types-mock==5.1.*


### PR DESCRIPTION
## Overview
*Separate unit test from integration test in CI run to speed things up*

## Description

* Integration tests cannot be run with xdist in parallel because they touch files in the disk. That's ok!
* Unti tests have no problem using xdist. By running them separately with xdist, the total run for testing goes down by almost half! 

🚀 