### PR TITLE
Prevent codemod bleedover

### DIFF
--- a/.github/workflows/codemod_pygoat.yml
+++ b/.github/workflows/codemod_pygoat.yml
@@ -28,6 +28,8 @@ jobs:
         uses: actions/checkout@v4
       - name: Install Codemodder Package
         run: pip install .
+      - name: Install Test Dependencies
+        run: pip install -r requirements/test.txt
       - name: Check out Pygoat
         uses: actions/checkout@v4
         with:
@@ -35,3 +37,5 @@ jobs:
           path: pygoat
       - name: Run Codemodder
         run: codemodder --output output.codetf pygoat
+      - name: Check PyGoat Findings
+        run: pytest -v ci_tests/test_webgoat_findings.py

--- a/.gitignore
+++ b/.gitignore
@@ -130,3 +130,7 @@ dmypy.json
 
 # IDEs
 .idea/
+
+# CodeTF and sarif files
+*.codetf*
+*.sarif

--- a/ci_tests/test_webgoat_findings.py
+++ b/ci_tests/test_webgoat_findings.py
@@ -1,0 +1,32 @@
+import json
+
+import pytest
+
+
+EXPECTED_FINDINGS = [
+    "pixee:python/order-imports",
+    "pixee:python/secure-random",
+    "pixee:python/sandbox-process-creation",
+    "pixee:python/unused-imports",
+    "pixee:python/django-session-cookie-secure-off",
+    "pixee:python/harden-pyyaml",
+    "pixee:python/django-debug-flag-on",
+    "pixee:python/url-sandbox",
+]
+
+
+@pytest.fixture(scope="session")
+def webgoat_findings():
+    with open("output.codetf") as ff:
+        results = json.load(ff)
+
+    yield set([x["codemod"] for x in results["results"]])
+
+
+def test_num_webgoat_findings(webgoat_findings):
+    assert len(webgoat_findings) == len(EXPECTED_FINDINGS)
+
+
+@pytest.mark.parametrize("finding", EXPECTED_FINDINGS)
+def test_webgoat_findings(webgoat_findings, finding):
+    assert finding in webgoat_findings

--- a/src/codemodder/codemods/__init__.py
+++ b/src/codemodder/codemods/__init__.py
@@ -41,6 +41,9 @@ CODEMOD_IDS = [codemod.id() for codemod in DEFAULT_CODEMODS]
 CODEMOD_NAMES = [codemod.name() for codemod in DEFAULT_CODEMODS]
 
 
+# TODO: codemod registry
+
+
 def match_codemods(codemod_include: list, codemod_exclude: list) -> dict:
     if not codemod_include and not codemod_exclude:
         return {codemod.name(): codemod for codemod in DEFAULT_CODEMODS}

--- a/src/codemodder/codemods/api/__init__.py
+++ b/src/codemodder/codemods/api/__init__.py
@@ -80,8 +80,6 @@ class BaseCodemod(
     BaseTransformer,
     Helpers,
 ):
-    CHANGESET_ALL_FILES: list = []
-
     def report_change(self, original_node):
         line_number = self.lineno_for_node(original_node)
         self.file_context.codemod_changes.append(

--- a/src/codemodder/context.py
+++ b/src/codemodder/context.py
@@ -1,0 +1,30 @@
+from pathlib import Path
+from dataclasses import dataclass
+
+from codemodder.codemods.change import Change
+
+
+@dataclass
+class ChangeSet:
+    """A set of changes made to a file at `path`"""
+
+    path: str
+    diff: str
+    changes: list[Change]
+
+    def to_json(self):
+        return {"path": self.path, "diff": self.diff, "changes": self.changes}
+
+
+class CodemodExecutionContext:
+    results_by_codemod: dict[str, list[ChangeSet]] = {}
+    directory: Path
+    dry_run: bool = False
+
+    def __init__(self, directory, dry_run):
+        self.directory = directory
+        self.dry_run = dry_run
+        self.results_by_codemod = {}
+
+    def add_result(self, codemod_name, change_set):
+        self.results_by_codemod.setdefault(codemod_name, []).append(change_set)

--- a/src/codemodder/file_context.py
+++ b/src/codemodder/file_context.py
@@ -10,7 +10,6 @@ class FileContext:
     """
 
     file_path: Path
-    dry_run: bool
     line_exclude: List[int]
     line_include: List[int]
     results_by_id: DefaultDict

--- a/tests/codemods/base_codemod_test.py
+++ b/tests/codemods/base_codemod_test.py
@@ -3,6 +3,7 @@ import libcst as cst
 from libcst.codemod import CodemodContext
 from pathlib import Path
 import os
+from collections import defaultdict
 from codemodder.file_context import FileContext
 from codemodder.semgrep import run_on_directory as semgrep_run
 from codemodder.semgrep import find_all_yaml_files
@@ -23,10 +24,9 @@ class BaseCodemodTest:
         input_tree = cst.parse_module(input_code)
         self.file_context = FileContext(
             file_path,
-            False,
             [],
             [],
-            [],
+            defaultdict(list),
         )
         command_instance = self.codemod(CodemodContext(), self.file_context)
         output_tree = command_instance.transform_module(input_tree)
@@ -49,7 +49,6 @@ class BaseSemgrepCodemodTest(BaseCodemodTest):
         results = all_results[str(file_path)]
         self.file_context = FileContext(
             file_path,
-            False,
             [],
             [],
             results,

--- a/tests/shared.py
+++ b/tests/shared.py
@@ -1,11 +1,10 @@
 """Module to store shared utilities for both unit and integration tests"""
 import pytest
 from codemodder import global_state
-from codemodder.__main__ import RESULTS_BY_CODEMOD
-from codemodder.codemods import ALL_CODEMODS
 from codemodder.dependency_manager import DependencyManager
 
 
+# TODO: should not have any global state
 @pytest.fixture(autouse=True, scope="function")
 def reset_global_state():
     """
@@ -16,6 +15,3 @@ def reset_global_state():
     yield
     DependencyManager.clear_instance()
     global_state.set_directory("")
-    RESULTS_BY_CODEMOD.clear()
-    for codemod_kls in ALL_CODEMODS:
-        codemod_kls.CHANGESET_ALL_FILES = []

--- a/tests/test_file_context.py
+++ b/tests/test_file_context.py
@@ -2,6 +2,6 @@ from codemodder.file_context import FileContext
 
 
 def test_file_context():
-    file_context = FileContext(None, None, None, None, None)
+    file_context = FileContext(None, None, None, None)
     assert file_context.line_exclude == []
     assert file_context.line_include == []


### PR DESCRIPTION
## Overview
*Fix problem where all supported codemod IDs are (incorrectly) added to CodeTF file*

## Description

* We expect only applicable codemod IDs to be present in CodeTF output when running with a list of codemod IDs
  * Prior to this, all supported codemod IDs would be added to CodeTF, which breaks the contract with callers
* The problem appears to be related to the fact that results were stored as class-level attributes on each codemod class
* To fix this, I added a new `CodemodExecutionContext` that is intended to store process-level state
  * Eventually this will be used to store other state that is currently represented using globals/singletons
* I wasn't able to remove all global/shared state in this PR but I intend to open another PR in the near future
