### PR TITLE
Use latest tag when pushing to ECR

### DIFF
--- a/.github/workflows/image_to_aws.yml
+++ b/.github/workflows/image_to_aws.yml
@@ -25,5 +25,6 @@ jobs:
         id: login-ecr
         uses: aws-actions/amazon-ecr-login@v1
       - name: Build & Push Base Image
+        # TODO: we really should tag with a specific version as well, but that will come later
         run: |
-          docker buildx build --push -t ${{ steps.login-ecr.outputs.registry }}/pixee/codemodder-python:base-image .
+          docker buildx build --push -t ${{ steps.login-ecr.outputs.registry }}/pixee/codemodder-python:latest .


### PR DESCRIPTION
## Overview
*Update our image to use `:latest` tag when pushing to ECR*

## Description
* This is necessary in order to get the codemod orchestrator working properly
* Eventually we want to tag with a specific version as well, but for now this is enough