### PR TITLE
Use relative paths for codetf results

### DIFF
--- a/src/codemodder/__main__.py
+++ b/src/codemodder/__main__.py
@@ -74,7 +74,8 @@ def run_codemods_for_file(
 
             codemod_kls.CHANGESET_ALL_FILES.append(
                 ChangeSet(
-                    str(file_context.file_path),
+                    # TODO: we should not be using global state here
+                    str(file_context.file_path.relative_to(global_state.DIRECTORY)),
                     diff,
                     changes=file_context.codemod_changes,
                 ).to_json()

--- a/src/codemodder/codemods/base_codemod.py
+++ b/src/codemodder/codemods/base_codemod.py
@@ -26,6 +26,8 @@ class BaseCodemod:
 
     def __init_subclass__(cls, **kwargs):
         super().__init_subclass__(**kwargs)
+        # TODO: this should not belong to codemod classes
+        # Instead it should be owned by a global context that gets passed in
         cls.CHANGESET_ALL_FILES: list = []
 
         if "codemodder.codemods.base_codemod.SemgrepCodemod" in str(cls):

--- a/src/codemodder/global_state.py
+++ b/src/codemodder/global_state.py
@@ -3,6 +3,7 @@
 
 # Source code directory codemodder will analyze.
 # Should be overridden when codemodder starts.
+# TODO: we should not be managing global state at all
 DIRECTORY = ""
 
 


### PR DESCRIPTION
## Overview
*Use relative paths when reporting results in CodeTF2*

## Description
* The [spec](https://github.com/pixee/codemodder-specs/blob/b98a60689a0ff159bafb1a250aa4834a0a5c81ca/codetf.json#L34) requires that paths in results must be relative to the top of the repository