### PR TITLE
Update tests to use `.name()` and rely on wrapper id

### DIFF
--- a/src/codemodder/codemods/base_codemod.py
+++ b/src/codemodder/codemods/base_codemod.py
@@ -40,11 +40,6 @@ class BaseCodemod:
         # pylint: disable=no-member
         return cls.METADATA.NAME
 
-    @classmethod
-    def id(cls):
-        # pylint: disable=no-member
-        return f"pixee:python/{cls.name()}"
-
     @property
     def should_transform(self):
         return True

--- a/tests/codemods/test_django_debug_flag_on.py
+++ b/tests/codemods/test_django_debug_flag_on.py
@@ -5,8 +5,8 @@ from tests.codemods.base_codemod_test import BaseDjangoCodemodTest
 class TestDjangoDebugFlagOn(BaseDjangoCodemodTest):
     codemod = DjangoDebugFlagOn
 
-    def test_rule_ids(self):
-        assert self.codemod.METADATA.NAME == "django-debug-flag-on"
+    def test_name(self):
+        assert self.codemod.name() == "django-debug-flag-on"
 
     def test_settings_dot_py(self, tmpdir):
         django_root, settings_folder = self.create_dir_structure(tmpdir)

--- a/tests/codemods/test_django_session_cookie_secure_off.py
+++ b/tests/codemods/test_django_session_cookie_secure_off.py
@@ -8,8 +8,8 @@ from tests.codemods.base_codemod_test import BaseDjangoCodemodTest
 class TestDjangoSessionSecureCookieOff(BaseDjangoCodemodTest):
     codemod = DjangoSessionCookieSecureOff
 
-    def test_rule_ids(self):
-        assert self.codemod.METADATA.NAME == "django-session-cookie-secure-off"
+    def test_name(self):
+        assert self.codemod.name() == "django-session-cookie-secure-off"
 
     def test_not_settings_dot_py(self, tmpdir):
         django_root, settings_folder = self.create_dir_structure(tmpdir)

--- a/tests/codemods/test_harden_pyyaml.py
+++ b/tests/codemods/test_harden_pyyaml.py
@@ -10,8 +10,8 @@ UNSAFE_LOADERS.remove("SafeLoader")
 class TestHardenPyyaml(BaseSemgrepCodemodTest):
     codemod = HardenPyyaml
 
-    def test_rule_ids(self):
-        assert self.codemod.NAME == "harden-pyyaml"
+    def test_name(self):
+        assert self.codemod.name() == "harden-pyyaml"
 
     def test_safe_loader(self, tmpdir):
         input_code = """import yaml

--- a/tests/codemods/test_harden_ruamel.py
+++ b/tests/codemods/test_harden_ruamel.py
@@ -6,8 +6,8 @@ from tests.codemods.base_codemod_test import BaseSemgrepCodemodTest
 class TestHardenRuamel(BaseSemgrepCodemodTest):
     codemod = HardenRuamel
 
-    def test_rule_ids(self):
-        assert self.codemod.NAME == "harden-ruamel"
+    def test_name(self):
+        assert self.codemod.name() == "harden-ruamel"
 
     @pytest.mark.parametrize("loader", ["YAML()", "YAML(typ='rt')", "YAML(typ='safe')"])
     def test_safe(self, tmpdir, loader):

--- a/tests/codemods/test_jwt_decode_verify.py
+++ b/tests/codemods/test_jwt_decode_verify.py
@@ -6,8 +6,8 @@ from tests.codemods.base_codemod_test import BaseSemgrepCodemodTest
 class TestJwtDecodeVerify(BaseSemgrepCodemodTest):
     codemod = JwtDecodeVerify
 
-    def test_rule_ids(self):
-        assert self.codemod.NAME == "jwt-decode-verify"
+    def test_name(self):
+        assert self.codemod.name() == "jwt-decode-verify"
 
     def test_import(self, tmpdir):
         input_code = """import jwt

--- a/tests/codemods/test_limit_readline.py
+++ b/tests/codemods/test_limit_readline.py
@@ -5,8 +5,8 @@ from tests.codemods.base_codemod_test import BaseSemgrepCodemodTest
 class TestLimitReadline(BaseSemgrepCodemodTest):
     codemod = LimitReadline
 
-    def test_rule_ids(self):
-        assert self.codemod.NAME == "limit-readline"
+    def test_name(self):
+        assert self.codemod.name() == "limit-readline"
 
     def test_file_readline(self, tmpdir):
         input_code = """file = open('some_file.txt')

--- a/tests/codemods/test_process_creation_sandbox.py
+++ b/tests/codemods/test_process_creation_sandbox.py
@@ -6,8 +6,8 @@ from tests.codemods.base_codemod_test import BaseSemgrepCodemodTest
 class TestProcessCreationSandbox(BaseSemgrepCodemodTest):
     codemod = ProcessSandbox
 
-    def test_rule_ids(self):
-        assert self.codemod.NAME == "sandbox-process-creation"
+    def test_name(self):
+        assert self.codemod.name() == "sandbox-process-creation"
 
     def test_import_subprocess(self, tmpdir):
         input_code = """import subprocess

--- a/tests/codemods/test_request_verify.py
+++ b/tests/codemods/test_request_verify.py
@@ -8,8 +8,8 @@ REQUEST_FUNCS = ["get", "post", "request"]
 class TestRequestsVerify(BaseSemgrepCodemodTest):
     codemod = RequestsVerify
 
-    def test_rule_ids(self):
-        assert self.codemod.NAME == "requests-verify"
+    def test_name(self):
+        assert self.codemod.name() == "requests-verify"
 
     @pytest.mark.parametrize("func", REQUEST_FUNCS)
     def test_default_verify(self, tmpdir, func):

--- a/tests/codemods/test_secure_random.py
+++ b/tests/codemods/test_secure_random.py
@@ -6,8 +6,8 @@ from tests.codemods.base_codemod_test import BaseSemgrepCodemodTest
 class TestSecureRandom(BaseSemgrepCodemodTest):
     codemod = SecureRandom
 
-    def test_rule_ids(self):
-        assert self.codemod.NAME == "secure-random"
+    def test_name(self):
+        assert self.codemod.name() == "secure-random"
 
     def test_import_random(self, tmpdir):
         input_code = """import random

--- a/tests/codemods/test_tempfile_mktemp.py
+++ b/tests/codemods/test_tempfile_mktemp.py
@@ -6,8 +6,8 @@ from tests.codemods.base_codemod_test import BaseSemgrepCodemodTest
 class TestTempfileMktemp(BaseSemgrepCodemodTest):
     codemod = TempfileMktemp
 
-    def test_rule_ids(self):
-        assert self.codemod.NAME == "secure-tempfile"
+    def test_name(self):
+        assert self.codemod.name() == "secure-tempfile"
 
     def test_import(self, tmpdir):
         input_code = """import tempfile

--- a/tests/codemods/test_url_sandbox.py
+++ b/tests/codemods/test_url_sandbox.py
@@ -6,8 +6,8 @@ from tests.codemods.base_codemod_test import BaseSemgrepCodemodTest
 class TestUrlSandbox(BaseSemgrepCodemodTest):
     codemod = UrlSandbox
 
-    def test_rule_ids(self):
-        assert self.codemod.METADATA.NAME == "url-sandbox"
+    def test_name(self):
+        assert self.codemod.name() == "url-sandbox"
 
     def test_import_requests(self, tmpdir):
         input_code = """import requests


### PR DESCRIPTION
## Overview
I noticed we forgot to update tests when we changed the codemod API. I think this is the way to go to encourage us to use `.name()` instead of accessing the metadata attr directly.

Secondly, now that we have a codemod wrapper, and in fact the wrapper is what we use to report id in codetf results, then I was able to remove the base_codemod id class attr. It just needed an update in integration tests.