### PR TITLE
Sort codemod IDs with --list

### DIFF
--- a/src/codemodder/cli.py
+++ b/src/codemodder/cli.py
@@ -19,7 +19,7 @@ class ListAction(argparse.Action):
     """ """
 
     def _print_codemods(self):
-        for codemod in DEFAULT_CODEMODS:
+        for codemod in sorted(DEFAULT_CODEMODS, key=lambda x: x.id()):
             print(codemod.id())
 
     def __call__(self, parser, *args, **kwargs):


### PR DESCRIPTION
## Overview
*Ensure codemods are presented in sorted order when running with the `--list` option*