### PR TITLE
new jwt decode verify codemod

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -31,7 +31,7 @@ jobs:
       - name: Install Dependencies
         run: pip install -r requirements/lint.txt
       - name: Black Format Check
-        run: black --check .
+        run: black --check . --exclude samples/
       - name: Run pylint
         run: make lint
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -11,6 +11,7 @@ repos:
     rev: 23.9.1
     hooks:
     -   id: black
+        exclude: samples/
 - repo: https://github.com/pre-commit/mirrors-mypy
   rev: v1.5.1
   hooks:

--- a/integration_tests/test_jwt_decode_verify.py
+++ b/integration_tests/test_jwt_decode_verify.py
@@ -12,24 +12,16 @@ class TestJwtDecodeVerify(BaseIntegrationTest):
         code_path,
         [
             (
-                11,
+                10,
                 """decoded_payload = jwt.decode(encoded_jwt, SECRET_KEY, algorithms=["HS256"], verify=True)\n""",
             ),
             (
-                12,
+                11,
                 """decoded_payload = jwt.decode(encoded_jwt, SECRET_KEY, algorithms=["HS256"], options={"verify_signature": True})\n""",
-            ),
-            (
-                16,
-                """    encoded_jwt, SECRET_KEY, algorithms=["HS256"], verify=True)""",
-            ),
-            (
-                17,
-                "\n",
             ),
         ],
     )
-    expected_diff = '--- \n+++ \n@@ -9,13 +9,12 @@\n encoded_jwt = jwt.encode(payload, SECRET_KEY, algorithm="HS256")\n \n # these will work without black formatting\n-decoded_payload = jwt.decode(encoded_jwt, SECRET_KEY, algorithms=["HS256"], verify=False)\n-decoded_payload = jwt.decode(encoded_jwt, SECRET_KEY, algorithms=["HS256"], options={"verify_signature": False})\n+decoded_payload = jwt.decode(encoded_jwt, SECRET_KEY, algorithms=["HS256"], verify=True)\n+decoded_payload = jwt.decode(encoded_jwt, SECRET_KEY, algorithms=["HS256"], options={"verify_signature": True})\n \n # these will not work with semgrep pattern-regex\n decoded_payload = jwt.decode(\n-    encoded_jwt, SECRET_KEY, algorithms=["HS256"], verify=False\n-)\n+    encoded_jwt, SECRET_KEY, algorithms=["HS256"], verify=True)\n decoded_payload = jwt.decode(\n     encoded_jwt, SECRET_KEY, algorithms=["HS256"], options={"verify_signature": False}\n )\n'
-    expected_line_change = "12"
-    num_changes = 3
+    expected_diff = '--- \n+++ \n@@ -8,7 +8,7 @@\n \n encoded_jwt = jwt.encode(payload, SECRET_KEY, algorithm="HS256")\n \n-decoded_payload = jwt.decode(encoded_jwt, SECRET_KEY, algorithms=["HS256"], verify=False)\n-decoded_payload = jwt.decode(encoded_jwt, SECRET_KEY, algorithms=["HS256"], options={"verify_signature": False})\n+decoded_payload = jwt.decode(encoded_jwt, SECRET_KEY, algorithms=["HS256"], verify=True)\n+decoded_payload = jwt.decode(encoded_jwt, SECRET_KEY, algorithms=["HS256"], options={"verify_signature": True})\n \n var = "something"\n'
+    expected_line_change = "11"
+    num_changes = 2
     change_description = JwtDecodeVerify.CHANGE_DESCRIPTION

--- a/integration_tests/test_jwt_decode_verify.py
+++ b/integration_tests/test_jwt_decode_verify.py
@@ -1,0 +1,27 @@
+from codemodder.codemods.jwt_decode_verify import JwtDecodeVerify
+from integration_tests.base_test import (
+    BaseIntegrationTest,
+    original_and_expected_from_code_path,
+)
+
+
+class TestJwtDecodeVerify(BaseIntegrationTest):
+    codemod = JwtDecodeVerify
+    code_path = "tests/samples/jwt_decode_verify.py"
+    original_code, expected_new_code = original_and_expected_from_code_path(
+        code_path,
+        [
+            (
+                9,
+                """decoded_payload = jwt.decode(encoded_jwt, SECRET_KEY, algorithms=['HS256'], verify=True)\n""",
+            ),
+            (
+                10,
+                """decoded_payload = jwt.decode(encoded_jwt, SECRET_KEY, algorithms=['HS256'], options={"verify_signature": True})\n""",
+            ),
+        ],
+    )
+    expected_diff = "--- \n+++ \n@@ -7,6 +7,6 @@\n }\n \n encoded_jwt = jwt.encode(payload, SECRET_KEY, algorithm='HS256')\n-decoded_payload = jwt.decode(encoded_jwt, SECRET_KEY, algorithms=['HS256'], verify=False)\n-decoded_payload = jwt.decode(encoded_jwt, SECRET_KEY, algorithms=['HS256'], options={\"verify_signature\": False})\n+decoded_payload = jwt.decode(encoded_jwt, SECRET_KEY, algorithms=['HS256'], verify=True)\n+decoded_payload = jwt.decode(encoded_jwt, SECRET_KEY, algorithms=['HS256'], options={\"verify_signature\": True})\n var = \"something\""
+    expected_line_change = "10"
+    num_changes = 2
+    change_description = JwtDecodeVerify.CHANGE_DESCRIPTION

--- a/integration_tests/test_jwt_decode_verify.py
+++ b/integration_tests/test_jwt_decode_verify.py
@@ -12,16 +12,24 @@ class TestJwtDecodeVerify(BaseIntegrationTest):
         code_path,
         [
             (
-                9,
-                """decoded_payload = jwt.decode(encoded_jwt, SECRET_KEY, algorithms=['HS256'], verify=True)\n""",
+                11,
+                """decoded_payload = jwt.decode(encoded_jwt, SECRET_KEY, algorithms=["HS256"], verify=True)\n""",
             ),
             (
-                10,
-                """decoded_payload = jwt.decode(encoded_jwt, SECRET_KEY, algorithms=['HS256'], options={"verify_signature": True})\n""",
+                12,
+                """decoded_payload = jwt.decode(encoded_jwt, SECRET_KEY, algorithms=["HS256"], options={"verify_signature": True})\n""",
+            ),
+            (
+                16,
+                """    encoded_jwt, SECRET_KEY, algorithms=["HS256"], verify=True)""",
+            ),
+            (
+                17,
+                "\n",
             ),
         ],
     )
-    expected_diff = "--- \n+++ \n@@ -7,6 +7,6 @@\n }\n \n encoded_jwt = jwt.encode(payload, SECRET_KEY, algorithm='HS256')\n-decoded_payload = jwt.decode(encoded_jwt, SECRET_KEY, algorithms=['HS256'], verify=False)\n-decoded_payload = jwt.decode(encoded_jwt, SECRET_KEY, algorithms=['HS256'], options={\"verify_signature\": False})\n+decoded_payload = jwt.decode(encoded_jwt, SECRET_KEY, algorithms=['HS256'], verify=True)\n+decoded_payload = jwt.decode(encoded_jwt, SECRET_KEY, algorithms=['HS256'], options={\"verify_signature\": True})\n var = \"something\""
-    expected_line_change = "10"
-    num_changes = 2
+    expected_diff = '--- \n+++ \n@@ -9,13 +9,12 @@\n encoded_jwt = jwt.encode(payload, SECRET_KEY, algorithm="HS256")\n \n # these will work without black formatting\n-decoded_payload = jwt.decode(encoded_jwt, SECRET_KEY, algorithms=["HS256"], verify=False)\n-decoded_payload = jwt.decode(encoded_jwt, SECRET_KEY, algorithms=["HS256"], options={"verify_signature": False})\n+decoded_payload = jwt.decode(encoded_jwt, SECRET_KEY, algorithms=["HS256"], verify=True)\n+decoded_payload = jwt.decode(encoded_jwt, SECRET_KEY, algorithms=["HS256"], options={"verify_signature": True})\n \n # these will not work with semgrep pattern-regex\n decoded_payload = jwt.decode(\n-    encoded_jwt, SECRET_KEY, algorithms=["HS256"], verify=False\n-)\n+    encoded_jwt, SECRET_KEY, algorithms=["HS256"], verify=True)\n decoded_payload = jwt.decode(\n     encoded_jwt, SECRET_KEY, algorithms=["HS256"], options={"verify_signature": False}\n )\n'
+    expected_line_change = "12"
+    num_changes = 3
     change_description = JwtDecodeVerify.CHANGE_DESCRIPTION

--- a/src/codemodder/codemods/__init__.py
+++ b/src/codemodder/codemods/__init__.py
@@ -19,6 +19,7 @@ from codemodder.codemods.remove_unnecessary_f_str import RemoveUnnecessaryFStr
 from codemodder.codemods.tempfile_mktemp import TempfileMktemp
 from codemodder.codemods.requests_verify import RequestsVerify
 from codemodder.codemods.use_walrus_if import UseWalrusIf
+from codemodder.codemods.jwt_decode_verify import JwtDecodeVerify
 
 DEFAULT_CODEMODS = [
     DjangoDebugFlagOn,
@@ -38,6 +39,7 @@ DEFAULT_CODEMODS = [
     TempfileMktemp,
     RequestsVerify,
     UseWalrusIf,
+    JwtDecodeVerify,
 ]
 ALL_CODEMODS = DEFAULT_CODEMODS
 

--- a/src/codemodder/codemods/docs/pixee_python_jwt-decode-verify.md
+++ b/src/codemodder/codemods/docs/pixee_python_jwt-decode-verify.md
@@ -1,0 +1,18 @@
+This codemod ensures calls to [jwt.decode](https://pyjwt.readthedocs.io/en/stable/api.html#jwt.decode) do not disable signature validation and other
+verifications. It checks that both the `verify` parameter (soon to be deprecated) and any `verify` key in the `options` dict parameter are not assigned to `False`.
+
+Our change looks as follows:
+
+```diff
+  import jwt
+  ...
+- decoded_payload = jwt.decode(encoded_jwt, SECRET_KEY, algorithms=["HS256"], verify=False)
++ decoded_payload = jwt.decode(encoded_jwt, SECRET_KEY, algorithms=["HS256"], verify=True)
+  ...
+- decoded_payload = jwt.decode(
+    encoded_jwt, SECRET_KEY, algorithms=["HS256"], options={"verify_signature": False, "verify_exp": False})
++ decoded_payload = jwt.decode(
+    encoded_jwt, SECRET_KEY, algorithms=["HS256"], options={"verify_signature": True, "verify_exp": True})
+```
+
+Any `verify` parameter not listed relies on the secure `True` default value.

--- a/src/codemodder/codemods/jwt_decode_verify.py
+++ b/src/codemodder/codemods/jwt_decode_verify.py
@@ -1,0 +1,86 @@
+import libcst as cst
+from libcst import matchers
+from codemodder.codemods.base_codemod import ReviewGuidance
+from codemodder.codemods.api import SemgrepCodemod
+
+
+class JwtDecodeVerify(SemgrepCodemod):
+    NAME = "jwt-decode-verify"
+    REVIEW_GUIDANCE = ReviewGuidance.MERGE_WITHOUT_REVIEW
+    DESCRIPTION = "Makes any of the multiple `verify` parameters to a `jwt.decode` call be `True`."
+
+    @classmethod
+    def rule(cls):
+        return r"""
+            rules:
+                - pattern-either:
+                  - patterns:
+                      - pattern: jwt.decode(..., verify=False, ...)
+                      - pattern-inside: |
+                          import jwt
+                          ...
+                  - patterns:
+                      - pattern-regex:  |-
+                            jwt.decode\(.*options={.*"verify_(signature|exp|nbf|iat|aud|iss)": False.*}.*\)
+                      - pattern-inside: |
+                          import jwt
+                          ...
+        """
+
+    def _replace_opts_dict(self, opts_dict):
+        new_dict_elements = []
+
+        for element in opts_dict.elements:
+            if is_verify_keyword(element):
+                new_el = cst.DictElement(
+                    key=cst.parse_expression(element.key.value),
+                    value=cst.parse_expression("True"),
+                )
+            else:
+                new_el = element
+            new_dict_elements.append(new_el)
+        return new_dict_elements
+
+    def replace_options_arg(self, node_args):
+        new_args = []
+        for arg in node_args:
+            if matchers.matches(arg.keyword, matchers.Name("options")) and isinstance(
+                opts_dict := arg.value, cst.Dict
+            ):
+                new_dict_elements = self._replace_opts_dict(opts_dict)
+                new = cst.Arg(
+                    keyword=cst.parse_expression("options"),
+                    value=cst.Dict(
+                        elements=new_dict_elements,
+                    ),
+                    equal=arg.equal,
+                )
+            else:
+                new = arg
+            new_args.append(new)
+        return new_args
+
+    def replace_arg(self, original_node, target_arg_name, target_arg_replacement_val):
+        new_args = super().replace_arg(original_node, "verify", "True")
+        return self.replace_options_arg(new_args)
+
+    def on_result_found(self, original_node, updated_node):
+        new_args = self.replace_arg(original_node, "verify", "True")
+        return self.update_arg_target(updated_node, new_args)
+
+
+def is_verify_keyword(element: cst.DictElement) -> bool:
+    """Determine if DictElement is something like:
+        DictElement(
+            key=SimpleString(
+                value='"verify_signature"',
+                lpar=[],
+                rpar=[],
+            )
+            ...
+    where value should be anything with the word `verify`
+    """
+    return (
+        matchers.matches(element.key, matchers.SimpleString())
+        and "verify" in element.key.value
+    )

--- a/src/codemodder/codemods/jwt_decode_verify.py
+++ b/src/codemodder/codemods/jwt_decode_verify.py
@@ -20,11 +20,14 @@ class JwtDecodeVerify(SemgrepCodemod):
                           import jwt
                           ...
                   - patterns:
-                      - pattern-regex:  |-
-                            jwt.decode\(.*options={.*"verify_(signature|exp|nbf|iat|aud|iss)": False.*}.*\)
+                      - pattern: |
+                          jwt.decode(..., options={..., $KEY: False, ...}, ...)
+                      - metavariable-regex:
+                          metavariable: $KEY
+                          regex: \"verify_
                       - pattern-inside: |
                           import jwt
-                          ...
+                            ...
         """
 
     def _replace_opts_dict(self, opts_dict):

--- a/src/codemodder/codemods/jwt_decode_verify.py
+++ b/src/codemodder/codemods/jwt_decode_verify.py
@@ -7,6 +7,7 @@ from codemodder.codemods.api import SemgrepCodemod
 class JwtDecodeVerify(SemgrepCodemod):
     NAME = "jwt-decode-verify"
     REVIEW_GUIDANCE = ReviewGuidance.MERGE_WITHOUT_REVIEW
+    SUMMARY = "Enable all verifications in `jwt.decode` call."
     DESCRIPTION = "Makes any of the multiple `verify` parameters to a `jwt.decode` call be `True`."
 
     @classmethod

--- a/src/codemodder/codemods/jwt_decode_verify.py
+++ b/src/codemodder/codemods/jwt_decode_verify.py
@@ -22,10 +22,10 @@ class JwtDecodeVerify(SemgrepCodemod):
                           ...
                   - patterns:
                       - pattern: |
-                          jwt.decode(..., options={..., $KEY: False, ...}, ...)
+                          jwt.decode(..., options={..., "$KEY": False, ...}, ...)
                       - metavariable-regex:
                           metavariable: $KEY
-                          regex: \"verify_
+                          regex: verify_
                       - pattern-inside: |
                           import jwt
                             ...

--- a/tests/codemods/test_jwt_decode_verify.py
+++ b/tests/codemods/test_jwt_decode_verify.py
@@ -1,0 +1,95 @@
+import pytest
+from codemodder.codemods.jwt_decode_verify import JwtDecodeVerify
+from tests.codemods.base_codemod_test import BaseSemgrepCodemodTest
+
+
+class TestJwtDecodeVerify(BaseSemgrepCodemodTest):
+    codemod = JwtDecodeVerify
+
+    def test_rule_ids(self):
+        assert self.codemod.RULE_IDS == ["jwt-decode-verify"]
+
+    def test_import(self, tmpdir):
+        input_code = """import jwt
+
+jwt.decode(encoded_jwt, SECRET_KEY, algorithms=['HS256'], verify=False)
+var = "hello"
+"""
+        expexted_output = """import jwt
+
+jwt.decode(encoded_jwt, SECRET_KEY, algorithms=['HS256'], verify=True)
+var = "hello"
+"""
+
+        self.run_and_assert(tmpdir, input_code, expexted_output)
+
+    def test_from_import(self, tmpdir):
+        input_code = """from jwt import decode
+
+decode(encoded_jwt, SECRET_KEY, algorithms=['HS256'], verify=False)
+var = "hello"
+"""
+        expexted_output = """from jwt import decode
+
+decode(encoded_jwt, SECRET_KEY, algorithms=['HS256'], verify=True)
+var = "hello"
+"""
+
+        self.run_and_assert(tmpdir, input_code, expexted_output)
+
+    def test_import_alias(self, tmpdir):
+        input_code = """import jwt as _jwtmod
+
+_jwtmod.decode(encoded_jwt, SECRET_KEY, algorithms=['HS256'], verify=False)
+var = "hello"
+"""
+        expexted_output = """import jwt as _jwtmod
+
+_jwtmod.decode(encoded_jwt, SECRET_KEY, algorithms=['HS256'], verify=True)
+var = "hello"
+"""
+
+        self.run_and_assert(tmpdir, input_code, expexted_output)
+
+    @pytest.mark.parametrize(
+        "input_args,expected_args",
+        [
+            (
+                "",
+                "",
+            ),
+            (
+                "verify=True",
+                "verify=True",
+            ),
+            (
+                """verify=False, options={"verify_signature": False}""",
+                """verify=True, options={"verify_signature": True}""",
+            ),
+            (
+                """options={"verify_exp": False}""",
+                """options={"verify_exp": True}""",
+            ),
+            (
+                """options={"verify_iss": False, "verify_exp": False, }""",
+                """options={"verify_iss": True, "verify_exp": True}""",
+            ),
+            (
+                """options={"strict_aud": False, "verify_signature": False}""",
+                """options={"strict_aud": False, "verify_signature": True}""",
+            ),
+        ],
+    )
+    def test_verify_variations(self, tmpdir, input_args, expected_args):
+        input_code = f"""import jwt
+
+jwt.decode(encoded_jwt, SECRET_KEY, algorithms=['HS256'], {input_args})
+var = "hello"
+"""
+        expexted_output = f"""import jwt
+
+jwt.decode(encoded_jwt, SECRET_KEY, algorithms=['HS256'], {expected_args})
+var = "hello"
+"""
+
+        self.run_and_assert(tmpdir, input_code, expexted_output)

--- a/tests/codemods/test_jwt_decode_verify.py
+++ b/tests/codemods/test_jwt_decode_verify.py
@@ -115,20 +115,21 @@ var = "hello"
 
         self.run_and_assert(tmpdir, input_code, expexted_output)
 
-    def test_multiline_formatting_options(self, tmpdir):
-        input_code = """import jwt
+    @pytest.mark.parametrize("quote", ["'", '"'])
+    def test_multiline_formatting_options(self, tmpdir, quote):
+        input_code = f"""import jwt
 
 decoded_payload = jwt.decode(
     encoded_jwt, SECRET_KEY, algorithms=["HS256"],
-    options={"verify_signature": False, "verify_exp": False}
+    options={{{quote}verify_signature{quote}: False, {quote}verify_exp{quote}: False}}
 )
 var = "hello"
 """
-        expexted_output = """import jwt
+        expexted_output = f"""import jwt
 
 decoded_payload = jwt.decode(
     encoded_jwt, SECRET_KEY, algorithms=["HS256"],
-    options={"verify_signature": True, "verify_exp": True})
+    options={{{quote}verify_signature{quote}: True, {quote}verify_exp{quote}: True}})
 var = "hello"
 """
 

--- a/tests/codemods/test_jwt_decode_verify.py
+++ b/tests/codemods/test_jwt_decode_verify.py
@@ -93,3 +93,41 @@ var = "hello"
 """
 
         self.run_and_assert(tmpdir, input_code, expexted_output)
+
+    def test_multiline_formatting_verify_flag(self, tmpdir):
+        input_code = """import jwt
+
+decoded_payload = jwt.decode(
+    encoded_jwt, SECRET_KEY, algorithms=["HS256"], verify=False
+)
+var = "hello"
+"""
+        expexted_output = """import jwt
+
+decoded_payload = jwt.decode(
+    encoded_jwt, SECRET_KEY, algorithms=["HS256"], verify=True)
+var = "hello"
+"""
+
+        self.run_and_assert(tmpdir, input_code, expexted_output)
+
+    @pytest.mark.skip(reason="Cannot support multiline opts dict given pattern-regex")
+    def test_multiline_formatting_options(self, tmpdir):
+        input_code = """import jwt
+
+decoded_payload = jwt.decode(
+    encoded_jwt, SECRET_KEY, algorithms=["HS256"],
+    options={"verify_signature": False, "verify_exp": False}
+)
+var = "hello"
+"""
+        expexted_output = """import jwt
+
+decoded_payload = jwt.decode(
+    encoded_jwt, SECRET_KEY, algorithms=["HS256"],
+    options={"verify_signature": True, "verify_exp": True}
+)
+var = "hello"
+"""
+
+        self.run_and_assert(tmpdir, input_code, expexted_output)

--- a/tests/codemods/test_jwt_decode_verify.py
+++ b/tests/codemods/test_jwt_decode_verify.py
@@ -78,6 +78,10 @@ var = "hello"
                 """options={"strict_aud": False, "verify_signature": False}""",
                 """options={"strict_aud": False, "verify_signature": True}""",
             ),
+            (
+                """options={"verify_iss": True, "verify_signature": True}""",
+                """options={"verify_iss": True, "verify_signature": True}""",
+            ),
         ],
     )
     def test_verify_variations(self, tmpdir, input_args, expected_args):
@@ -111,7 +115,6 @@ var = "hello"
 
         self.run_and_assert(tmpdir, input_code, expexted_output)
 
-    @pytest.mark.skip(reason="Cannot support multiline opts dict given pattern-regex")
     def test_multiline_formatting_options(self, tmpdir):
         input_code = """import jwt
 
@@ -125,8 +128,7 @@ var = "hello"
 
 decoded_payload = jwt.decode(
     encoded_jwt, SECRET_KEY, algorithms=["HS256"],
-    options={"verify_signature": True, "verify_exp": True}
-)
+    options={"verify_signature": True, "verify_exp": True})
 var = "hello"
 """
 

--- a/tests/samples/jwt_decode_verify.py
+++ b/tests/samples/jwt_decode_verify.py
@@ -1,0 +1,16 @@
+import jwt
+
+SECRET_KEY = "mysecretkey"
+payload = {
+    "user_id": 123,
+    "username": "john",
+}
+
+encoded_jwt = jwt.encode(payload, SECRET_KEY, algorithm="HS256")
+decoded_payload = jwt.decode(
+    encoded_jwt, SECRET_KEY, algorithms=["HS256"], verify=False
+)
+decoded_payload = jwt.decode(
+    encoded_jwt, SECRET_KEY, algorithms=["HS256"], options={"verify_signature": False}
+)
+var = "something"

--- a/tests/samples/jwt_decode_verify.py
+++ b/tests/samples/jwt_decode_verify.py
@@ -7,6 +7,12 @@ payload = {
 }
 
 encoded_jwt = jwt.encode(payload, SECRET_KEY, algorithm="HS256")
+
+# these will work without black formatting
+decoded_payload = jwt.decode(encoded_jwt, SECRET_KEY, algorithms=["HS256"], verify=False)
+decoded_payload = jwt.decode(encoded_jwt, SECRET_KEY, algorithms=["HS256"], options={"verify_signature": False})
+
+# these will not work with semgrep pattern-regex
 decoded_payload = jwt.decode(
     encoded_jwt, SECRET_KEY, algorithms=["HS256"], verify=False
 )

--- a/tests/samples/jwt_decode_verify.py
+++ b/tests/samples/jwt_decode_verify.py
@@ -8,11 +8,8 @@ payload = {
 
 encoded_jwt = jwt.encode(payload, SECRET_KEY, algorithm="HS256")
 
-# these will work without black formatting
 decoded_payload = jwt.decode(encoded_jwt, SECRET_KEY, algorithms=["HS256"], verify=False)
 decoded_payload = jwt.decode(encoded_jwt, SECRET_KEY, algorithms=["HS256"], options={"verify_signature": False})
-
-# these will not work with semgrep pattern-regex
 decoded_payload = jwt.decode(
     encoded_jwt, SECRET_KEY, algorithms=["HS256"], verify=False
 )

--- a/tests/samples/jwt_decode_verify.py
+++ b/tests/samples/jwt_decode_verify.py
@@ -10,10 +10,5 @@ encoded_jwt = jwt.encode(payload, SECRET_KEY, algorithm="HS256")
 
 decoded_payload = jwt.decode(encoded_jwt, SECRET_KEY, algorithms=["HS256"], verify=False)
 decoded_payload = jwt.decode(encoded_jwt, SECRET_KEY, algorithms=["HS256"], options={"verify_signature": False})
-decoded_payload = jwt.decode(
-    encoded_jwt, SECRET_KEY, algorithms=["HS256"], verify=False
-)
-decoded_payload = jwt.decode(
-    encoded_jwt, SECRET_KEY, algorithms=["HS256"], options={"verify_signature": False}
-)
+
 var = "something"


### PR DESCRIPTION
## Overview
*Add a codemod that will check either the `verify` (soon to be deprecated) flag to jwt.decode and/or the multiple `verify_*` kwargs in the `options` param*

## Description

* see [docs](https://www.notion.so/pixee/Verified-JWT-decode-2a2a10fda3b8427582bcdc46dfd6fa4d)
* We already had an api solution to flip to `verify=True`, but for `options={...verify...}` I had to write some codemod-specific code. Maybe it can be generalized later on.
* I also think I have covered many edge cases, such as other keys to `options`, a mixture of verify flag and options, etc.

## Additional Details
* Any follow up tickets or discussion
* Any specific merge / deploy details
