### PR TITLE
Add codemodder entry point script

### DIFF
--- a/.github/workflows/codemod_pygoat.yml
+++ b/.github/workflows/codemod_pygoat.yml
@@ -34,4 +34,4 @@ jobs:
           repository: pixee/pygoat
           path: pygoat
       - name: Run Codemodder
-        run: python -m codemodder --output output.codetf pygoat
+        run: codemodder --output output.codetf pygoat

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -25,4 +25,4 @@ to specify a specific Python version. If using `bash` or any compatible shell, a
 ## Docker
 
 You can build the docker image with `docker build -t codemodder .` and run it with `docker run`. You can also do
-`docker run codemodder python -m codemodder ....`
+`docker run codemodder ...`

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,4 +3,6 @@ WORKDIR /codemodder
 COPY . .
 
 RUN pip install .
-CMD codemodder --help
+
+ENTRYPOINT ["codemodder"]
+CMD ["--help"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,4 +3,4 @@ WORKDIR /codemodder
 COPY . .
 
 RUN pip install .
-CMD python -m codemodder --help
+CMD codemodder --help

--- a/README.md
+++ b/README.md
@@ -28,10 +28,10 @@ pip install .
 
 You can run the codemodder program with
 
-```python -m codemodder <directory> --output <file> ...```
+```codemodder <directory> --output <file> ...```
 
 ```bash
-python -m codemodder --help
+codemodder --help
 ```
 
 ## Contributing

--- a/integration_tests/base_test.py
+++ b/integration_tests/base_test.py
@@ -54,7 +54,7 @@ class BaseIntegrationTest(DependencyTestMixin, CleanRepoMixin):
         assert run["elapsed"] != ""
         assert (
             run["commandLine"]
-            == f"python -m codemodder tests/samples/ --output {output_path} --codemod-include={self.codemod.name()}"
+            == f"codemodder tests/samples/ --output {output_path} --codemod-include={self.codemod.name()}"
         )
         assert run["directory"] == os.path.abspath("tests/samples/")
         assert run["sarifs"] == []

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,7 @@ dependencies = [
 ]
 
 [project.scripts]
-codemodder = "codemodder.__main__:run"
+codemodder = "codemodder.__main__:main"
 
 [tool.setuptools]
 

--- a/src/codemodder/__main__.py
+++ b/src/codemodder/__main__.py
@@ -192,6 +192,18 @@ def run(argv, original_args) -> int:
     return 0
 
 
-if __name__ == "__main__":
+def main():
+    # TODO: I'm not sure why this needs to be parsed out separately
+    # Maybe it has something to do with the invocation as python -m codemodder.
+    # But I think we should deprecate that interface which should simplify this.
     sys_argv = sys.argv[1:]
     sys.exit(run(parse_args(sys_argv), sys_argv))
+
+
+if __name__ == "__main__":
+    import warnings
+
+    warnings.warn(
+        "This command interface is deprecated. Please call the `codemodder` script directly instead"
+    )
+    main()

--- a/src/codemodder/report/codetf_reporter.py
+++ b/src/codemodder/report/codetf_reporter.py
@@ -29,12 +29,14 @@ class CodeTF:
 
     def generate(self, elapsed_ms, original_args, absolute_path, results_by_codemod):
         self.report["run"]["elapsed"] = str(elapsed_ms)
+        # TODO: this shouldn't be necessary, we should just use sys.argv
+        # I think this is an artifact of using python -m codemodder, which is being deprecated
         self.report["run"]["commandLine"] = self._recreate_command(original_args)
         self.report["run"]["directory"] = absolute_path
         self.report["results"] = results_by_codemod
 
     def _recreate_command(self, original_args):
-        return f"python -m codemodder {' '.join(original_args)}"
+        return f"codemodder {' '.join(original_args)}"
 
     def write_report(self, outfile):
         try:


### PR DESCRIPTION
## Overview
*Add `codemodder` entry point script*

## Description

* This is mainly motivated by the need to integrate with the codemodder orchestrator
* Eventually I want to deprecate the `python -m codemodder` CLI, which I think will allow us to simplify a lot of the code around argument parsing, etc.