### PR TITLE
Jinja autoescape

### DIFF
--- a/integration_tests/test_jinja2_autoescape.py
+++ b/integration_tests/test_jinja2_autoescape.py
@@ -1,0 +1,21 @@
+from core_codemods.enable_jinja2_autoescape import EnableJinja2Autoescape
+from integration_tests.base_test import (
+    BaseIntegrationTest,
+    original_and_expected_from_code_path,
+)
+
+
+class TestEnableJinja2Autoescape(BaseIntegrationTest):
+    codemod = EnableJinja2Autoescape
+    code_path = "tests/samples/jinja2_autoescape.py"
+    original_code, expected_new_code = original_and_expected_from_code_path(
+        code_path,
+        [
+            (1, "env = Environment(autoescape=True)\n"),
+            (2, "env = Environment(autoescape=True)\n"),
+        ],
+    )
+    expected_diff = "--- \n+++ \n@@ -1,3 +1,3 @@\n from jinja2 import Environment\n-env = Environment()\n-env = Environment(autoescape=False)\n+env = Environment(autoescape=True)\n+env = Environment(autoescape=True)\n"
+    expected_line_change = "2"
+    num_changes = 2
+    change_description = EnableJinja2Autoescape.CHANGE_DESCRIPTION

--- a/integration_tests/test_jinja2_autoescape.py
+++ b/integration_tests/test_jinja2_autoescape.py
@@ -11,11 +11,11 @@ class TestEnableJinja2Autoescape(BaseIntegrationTest):
     original_code, expected_new_code = original_and_expected_from_code_path(
         code_path,
         [
-            (1, "env = Environment(autoescape=True)\n"),
             (2, "env = Environment(autoescape=True)\n"),
+            (3, "env = Environment(autoescape=True)\n"),
         ],
     )
-    expected_diff = "--- \n+++ \n@@ -1,3 +1,3 @@\n from jinja2 import Environment\n-env = Environment()\n-env = Environment(autoescape=False)\n+env = Environment(autoescape=True)\n+env = Environment(autoescape=True)\n"
-    expected_line_change = "2"
+    expected_diff = "--- \n+++ \n@@ -1,4 +1,4 @@\n from jinja2 import Environment\n \n-env = Environment()\n-env = Environment(autoescape=False)\n+env = Environment(autoescape=True)\n+env = Environment(autoescape=True)\n"
+    expected_line_change = "3"
     num_changes = 2
     change_description = EnableJinja2Autoescape.CHANGE_DESCRIPTION

--- a/src/codemodder/codemods/api/helpers.py
+++ b/src/codemodder/codemods/api/helpers.py
@@ -64,10 +64,8 @@ class Helpers:
 
         for arg in original_node.args:
             if matchers.matches(arg.keyword, matchers.Name(target_arg_name)):
-                new = cst.Arg(
-                    keyword=cst.parse_expression(target_arg_name),
-                    value=cst.parse_expression(target_arg_replacement_val),
-                    equal=arg.equal,
+                new = self.make_new_arg(
+                    target_arg_name, target_arg_replacement_val, arg
                 )
                 arg_added = True
             else:
@@ -75,13 +73,21 @@ class Helpers:
             new_args.append(new)
 
         if add_if_missing and not arg_added:
-            new = cst.Arg(
-                keyword=cst.parse_expression(target_arg_name),
-                value=cst.parse_expression(target_arg_replacement_val),
-                equal=cst.AssignEqual(
-                    whitespace_before=cst.SimpleWhitespace(""),
-                    whitespace_after=cst.SimpleWhitespace(""),
-                ),
-            )
+            new = self.make_new_arg(target_arg_name, target_arg_replacement_val)
             new_args.append(new)
         return new_args
+
+    def make_new_arg(self, name, value, existing_arg=None):
+        equal = (
+            existing_arg.equal
+            if existing_arg
+            else cst.AssignEqual(
+                whitespace_before=cst.SimpleWhitespace(""),
+                whitespace_after=cst.SimpleWhitespace(""),
+            )
+        )
+        return cst.Arg(
+            keyword=cst.parse_expression(name),
+            value=cst.parse_expression(value),
+            equal=equal,
+        )

--- a/src/codemodder/codemods/api/helpers.py
+++ b/src/codemodder/codemods/api/helpers.py
@@ -47,10 +47,21 @@ class Helpers:
     def parse_expression(self, expression: str):
         return cst.parse_expression(expression)
 
-    def replace_arg(self, original_node, target_arg_name, target_arg_replacement_val):
-        """Given a node, return its args with one arg's value changed"""
+    def replace_arg(
+        self,
+        original_node,
+        target_arg_name,
+        target_arg_replacement_val,
+        add_if_missing=False,
+    ):
+        """Given a node, return its args with one arg's value changed.
+
+        If add_if_missing is True, then if target arg is not present, add it.
+        """
         assert hasattr(original_node, "args")
         new_args = []
+        arg_added = False
+
         for arg in original_node.args:
             if matchers.matches(arg.keyword, matchers.Name(target_arg_name)):
                 new = cst.Arg(
@@ -58,7 +69,19 @@ class Helpers:
                     value=cst.parse_expression(target_arg_replacement_val),
                     equal=arg.equal,
                 )
+                arg_added = True
             else:
                 new = arg
+            new_args.append(new)
+
+        if add_if_missing and not arg_added:
+            new = cst.Arg(
+                keyword=cst.parse_expression(target_arg_name),
+                value=cst.parse_expression(target_arg_replacement_val),
+                equal=cst.AssignEqual(
+                    whitespace_before=cst.SimpleWhitespace(""),
+                    whitespace_after=cst.SimpleWhitespace(""),
+                ),
+            )
             new_args.append(new)
         return new_args

--- a/src/codemodder/codemods/base_visitor.py
+++ b/src/codemodder/codemods/base_visitor.py
@@ -26,6 +26,8 @@ class UtilsMixin:
         return True
 
     def node_is_selected(self, node) -> bool:
+        if not self.results:
+            return False
         pos_to_match = self.node_position(node)
         return self.filter_by_result(
             pos_to_match

--- a/src/core_codemods/__init__.py
+++ b/src/core_codemods/__init__.py
@@ -2,6 +2,7 @@ from codemodder.registry import CodemodCollection
 
 from .django_debug_flag_on import DjangoDebugFlagOn
 from .django_session_cookie_secure_off import DjangoSessionCookieSecureOff
+from .enable_jinja2_autoescape import EnableJinja2Autoescape
 from .fix_mutable_params import FixMutableParams
 from .harden_pyyaml import HardenPyyaml
 from .harden_ruamel import HardenRuamel
@@ -27,6 +28,7 @@ registry = CodemodCollection(
     codemods=[
         DjangoDebugFlagOn,
         DjangoSessionCookieSecureOff,
+        EnableJinja2Autoescape,
         FixMutableParams,
         HardenPyyaml,
         HardenRuamel,

--- a/src/core_codemods/docs/pixee_python_enable-jinja2-autoescape.md
+++ b/src/core_codemods/docs/pixee_python_enable-jinja2-autoescape.md
@@ -1,8 +1,8 @@
-This codemod ensures you configure jinja2 to turn on autoescaping of HTML content. Unfortunately, the jinja2
+This codemod enables autoescaping of HTML content in `jinja2`. Unfortunately, the jinja2
 default behavior is to not autoescape when rendering templates, which makes your applications
 vulnerable to Cross-Site Scripting (XSS) attacks.
 
-Our codemod currently checks if you forgot to turn autoescape on or if you explicitly disabled it. The change looks as follows:
+Our codemod checks if you forgot to enable autoescape or if you explicitly disabled it. The change looks as follows:
 
 ```diff
   from jinja2 import Environment
@@ -14,4 +14,3 @@ Our codemod currently checks if you forgot to turn autoescape on or if you expli
   ...
 ```
 
-At this time, this codemod will not detect if `autoescape` is assigned to a callable.

--- a/src/core_codemods/docs/pixee_python_enable-jinja2-autoescape.md
+++ b/src/core_codemods/docs/pixee_python_enable-jinja2-autoescape.md
@@ -1,0 +1,17 @@
+This codemod ensures you configure jinja2 to turn on autoescaping of HTML content. Unfortunately, the jinja2
+default behavior is to not autoescape when rendering templates, which makes your applications
+vulnerable to Cross-Site Scripting (XSS) attacks.
+
+Our codemod currently checks if you forgot to turn autoescape on or if you explicitly disabled it. The change looks as follows:
+
+```diff
+  from jinja2 import Environment
+
+- env = Environment()
+- env = Environment(autoescape=False, loader=some-loader)
++ env = Environment(autoescape=True)
++ env = Environment(autoescape=True, loader=some-loader)
+  ...
+```
+
+At this time, this codemod will not detect if `autoescape` is assigned to a callable.

--- a/src/core_codemods/docs/pixee_python_enable-jinja2-autoescape.md
+++ b/src/core_codemods/docs/pixee_python_enable-jinja2-autoescape.md
@@ -8,9 +8,9 @@ Our codemod currently checks if you forgot to turn autoescape on or if you expli
   from jinja2 import Environment
 
 - env = Environment()
-- env = Environment(autoescape=False, loader=some-loader)
+- env = Environment(autoescape=False, loader=some_loader)
 + env = Environment(autoescape=True)
-+ env = Environment(autoescape=True, loader=some-loader)
++ env = Environment(autoescape=True, loader=some_loader)
   ...
 ```
 

--- a/src/core_codemods/enable_jinja2_autoescape.py
+++ b/src/core_codemods/enable_jinja2_autoescape.py
@@ -1,0 +1,34 @@
+from codemodder.codemods.base_codemod import ReviewGuidance
+from codemodder.codemods.api import SemgrepCodemod
+
+
+class EnableJinja2Autoescape(SemgrepCodemod):
+    NAME = "enable-jinja2-autoescape"
+    REVIEW_GUIDANCE = ReviewGuidance.MERGE_AFTER_CURSORY_REVIEW
+    SUMMARY = "Enable jinja2 autoescape"
+    DESCRIPTION = "Makes the `autoescape` parameter to jinja2.Environment be `True`."
+
+    @classmethod
+    def rule(cls):
+        return """
+            rules:
+                - patterns:
+                  - pattern-either:
+                    - pattern: |
+                        jinja2.Environment()
+                    - pattern: |
+                        jinja2.Environment(...)
+                    - pattern: |
+                        jinja2.Environment(..., autoescape=False, ...)
+                  - pattern-not: |
+                      jinja2.Environment(..., autoescape=True, ...)
+                  - pattern-inside: |
+                      import jinja2
+                        ...
+        """
+
+    def on_result_found(self, original_node, updated_node):
+        new_args = self.replace_arg(
+            original_node, "autoescape", "True", add_if_missing=True
+        )
+        return self.update_arg_target(updated_node, new_args)

--- a/src/core_codemods/enable_jinja2_autoescape.py
+++ b/src/core_codemods/enable_jinja2_autoescape.py
@@ -13,18 +13,11 @@ class EnableJinja2Autoescape(SemgrepCodemod):
         return """
             rules:
                 - patterns:
-                  - pattern-either:
-                    - pattern: |
-                        jinja2.Environment()
-                    - pattern: |
-                        jinja2.Environment(...)
-                    - pattern: |
-                        jinja2.Environment(..., autoescape=False, ...)
-                  - pattern-not: |
-                      jinja2.Environment(..., autoescape=True, ...)
+                  - pattern: jinja2.Environment(...)
+                  - pattern-not: jinja2.Environment(..., autoescape=True, ...)
                   - pattern-inside: |
                       import jinja2
-                        ...
+                      ...
         """
 
     def on_result_found(self, original_node, updated_node):

--- a/src/core_codemods/jwt_decode_verify.py
+++ b/src/core_codemods/jwt_decode_verify.py
@@ -64,7 +64,13 @@ class JwtDecodeVerify(SemgrepCodemod):
             new_args.append(new)
         return new_args
 
-    def replace_arg(self, original_node, target_arg_name, target_arg_replacement_val):
+    def replace_arg(
+        self,
+        original_node,
+        target_arg_name,
+        target_arg_replacement_val,
+        add_if_missing=False,
+    ):
         new_args = super().replace_arg(original_node, "verify", "True")
         return self.replace_options_arg(new_args)
 

--- a/tests/codemods/test_enable_jinja2_autoescape.py
+++ b/tests/codemods/test_enable_jinja2_autoescape.py
@@ -1,0 +1,88 @@
+import pytest
+from codemodder.codemods.enable_jinja2_autoescape import EnableJinja2Autoescape
+from tests.codemods.base_codemod_test import BaseSemgrepCodemodTest
+
+
+class TestEnableJinja2Autoescape(BaseSemgrepCodemodTest):
+    codemod = EnableJinja2Autoescape
+
+    def test_rule_ids(self):
+        assert self.codemod.RULE_IDS == ["enable-jinja2-autoescape"]
+
+    def test_import(self, tmpdir):
+        input_code = """import jinja2
+env = jinja2.Environment()
+var = "hello"
+"""
+        expexted_output = """import jinja2
+env = jinja2.Environment(autoescape=True)
+var = "hello"
+"""
+
+        self.run_and_assert(tmpdir, input_code, expexted_output)
+
+    def test_import_with_arg(self, tmpdir):
+        input_code = """import jinja2
+env = jinja2.Environment(autoescape=False)
+var = "hello"
+"""
+        expexted_output = """import jinja2
+env = jinja2.Environment(autoescape=True)
+var = "hello"
+"""
+
+        self.run_and_assert(tmpdir, input_code, expexted_output)
+
+    def test_import_with_more_args(self, tmpdir):
+        input_code = """import jinja2
+env = jinja2.Environment(loader=some_loader, autoescape=False)
+var = "hello"
+"""
+        expexted_output = """import jinja2
+env = jinja2.Environment(loader=some_loader, autoescape=True)
+var = "hello"
+"""
+
+        self.run_and_assert(tmpdir, input_code, expexted_output)
+
+    def test_import_with_other_args(self, tmpdir):
+        input_code = """import jinja2
+env = jinja2.Environment(loader=some_loader)
+var = "hello"
+"""
+        expexted_output = """import jinja2
+env = jinja2.Environment(loader=some_loader, autoescape=True)
+var = "hello"
+"""
+
+        self.run_and_assert(tmpdir, input_code, expexted_output)
+
+    def test_from_import(self, tmpdir):
+        input_code = """from jinja2 import Environment
+env = Environment()
+var = "hello"
+"""
+        expexted_output = """from jinja2 import Environment
+env = Environment(autoescape=True)
+var = "hello"
+"""
+        self.run_and_assert(tmpdir, input_code, expexted_output)
+
+    def test_import_alias(self, tmpdir):
+        input_code = """import jinja2 as templating
+env = templating.Environment()
+var = "hello"
+"""
+        expexted_output = """import jinja2 as templating
+env = templating.Environment(autoescape=True)
+var = "hello"
+"""
+        self.run_and_assert(tmpdir, input_code, expexted_output)
+
+    def test_autoescape_enabled(self, tmpdir):
+        input_code = """import jinja2
+env = jinja2.Environment(autoescape=True)
+var = "hello"
+"""
+        expexted_output = input_code
+        self.run_and_assert(tmpdir, input_code, expexted_output)

--- a/tests/codemods/test_enable_jinja2_autoescape.py
+++ b/tests/codemods/test_enable_jinja2_autoescape.py
@@ -1,5 +1,4 @@
-import pytest
-from codemodder.codemods.enable_jinja2_autoescape import EnableJinja2Autoescape
+from core_codemods.enable_jinja2_autoescape import EnableJinja2Autoescape
 from tests.codemods.base_codemod_test import BaseSemgrepCodemodTest
 
 
@@ -7,7 +6,7 @@ class TestEnableJinja2Autoescape(BaseSemgrepCodemodTest):
     codemod = EnableJinja2Autoescape
 
     def test_rule_ids(self):
-        assert self.codemod.RULE_IDS == ["enable-jinja2-autoescape"]
+        assert self.codemod.NAME == "enable-jinja2-autoescape"
 
     def test_import(self, tmpdir):
         input_code = """import jinja2

--- a/tests/samples/jinja2_autoescape.py
+++ b/tests/samples/jinja2_autoescape.py
@@ -1,0 +1,4 @@
+from jinja2 import Environment
+
+env = Environment()
+env = Environment(autoescape=False)

--- a/tests/samples/jwt_decode_verify.py
+++ b/tests/samples/jwt_decode_verify.py
@@ -8,7 +8,11 @@ payload = {
 
 encoded_jwt = jwt.encode(payload, SECRET_KEY, algorithm="HS256")
 
-decoded_payload = jwt.decode(encoded_jwt, SECRET_KEY, algorithms=["HS256"], verify=False)
-decoded_payload = jwt.decode(encoded_jwt, SECRET_KEY, algorithms=["HS256"], options={"verify_signature": False})
+decoded_payload = jwt.decode(
+    encoded_jwt, SECRET_KEY, algorithms=["HS256"], verify=False
+)
+decoded_payload = jwt.decode(
+    encoded_jwt, SECRET_KEY, algorithms=["HS256"], options={"verify_signature": False}
+)
 
 var = "something"

--- a/tests/samples/jwt_decode_verify.py
+++ b/tests/samples/jwt_decode_verify.py
@@ -8,11 +8,7 @@ payload = {
 
 encoded_jwt = jwt.encode(payload, SECRET_KEY, algorithm="HS256")
 
-decoded_payload = jwt.decode(
-    encoded_jwt, SECRET_KEY, algorithms=["HS256"], verify=False
-)
-decoded_payload = jwt.decode(
-    encoded_jwt, SECRET_KEY, algorithms=["HS256"], options={"verify_signature": False}
-)
+decoded_payload = jwt.decode(encoded_jwt, SECRET_KEY, algorithms=["HS256"], verify=False)
+decoded_payload = jwt.decode(encoded_jwt, SECRET_KEY, algorithms=["HS256"], options={"verify_signature": False})
 
 var = "something"


### PR DESCRIPTION
## Overview
*Add a codemod that checks if jinja2.Environment enables autoescape*

## Description

* `autoescape`, a jinja2 setting to guard against XSS attacks, is disabled by default (and can explicitly be disabled)
* This PR ensures users enable autoescape
* Due to confusion around jinja2's `select_autoescape` function (see bug report [here](https://github.com/pallets/jinja/issues/1890)), this codemod does not detect if autoescape is assigned to a callable, such as `Environment(autoescape=select_autoescape())`. this is the recommended way in the docs. We will cover that later.
