### PR TITLE
Codemod: fix mutable params

### DIFF
--- a/integration_tests/test_fix_mutable_params.py
+++ b/integration_tests/test_fix_mutable_params.py
@@ -1,0 +1,33 @@
+from codemodder.codemods.fix_mutable_params import FixMutableParams
+from integration_tests.base_test import (
+    BaseIntegrationTest,
+    original_and_expected_from_code_path,
+)
+
+
+class TestFixMutableParams(BaseIntegrationTest):
+    codemod = FixMutableParams
+    code_path = "tests/samples/mutable_params.py"
+    original_code, _ = original_and_expected_from_code_path(code_path, [])
+    expected_new_code = """
+def foo(x, y=None):
+    y = [] if y is None else y
+    y.append(x)
+    print(y)
+
+
+def bar(x="hello"):
+    print(x)
+
+
+def baz(x=None, y=None):
+    x = {"foo": 42} if x is None else x
+    y = set() if y is None else y
+    print(x)
+    print(y)
+""".lstrip()
+
+    expected_diff = '--- \n+++ \n@@ -1,4 +1,5 @@\n-def foo(x, y=[]):\n+def foo(x, y=None):\n+    y = [] if y is None else y\n     y.append(x)\n     print(y)\n \n@@ -7,6 +8,8 @@\n     print(x)\n \n \n-def baz(x={"foo": 42}, y=set()):\n+def baz(x=None, y=None):\n+    x = {"foo": 42} if x is None else x\n+    y = set() if y is None else y\n     print(x)\n     print(y)\n'
+    expected_line_change = 1
+    num_changes = 2
+    change_description = FixMutableParams.CHANGE_DESCRIPTION

--- a/src/codemodder/codemods/__init__.py
+++ b/src/codemodder/codemods/__init__.py
@@ -4,6 +4,7 @@ from codemodder.codemods.django_debug_flag_on import DjangoDebugFlagOn
 from codemodder.codemods.django_session_cookie_secure_off import (
     DjangoSessionCookieSecureOff,
 )
+from codemodder.codemods.fix_mutable_params import FixMutableParams
 from codemodder.codemods.harden_pyyaml import HardenPyyaml
 from codemodder.codemods.harden_ruamel import HardenRuamel
 from codemodder.codemods.https_connection import HTTPSConnection
@@ -27,6 +28,7 @@ DEFAULT_CODEMODS = [
     HardenPyyaml,
     HardenRuamel,
     HTTPSConnection,
+    FixMutableParams,
     LimitReadline,
     OrderImports,
     ProcessSandbox,

--- a/src/codemodder/codemods/api/__init__.py
+++ b/src/codemodder/codemods/api/__init__.py
@@ -84,6 +84,15 @@ class BaseCodemod(
     BaseTransformer,
     Helpers,
 ):
+    def __init__(
+        self,
+        codemod_context: CodemodContext,
+        execution_context: CodemodExecutionContext,
+        file_context: FileContext,
+    ):
+        _BaseCodemod.__init__(self, execution_context, file_context)
+        BaseTransformer.__init__(self, codemod_context, [])
+
     def report_change(self, original_node):
         line_number = self.lineno_for_node(original_node)
         self.file_context.codemod_changes.append(
@@ -110,6 +119,7 @@ class SemgrepCodemod(
         execution_context: CodemodExecutionContext,
         file_context: FileContext,
     ):
+        BaseCodemod.__init__(self, codemod_context, execution_context, file_context)
         _SemgrepCodemod.__init__(self, execution_context, file_context)
         BaseTransformer.__init__(self, codemod_context, self._results)
 

--- a/src/codemodder/codemods/base_codemod.py
+++ b/src/codemodder/codemods/base_codemod.py
@@ -3,6 +3,9 @@ from enum import Enum
 import itertools
 from typing import List, ClassVar
 
+from libcst._position import CodeRange
+
+from codemodder.change import Change
 from codemodder.context import CodemodExecutionContext
 from codemodder.file_context import FileContext
 from codemodder.semgrep import rule_ids_from_yaml_files
@@ -71,6 +74,18 @@ class BaseCodemod:
         # pylint: disable=no-member
         # See https://github.com/Instagram/LibCST/blob/main/libcst/_metadata_dependent.py#L112
         return self.get_metadata(self.METADATA_DEPENDENCIES[0], node)
+
+    def add_change(self, node, description):
+        position = self.node_position(node)
+        self.add_change_from_position(position, description)
+
+    def add_change_from_position(self, position: CodeRange, description):
+        self.file_context.codemod_changes.append(
+            Change(
+                lineNumber=position.start.line,
+                description=description,
+            ).to_json()
+        )
 
     def lineno_for_node(self, node):
         return self.node_position(node).start.line

--- a/src/codemodder/codemods/docs/pixee_python_fix-mutable-params.md
+++ b/src/codemodder/codemods/docs/pixee_python_fix-mutable-params.md
@@ -1,0 +1,52 @@
+Using mutable values for default arguments is not a safe practice.
+Look at the following very simple example code:
+
+```python
+def foo(x, y=[]):
+    y.append(x)
+    print(y)
+```
+
+The function `foo` doesn't do anything very interesting; it just prints the
+result of `x` appended to `y`. Naively we might expect this to simply print an
+array containing only `x` every time `foo` is called, like this:
+
+```python
+>>> foo(1)
+[1]
+>>> foo(2)
+[2]
+```
+
+But that's not what happens!
+
+```python
+>>> foo(1)
+[1]
+>>> foo(2)
+[1, 2]
+```
+
+The value of `y` is preserved between calls! This might seem surprising, and it is.
+It's due to the way that scope works for function arguments in Python.
+
+The result is that any default argument value will be preserved between
+function calls. This is problematic for *mutable* types, including things
+like `list`, `dict`, and `set`.
+
+Relying on this behavior is unpredictable and generally considered to be
+unsafe. Most of us who write code like this were not anticipating the
+surprising behavior, so it's best to fix it.
+
+Our codemod makes an update that looks like this:
+```diff
+- def foo(x, y=[]):
++ def foo(x, y=None):
++   y = [] if y is None else y
+    y.append(x)
+    print(y)
+```
+
+Using `None` is a much safer default. The new code checks if `None` is passed,
+and if so uses an empty `list` for the value of `y`. This will guarantee
+consistent and safe behavior between calls.

--- a/src/codemodder/codemods/fix_mutable_params.py
+++ b/src/codemodder/codemods/fix_mutable_params.py
@@ -1,0 +1,112 @@
+import libcst as cst
+from libcst import matchers as m
+
+from codemodder.codemods.base_codemod import ReviewGuidance
+from codemodder.codemods.api import BaseCodemod
+
+
+class FixMutableParams(BaseCodemod):
+    NAME = "fix-mutable-params"
+    SUMMARY = "Replace mutable parameters with None"
+    REVIEW_GUIDANCE = ReviewGuidance.MERGE_AFTER_CURSORY_REVIEW
+    DESCRIPTION = "Replace mutable parameters with None"
+
+    _BUILTIN_TO_LITERAL = {
+        "list": cst.List(elements=[]),
+        "dict": cst.Dict(elements=[]),
+    }
+
+    _matches_literal: m.OneOf
+    _matches_builtin: m.Call
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        # Looking for [], {}, or set() (which has no empty literal)
+        self._matches_literal = m.OneOf(
+            m.List | m.Dict | m.Set,
+            m.Call(func=m.Name("set")),
+        )
+        # Looking for list() or dict()
+        self._matches_builtin = m.Call(func=m.Name("list") | m.Name("dict"))
+
+    def _gather_and_update_params(
+        self, original_node: cst.FunctionDef, updated_node: cst.FunctionDef
+    ):
+        updated_params = []
+        new_var_decls = []
+
+        # Iterate over all original/update parameters in parallel
+        for orig, updated in zip(
+            original_node.params.params,
+            updated_node.params.params,
+        ):
+            needs_update = False
+            if orig.default is not None:
+                if m.matches(orig.default, self._matches_literal):
+                    # We can reuse the original literal value in this case
+                    new_var_decls.append(orig)
+                    needs_update = True
+                elif m.matches(orig.default, self._matches_builtin):
+                    # Try to replace call to builtin with bare literal as long as there are no arguments
+                    # Otherwise the safest thing is just to reuse the original value inline
+                    new_var_decls.append(
+                        orig.with_changes(
+                            # Should be a safe attribute access since we've already matched the call
+                            default=self._BUILTIN_TO_LITERAL[orig.default.func.value]
+                        )
+                        if not orig.default.args
+                        else orig
+                    )
+                    needs_update = True
+
+            updated_params.append(
+                updated.with_changes(default=cst.Name("None")) if needs_update else orig
+            )
+
+        return updated_params, new_var_decls
+
+    def _build_body_prefix(self, new_var_decls: list[cst.Param]):
+        return [
+            cst.SimpleStatementLine(
+                body=[
+                    cst.Assign(
+                        targets=[cst.AssignTarget(target=var_decl.name)],
+                        value=cst.IfExp(
+                            test=cst.Comparison(
+                                left=var_decl.name,
+                                comparisons=[
+                                    cst.ComparisonTarget(cst.Is(), cst.Name("None"))
+                                ],
+                            ),
+                            # In the case of list() or dict(), this particular
+                            # default value has been updated to use the literal
+                            # instead. This does not affect the default
+                            # argument in the function itself.
+                            body=var_decl.default,
+                            orelse=var_decl.name,
+                        ),
+                    )
+                ]
+            )
+            for var_decl in new_var_decls
+        ]
+
+    def leave_FunctionDef(
+        self,
+        original_node: cst.FunctionDef,
+        updated_node: cst.FunctionDef,
+    ):
+        """Transforms function definitions with mutable default parameters"""
+        updated_params, new_var_decls = self._gather_and_update_params(
+            original_node, updated_node
+        )
+        # Add any new variable declarations to the top of the function body
+        if body_prefix := self._build_body_prefix(new_var_decls):
+            # If we're adding statements to the body, we know a change took place
+            self.add_change(original_node, self.CHANGE_DESCRIPTION)
+
+        new_body = tuple(body_prefix) + updated_node.body.body
+        return updated_node.with_changes(
+            params=updated_node.params.with_changes(params=updated_params),
+            body=updated_node.body.with_changes(body=new_body),
+        )

--- a/src/codemodder/codemods/remove_unnecessary_f_str.py
+++ b/src/codemodder/codemods/remove_unnecessary_f_str.py
@@ -16,7 +16,7 @@ class RemoveUnnecessaryFStr(BaseCodemod, UnnecessaryFormatString):
 
     def __init__(self, codemod_context: CodemodContext, *codemod_args):
         UnnecessaryFormatString.__init__(self, codemod_context)
-        BaseCodemod.__init__(self, *codemod_args)
+        BaseCodemod.__init__(self, codemod_context, *codemod_args)
 
     @m.leave(m.FormattedString(parts=(m.FormattedStringText(),)))
     def _check_formatted_string(

--- a/tests/codemods/test_fix_mutable_params.py
+++ b/tests/codemods/test_fix_mutable_params.py
@@ -1,0 +1,123 @@
+import pytest
+
+from codemodder.codemods.fix_mutable_params import FixMutableParams
+from tests.codemods.base_codemod_test import BaseCodemodTest
+
+
+class TestFixMutableParams(BaseCodemodTest):
+    codemod = FixMutableParams
+
+    # There's no literal for empty sets, so we use set() instead
+    @pytest.mark.parametrize("mutable", ["[]", "{}", "set()"])
+    def test_fix_single_arg(self, tmpdir, mutable):
+        input_code = f"""
+def foo(bar={mutable}):
+    print(bar)
+"""
+        expected_output = f"""
+def foo(bar=None):
+    bar = {mutable} if bar is None else bar
+    print(bar)
+"""
+        self.run_and_assert(tmpdir, input_code, expected_output)
+
+    @pytest.mark.parametrize("mutable", ["[]", "{}", "set()"])
+    def test_fix_single_arg_method(self, tmpdir, mutable):
+        input_code = f"""
+class Whatever:
+    def foo(self, bar={mutable}):
+        print(bar)
+"""
+        expected_output = f"""
+class Whatever:
+    def foo(self, bar=None):
+        bar = {mutable} if bar is None else bar
+        print(bar)
+"""
+        self.run_and_assert(tmpdir, input_code, expected_output)
+
+    @pytest.mark.parametrize("mutable", ["[1, 2, 3]", '{"a": 42}', "{1, 2, 3}"])
+    def test_with_values(self, tmpdir, mutable):
+        input_code = f"""
+def foo(bar={mutable}):
+    print(bar)
+"""
+        expected_output = f"""
+def foo(bar=None):
+    bar = {mutable} if bar is None else bar
+    print(bar)
+"""
+        self.run_and_assert(tmpdir, input_code, expected_output)
+
+    @pytest.mark.parametrize("orig,updated", [("list()", "[]"), ("dict()", "{}")])
+    def test_fix_single_arg_call_builtin(self, tmpdir, orig, updated):
+        input_code = f"""
+def foo(bar={orig}):
+    print(bar)
+"""
+        expected_output = f"""
+def foo(bar=None):
+    bar = {updated} if bar is None else bar
+    print(bar)
+"""
+        self.run_and_assert(tmpdir, input_code, expected_output)
+
+    @pytest.mark.parametrize("mutable", ["list([1, 2, 3])", "dict({'a': 42})"])
+    def test_fix_single_arg_call_builtin_with_values(self, tmpdir, mutable):
+        input_code = f"""
+def foo(bar={mutable}):
+    print(bar)
+"""
+        expected_output = f"""
+def foo(bar=None):
+    bar = {mutable} if bar is None else bar
+    print(bar)
+"""
+        self.run_and_assert(tmpdir, input_code, expected_output)
+
+    def test_fix_multiple_args(self, tmpdir):
+        input_code = """
+def foo(bar=[], baz={}):
+    print(bar)
+    print(baz)
+"""
+        expected_output = """
+def foo(bar=None, baz=None):
+    bar = [] if bar is None else bar
+    baz = {} if baz is None else baz
+    print(bar)
+    print(baz)
+"""
+        self.run_and_assert(tmpdir, input_code, expected_output)
+
+    def test_fix_multiple_args_mixed(self, tmpdir):
+        input_code = """
+def foo(bar=[], x="hello", baz={"foo": 42}, biz=set(), boz=list(), buz={1, 2, 3}):
+    print(bar)
+    print(baz)
+"""
+        expected_output = """
+def foo(bar=None, x="hello", baz=None, biz=None, boz=None, buz=None):
+    bar = [] if bar is None else bar
+    baz = {"foo": 42} if baz is None else baz
+    biz = set() if biz is None else biz
+    boz = [] if boz is None else boz
+    buz = {1, 2, 3} if buz is None else buz
+    print(bar)
+    print(baz)
+"""
+        self.run_and_assert(tmpdir, input_code, expected_output)
+
+    def test_fix_only_one(self, tmpdir):
+        input_code = """
+def foo(bar="hello", baz={}):
+    print(bar)
+    print(baz)
+"""
+        expected_output = """
+def foo(bar="hello", baz=None):
+    baz = {} if baz is None else baz
+    print(bar)
+    print(baz)
+"""
+        self.run_and_assert(tmpdir, input_code, expected_output)

--- a/tests/samples/mutable_params.py
+++ b/tests/samples/mutable_params.py
@@ -1,0 +1,12 @@
+def foo(x, y=[]):
+    y.append(x)
+    print(y)
+
+
+def bar(x="hello"):
+    print(x)
+
+
+def baz(x={"foo": 42}, y=set()):
+    print(x)
+    print(y)


### PR DESCRIPTION
## Overview
*Add codemod to fix mutable default params in function/method arguments*

## Description

* This fixes cases where a mutable default argument was used in a function definition
* This is generally considered bad practice and potentially unsafe, so it's useful to have a codemod that fixes it
* It seemed easiest to implement this without using semgrep since it can be done efficiently with LibCST matchers