### PR TITLE
Temporary workaround for Docker build for libcst

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,6 +2,16 @@ FROM python:3.11
 WORKDIR /codemodder
 COPY . .
 
+# Install Rust (temporary workaround for libcst dependency)
+RUN apt-get update && \
+    apt-get install -y curl && \
+    curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y && \
+    apt-get remove -y curl && \
+    apt-get autoremove -y && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/*
+ENV PATH="/root/.cargo/bin:${PATH}"
+
 RUN pip install .
 
 ENTRYPOINT ["codemodder"]


### PR DESCRIPTION
## Overview
*Fix the deploy pipeline*

## Description
* This contains a workaround for a temporary dependency on a fork of libcst