### PR TITLE
Attr should not be NotImplemented

### DIFF
--- a/src/codemodder/codemods/api/__init__.py
+++ b/src/codemodder/codemods/api/__init__.py
@@ -54,7 +54,10 @@ class _CodemodSubclassWithMetadata:
             missing_fields = []
             for field in ["SUMMARY", "DESCRIPTION", "REVIEW_GUIDANCE"]:
                 try:
-                    assert hasattr(cls, field)
+                    assert (
+                        hasattr(cls, field)
+                        and getattr(cls, field) is not NotImplemented
+                    )
                 except AssertionError:
                     missing_fields.append(field)
 

--- a/src/codemodder/codemods/utils_mixin.py
+++ b/src/codemodder/codemods/utils_mixin.py
@@ -1,4 +1,4 @@
-from typing import Optional, Union
+from typing import Any, Optional, Tuple, Union
 import libcst as cst
 from libcst import MetadataDependent, matchers
 from libcst.helpers import get_full_name_for_node
@@ -6,7 +6,7 @@ from libcst.metadata import Assignment, ImportAssignment, ScopeProvider
 
 
 class NameResolutionMixin(MetadataDependent):
-    METADATA_DEPENDENCIES = (ScopeProvider,)
+    METADATA_DEPENDENCIES: Tuple[Any, ...] = (ScopeProvider,)
 
     def find_base_name(self, node):
         """


### PR DESCRIPTION
## Overview
*If someone writes a codemod and doesn't implement one of the class attrs that are `NotImplemented`, we should complain*

## Description

* Without this change, the codemod was able to codemod but we then errored at the very end of the program, when writing codetf.
* I wasn't sure if to add a test given @drdavella is about to make lots of changes to this interface. At least it's a very temporary patch.
