### PR TITLE
Implement logging spec

### DIFF
--- a/src/codemodder/__init__.py
+++ b/src/codemodder/__init__.py
@@ -1,1 +1,2 @@
-__VERSION__ = "0.1.0"
+# TODO: use tag-based versioning
+__VERSION__ = "0.57.0"

--- a/src/codemodder/cli.py
+++ b/src/codemodder/cli.py
@@ -134,11 +134,13 @@ def parse_args(argv, codemod_registry):
     parser.add_argument(
         "--path-exclude",
         action=CsvListAction,
+        default="",
         help="Comma-separated set of UNIX glob patterns to exclude",
     )
     parser.add_argument(
         "--path-include",
         action=CsvListAction,
+        default="**/*.py",
         help="Comma-separated set of UNIX glob patterns to include",
     )
 

--- a/src/codemodder/cli.py
+++ b/src/codemodder/cli.py
@@ -2,7 +2,7 @@ import argparse
 import sys
 
 from codemodder import __VERSION__
-from codemodder.logging import logger
+from codemodder.logging import OutputFormat, logger
 
 
 class ArgumentParser(argparse.ArgumentParser):
@@ -133,6 +133,13 @@ def parse_args(argv, codemod_registry):
         "--verbose",
         action=argparse.BooleanOptionalAction,
         help="print more to stdout",
+    )
+    parser.add_argument(
+        "--log-format",
+        type=OutputFormat,
+        default=OutputFormat.HUMAN,
+        choices=[str(x).split(".")[-1].lower() for x in list(OutputFormat)],
+        help="the format for the log output",
     )
     parser.add_argument(
         "--path-exclude",

--- a/src/codemodder/cli.py
+++ b/src/codemodder/cli.py
@@ -129,8 +129,11 @@ def parse_args(argv, codemod_registry):
         action=argparse.BooleanOptionalAction,
         help="do everything except make changes to files",
     )
-
-    parser.add_argument("--verbose", type=bool, help="print more to stdout")
+    parser.add_argument(
+        "--verbose",
+        action=argparse.BooleanOptionalAction,
+        help="print more to stdout",
+    )
     parser.add_argument(
         "--path-exclude",
         action=CsvListAction,

--- a/src/codemodder/codemodder.py
+++ b/src/codemodder/codemodder.py
@@ -10,7 +10,7 @@ from libcst.codemod import CodemodContext
 from codemodder.file_context import FileContext
 
 from codemodder import registry, __VERSION__
-from codemodder.logging import logger
+from codemodder.logging import configure_logger, logger
 from codemodder.cli import parse_args
 from codemodder.code_directory import file_line_patterns, match_files
 from codemodder.context import CodemodExecutionContext, ChangeSet
@@ -130,13 +130,15 @@ def run(original_args) -> int:
         )
         return 1
 
+    configure_logger(argv.verbose)
+
     logger.info("[startup]")
     logger.info("codemodder: python/%s", __VERSION__)
 
     context = CodemodExecutionContext(
         Path(argv.directory),
-        # TODO: pass all of argv instead of just dry_run
         argv.dry_run,
+        argv.verbose,
         codemod_registry,
     )
 

--- a/src/codemodder/codemodder.py
+++ b/src/codemodder/codemodder.py
@@ -3,11 +3,13 @@ import difflib
 import os
 import sys
 from pathlib import Path
+from textwrap import indent
+
 import libcst as cst
 from libcst.codemod import CodemodContext
 from codemodder.file_context import FileContext
 
-from codemodder import registry
+from codemodder import registry, __VERSION__
 from codemodder.logging import logger
 from codemodder.cli import parse_args
 from codemodder.code_directory import file_line_patterns, match_files
@@ -21,7 +23,6 @@ def update_code(file_path, new_code):
     """
     Write the `new_code` to the `file_path`
     """
-    logger.info("Updated file %s", file_path)
     with open(file_path, "w", encoding="utf-8") as f:
         f.write(new_code)
 
@@ -40,33 +41,31 @@ def apply_codemod_to_file(
         file_context,
     )
     if not codemod.should_transform:
-        return
+        return False
 
-    logger.info("Running codemod %s for %s", name, file_context.file_path)
     output_tree = codemod.transform_module(source_tree)
-    # TODO: there has got to be a more efficient way to check this?
-    changed_file = not output_tree.deep_equals(source_tree)
+    # TODO: we can probably just use the presence of recorded changes instead of
+    # comparing the trees to gain some efficiency
+    if output_tree.deep_equals(source_tree):
+        return False
 
-    if changed_file:
-        diff = "".join(
-            difflib.unified_diff(
-                source_tree.code.splitlines(1), output_tree.code.splitlines(1)
-            )
+    diff = "".join(
+        difflib.unified_diff(
+            source_tree.code.splitlines(1), output_tree.code.splitlines(1)
         )
-        logger.debug("CHANGED %s with codemod %s", file_context.file_path, name)
-        logger.debug(diff)
+    )
 
-        change_set = ChangeSet(
-            str(file_context.file_path.relative_to(execution_context.directory)),
-            diff,
-            changes=file_context.codemod_changes,
-        )
-        execution_context.add_result(name, change_set)
+    change_set = ChangeSet(
+        str(file_context.file_path.relative_to(execution_context.directory)),
+        diff,
+        changes=file_context.codemod_changes,
+    )
+    execution_context.add_result(name, change_set)
 
-        if execution_context.dry_run:
-            logger.info("Dry run, not changing files")
-        else:
-            update_code(file_context.file_path, output_tree.code)
+    if not execution_context.dry_run:
+        update_code(file_context.file_path, output_tree.code)
+
+    return True
 
 
 def analyze_files(
@@ -76,15 +75,16 @@ def analyze_files(
     sarif,
     cli_args,
 ):
-    for file_path in files_to_analyze:
-        # TODO: handle potential race condition that file no longer exists at this point
-        with open(file_path, "r", encoding="utf-8") as f:
-            code = f.read()
+    for idx, file_path in enumerate(files_to_analyze):
+        if idx and idx % 100 == 0:
+            logger.info("scanned %s files...", idx)  # pragma: no cover
 
         try:
-            source_tree = cst.parse_module(code)
+            with open(file_path, "r", encoding="utf-8") as f:
+                source_tree = cst.parse_module(f.read())
         except Exception:
-            logger.exception("Error parsing file %s", file_path)
+            execution_context.add_failure(codemod.id, file_path)
+            logger.exception("error parsing file %s", file_path)
             continue
 
         line_exclude = file_line_patterns(file_path, cli_args.path_exclude)
@@ -105,6 +105,16 @@ def analyze_files(
             source_tree,
         )
 
+    if failures := execution_context.get_failures(codemod.id):
+        logger.info("failed:")
+        for name in failures:
+            logger.info("  - %s", name)
+    if changes := execution_context.get_results(codemod.id):
+        logger.info("changed:")
+        for change in changes:
+            logger.info("  - %s", change.path)
+            logger.debug("    diff:\n%s", indent(change.diff, " " * 6))
+
 
 def run(original_args) -> int:
     start = datetime.datetime.now()
@@ -115,10 +125,13 @@ def run(original_args) -> int:
     argv = parse_args(original_args, codemod_registry)
     if not os.path.exists(argv.directory):
         logger.error(
-            "Given directory '%s' doesn't exist or can’t be read",
+            "given directory '%s' doesn't exist or can’t be read",
             argv.directory,
         )
         return 1
+
+    logger.info("[startup]")
+    logger.info("codemodder: python/%s", __VERSION__)
 
     context = CodemodExecutionContext(
         Path(argv.directory),
@@ -132,26 +145,33 @@ def run(original_args) -> int:
         argv.codemod_include, argv.codemod_exclude
     )
     if not codemods_to_run:
-        # We only currently have semgrep codemods so don't go on if no codemods matched.
-        logger.warning("No codemods to run")
+        # XXX: sarif files given on the command line are currently not used by any codemods
+        logger.error("no codemods to run")
         return 0
 
-    logger.debug("Codemods to run: %s", [codemod.id for codemod in codemods_to_run])
-
-    # XXX: sarif files given on the command line are currently not used by any codemods
+    logger.info("[setup]")
+    logger.info("running:")
+    for codemod in codemods_to_run:
+        logger.info("  - %s", codemod.id)
+    logger.info("including paths: %s", argv.path_include)
+    logger.info("excluding paths: %s", argv.path_exclude)
 
     files_to_analyze = match_files(
         context.directory, argv.path_exclude, argv.path_include
     )
     if not files_to_analyze:
-        logger.warning("No files matched.")
+        logger.error("no files matched.")
         return 0
 
     full_names = [str(path) for path in files_to_analyze]
-    logger.debug("Matched files:\n%s", "\n".join(full_names))
+    logger.debug("matched files:")
+    for name in full_names:
+        logger.debug("  - %s", name)
 
-    # run codemods in sequence
+    logger.info("[scanning]")
+    # run codemods one at a time making sure to respect the given sequence
     for codemod in codemods_to_run:
+        logger.info("running codemod %s", codemod.id)
         results = codemod.apply(context)
         analyze_files(
             context,
@@ -167,6 +187,24 @@ def run(original_args) -> int:
     elapsed = datetime.datetime.now() - start
     elapsed_ms = int(elapsed.total_seconds() * 1000)
     report_default(elapsed_ms, argv, original_args, results)
+
+    logger.info("[report]")
+    logger.info("scanned: %s files", len(files_to_analyze))
+    all_failures = context.get_failed_files()
+    logger.info(
+        "failed: %s files (%s unique)",
+        len(all_failures),
+        len(set(all_failures)),
+    )
+    all_changes = context.get_changed_files()
+    logger.info(
+        "changed: %s files (%s unique)",
+        len(all_changes),
+        len(set(all_changes)),
+    )
+    logger.info("report file: %s", argv.output)
+    logger.info("elapsed: %s ms", elapsed_ms)
+
     return 0
 
 

--- a/src/codemodder/codemodder.py
+++ b/src/codemodder/codemodder.py
@@ -10,7 +10,7 @@ from libcst.codemod import CodemodContext
 from codemodder.file_context import FileContext
 
 from codemodder import registry, __VERSION__
-from codemodder.logging import configure_logger, logger
+from codemodder.logging import configure_logger, logger, log_section
 from codemodder.cli import parse_args
 from codemodder.code_directory import file_line_patterns, match_files
 from codemodder.context import CodemodExecutionContext, ChangeSet
@@ -132,7 +132,7 @@ def run(original_args) -> int:
 
     configure_logger(argv.verbose)
 
-    logger.info("[startup]")
+    log_section("startup")
     logger.info("codemodder: python/%s", __VERSION__)
 
     context = CodemodExecutionContext(
@@ -151,7 +151,7 @@ def run(original_args) -> int:
         logger.error("no codemods to run")
         return 0
 
-    logger.info("[setup]")
+    log_section("setup")
     logger.info("running:")
     for codemod in codemods_to_run:
         logger.info("  - %s", codemod.id)
@@ -170,7 +170,7 @@ def run(original_args) -> int:
     for name in full_names:
         logger.debug("  - %s", name)
 
-    logger.info("[scanning]")
+    log_section("scanning")
     # run codemods one at a time making sure to respect the given sequence
     for codemod in codemods_to_run:
         logger.info("running codemod %s", codemod.id)
@@ -190,7 +190,7 @@ def run(original_args) -> int:
     elapsed_ms = int(elapsed.total_seconds() * 1000)
     report_default(elapsed_ms, argv, original_args, results)
 
-    logger.info("[report]")
+    log_section("report")
     logger.info("scanned: %s files", len(files_to_analyze))
     all_failures = context.get_failed_files()
     logger.info(

--- a/src/codemodder/context.py
+++ b/src/codemodder/context.py
@@ -1,5 +1,6 @@
 from pathlib import Path
 from dataclasses import dataclass
+import itertools
 
 from codemodder.change import Change
 from codemodder.executor import CodemodExecutorWrapper
@@ -20,6 +21,7 @@ class ChangeSet:
 
 class CodemodExecutionContext:
     _results_by_codemod: dict[str, list[ChangeSet]] = {}
+    _failures_by_codemod: dict[str, list[Path]] = {}
     dependencies: set[str]
     directory: Path
     dry_run: bool = False
@@ -30,10 +32,34 @@ class CodemodExecutionContext:
         self.dry_run = dry_run
         self.dependencies = set()
         self._results_by_codemod = {}
+        self._failures_by_codemod = {}
         self.registry = registry
 
     def add_result(self, codemod_name, change_set):
         self._results_by_codemod.setdefault(codemod_name, []).append(change_set)
+
+    def add_failure(self, codemod_name, file_path):
+        self._failures_by_codemod.setdefault(codemod_name, []).append(file_path)
+
+    def get_results(self, codemod_name):
+        return self._results_by_codemod.get(codemod_name, [])
+
+    def get_changed_files(self):
+        return [
+            change_set.path
+            for changes in self._results_by_codemod.values()
+            for change_set in changes
+        ]
+
+    def get_failures(self, codemod_name):
+        return self._failures_by_codemod.get(codemod_name, [])
+
+    def get_failed_files(self):
+        return list(
+            itertools.chain.from_iterable(
+                failures for failures in self._failures_by_codemod.values()
+            )
+        )
 
     def add_dependency(self, dependency: str):
         self.dependencies.add(dependency)

--- a/src/codemodder/context.py
+++ b/src/codemodder/context.py
@@ -19,17 +19,25 @@ class ChangeSet:
         return {"path": self.path, "diff": self.diff, "changes": self.changes}
 
 
-class CodemodExecutionContext:
+class CodemodExecutionContext:  # pylint: disable=too-many-instance-attributes
     _results_by_codemod: dict[str, list[ChangeSet]] = {}
     _failures_by_codemod: dict[str, list[Path]] = {}
     dependencies: set[str]
     directory: Path
     dry_run: bool = False
+    verbose: bool = False
     registry: CodemodRegistry
 
-    def __init__(self, directory, dry_run, registry: CodemodRegistry):
+    def __init__(
+        self,
+        directory: Path,
+        dry_run: bool,
+        verbose: bool,
+        registry: CodemodRegistry,
+    ):
         self.directory = directory
         self.dry_run = dry_run
+        self.verbose = verbose
         self.dependencies = set()
         self._results_by_codemod = {}
         self._failures_by_codemod = {}

--- a/src/codemodder/dependency_manager.py
+++ b/src/codemodder/dependency_manager.py
@@ -1,3 +1,6 @@
+import sys
+import io
+
 from dependency_manager import DependencyManagerAbstract
 from pathlib import Path
 
@@ -11,5 +14,12 @@ def write_dependencies(execution_context: CodemodExecutionContext):
 
     dm = DependencyManager()
     dm.add(list(execution_context.dependencies))
-    dm.write(dry_run=execution_context.dry_run)
+
+    try:
+        # Hacky solution to prevent the dependency manager from writing to stdout
+        sys.stdout = io.StringIO()
+        dm.write(dry_run=execution_context.dry_run)
+    finally:
+        sys.stdout = sys.__stdout__
+
     return dm

--- a/src/codemodder/logging.py
+++ b/src/codemodder/logging.py
@@ -1,5 +1,5 @@
 import logging
 import sys
 
-logging.basicConfig(stream=sys.stdout, level=logging.DEBUG)
+logging.basicConfig(format="%(message)s", stream=sys.stdout, level=logging.INFO)
 logger = logging.getLogger("codemodder")

--- a/src/codemodder/logging.py
+++ b/src/codemodder/logging.py
@@ -14,6 +14,13 @@ class OutputFormat(Enum):
     JSON = "json"
 
 
+def log_section(section_name: str):
+    """
+    Log a section header.
+    """
+    logger.info("\n[%s]", section_name)
+
+
 def configure_logger(verbose: bool):
     """
     Configure the logger based on the verbosity level.

--- a/src/codemodder/logging.py
+++ b/src/codemodder/logging.py
@@ -1,8 +1,18 @@
+from enum import Enum
 import logging
 import sys
 
 logging.basicConfig(format="%(message)s", stream=sys.stdout, level=logging.INFO)
 logger = logging.getLogger("codemodder")
+
+
+class OutputFormat(Enum):
+    """
+    Enum for the output format of the logger.
+    """
+
+    HUMAN = "human"
+    JSON = "json"
 
 
 def configure_logger(verbose: bool):

--- a/src/codemodder/logging.py
+++ b/src/codemodder/logging.py
@@ -3,3 +3,11 @@ import sys
 
 logging.basicConfig(format="%(message)s", stream=sys.stdout, level=logging.INFO)
 logger = logging.getLogger("codemodder")
+
+
+def configure_logger(verbose: bool):
+    """
+    Configure the logger based on the verbosity level.
+    """
+    # TODO: eventually process human/json here
+    logger.setLevel(logging.DEBUG if verbose else logging.INFO)

--- a/src/codemodder/logging.py
+++ b/src/codemodder/logging.py
@@ -2,7 +2,6 @@ from enum import Enum
 import logging
 import sys
 
-logging.basicConfig(format="%(message)s", stream=sys.stdout, level=logging.INFO)
 logger = logging.getLogger("codemodder")
 
 
@@ -19,5 +18,18 @@ def configure_logger(verbose: bool):
     """
     Configure the logger based on the verbosity level.
     """
-    # TODO: eventually process human/json here
-    logger.setLevel(logging.DEBUG if verbose else logging.INFO)
+    log_level = logging.DEBUG if verbose else logging.INFO
+
+    # TODO: this should all be conditional on the output format
+    stdout_handler = logging.StreamHandler(sys.stdout)
+    stdout_handler.setLevel(log_level)
+    stdout_handler.addFilter(lambda record: record.levelno <= logging.WARNING)
+
+    stderr_handler = logging.StreamHandler(sys.stderr)
+    stderr_handler.setLevel(logging.ERROR)
+
+    logging.basicConfig(
+        format="%(message)s",
+        level=log_level,
+        handlers=[stdout_handler, stderr_handler],
+    )

--- a/src/codemodder/registry.py
+++ b/src/codemodder/registry.py
@@ -102,10 +102,10 @@ class CodemodRegistry:
 
 def load_registered_codemods() -> CodemodRegistry:
     registry = CodemodRegistry()
-    logger.info("Loading registered codemod collections")
+    logger.debug("loading registered codemod collections")
     for entry_point in entry_points()["codemods"]:
         logger.debug(
-            'Loading codemod collection "%s" from "%s"',
+            '- loading codemod collection "%s" from "%s"',
             entry_point.name,
             entry_point.module,
         )

--- a/src/codemodder/report/codetf_reporter.py
+++ b/src/codemodder/report/codetf_reporter.py
@@ -43,8 +43,8 @@ class CodeTF:
             with open(outfile, "w", encoding="utf-8") as f:
                 json.dump(self.report, f)
         except Exception:
-            logger.exception("Failed to write report file.")
+            logger.exception("failed to write report file.")
             # Any issues with writing the output file should exit status 2.
             return 2
-        logger.info("Wrote report to %s", outfile)
+        logger.debug("wrote report to %s", outfile)
         return 0

--- a/src/codemodder/semgrep.py
+++ b/src/codemodder/semgrep.py
@@ -32,10 +32,16 @@ def run_on_directory(yaml_files: List[Path], directory: Path):
             )
         )
         command.append(str(directory))
-        joined_command = " ".join(command)
-        logger.debug("Executing semgrep with: `%s`", joined_command)
+        logger.debug("semgrep command: `%s`", " ".join(command))
         # TODO: make sure to capture stderr and stdout in the event of a problem
-        subprocess.run(command, shell=False, check=True)
+        subprocess.run(
+            command,
+            shell=False,
+            check=True,
+            # TODO: report on verbose mode
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+        )
         results = results_by_path_and_rule_id(temp_sarif_file.name)
         return results
 

--- a/src/codemodder/semgrep.py
+++ b/src/codemodder/semgrep.py
@@ -8,7 +8,7 @@ from codemodder.sarifs import results_by_path_and_rule_id
 from codemodder.logging import logger
 
 
-def run_on_directory(yaml_files: List[Path], directory: Path):
+def run(execution_context: CodemodExecutionContext, yaml_files: List[Path]) -> dict:
     """
     Runs Semgrep and outputs a dict with the results organized by rule_id.
     """
@@ -31,20 +31,14 @@ def run_on_directory(yaml_files: List[Path], directory: Path):
                 map(lambda f: ["--config", str(f)], yaml_files)
             )
         )
-        command.append(str(directory))
+        command.append(str(execution_context.directory))
         logger.debug("semgrep command: `%s`", " ".join(command))
-        # TODO: make sure to capture stderr and stdout in the event of a problem
         subprocess.run(
             command,
             shell=False,
             check=True,
-            # TODO: report on verbose mode
-            stdout=subprocess.PIPE,
-            stderr=subprocess.PIPE,
+            stdout=None if execution_context.verbose else subprocess.PIPE,
+            stderr=None if execution_context.verbose else subprocess.PIPE,
         )
         results = results_by_path_and_rule_id(temp_sarif_file.name)
         return results
-
-
-def run(execution_context: CodemodExecutionContext, yaml_files: List[Path]) -> dict:
-    return run_on_directory(yaml_files, execution_context.directory)

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -7,8 +7,8 @@ from codemodder.registry import load_registered_codemods
 
 class TestRun:
     @mock.patch("libcst.parse_module")
-    @mock.patch("codemodder.codemodder.logger.warning")
-    def test_no_files_matched(self, warning_log, mock_parse):
+    @mock.patch("codemodder.codemodder.logger.error")
+    def test_no_files_matched(self, error_log, mock_parse):
         args = [
             "tests/samples/",
             "--output",
@@ -20,8 +20,8 @@ class TestRun:
         res = run(args)
         assert res == 0
 
-        warning_log.assert_called()
-        assert warning_log.call_args_list[0][0][0] == "No files matched."
+        error_log.assert_called()
+        assert error_log.call_args_list[0][0][0] == "no files matched."
 
         mock_parse.assert_not_called()
 
@@ -46,10 +46,9 @@ class TestRun:
         _, _, _, results_by_codemod = args_to_reporting
         assert results_by_codemod == []
 
-    @mock.patch("codemodder.codemodder.logger.info")
     @mock.patch("codemodder.codemodder.update_code")
     @mock.patch("codemodder.codemods.base_codemod.semgrep_run", side_effect=semgrep_run)
-    def test_dry_run(self, _, mock_update_code, info_log):
+    def test_dry_run(self, _, mock_update_code):
         args = [
             "tests/samples/",
             "--output",
@@ -59,14 +58,6 @@ class TestRun:
 
         res = run(args)
         assert res == 0
-
-        info_log.assert_called()
-
-        logged_msgs = [
-            info_log.call_args_list[x][0][0]
-            for x in range(len(info_log.call_args_list))
-        ]
-        assert "Dry run, not changing files" in logged_msgs
 
         mock_update_code.assert_not_called()
 


### PR DESCRIPTION
## Overview
*Align codemodder logging output with the new logging spec*

## Description

* This implements the new [logging spec](https://github.com/pixee/codemodder-specs/blob/main/logging.md)
* JSON output will be implemented in a future PR

Example without `--verbose`:
```
[startup]
codemodder: python/0.57.0

[setup]
running:
  - pixee:python/secure-random
  - pixee:python/harden-pyyaml
including paths: **/*.py
excluding paths: 

[scanning]
running codemod pixee:python/secure-random
changed:
  - /Users/danieldavella/pygoat/introduction/views.py
running codemod pixee:python/harden-pyyaml
changed:
  - /Users/danieldavella/pygoat/introduction/views.py
  - /Users/danieldavella/pygoat/introduction/lab_code/test.py

[report]
scanned: 53 files
failed: 0 files (0 unique)
changed: 3 files (2 unique)
report file: output.codetf2
elapsed: 5398 ms
```

Snippet with `--verbose`:
```

[startup]
codemodder: python/0.57.0

[setup]
running:
  - pixee:python/secure-random
  - pixee:python/harden-pyyaml
including paths: **/*.py
excluding paths: 
matched files:
  - /Users/danieldavella/pygoat/uninstaller.py
  - /Users/danieldavella/pygoat/PyGoatBot.py
  - /Users/danieldavella/pygoat/setup.py
  - /Users/danieldavella/pygoat/temp.py
  - /Users/danieldavella/pygoat/manage.py
<... snip ...>

[scanning]
running codemod pixee:python/secure-random
semgrep command: `semgrep scan --legacy --no-error --dataflow-traces --sarif -o /var/folders/0j/khp_1wm11nb81wbvnjgl865m0000gn/T/semgreps7a8rxdw.sarif --config /var/folders/0j/khp_1wm11nb81wbvnjgl865m0000gn/T/tmp_palrp17 /Users/danieldavella/pygoat`
changed:
  - introduction/views.py
    --- 
    +++ 
    @@ -6,7 +6,6 @@
     from requests.structures import CaseInsensitiveDict
     from django.contrib.auth import login,authenticate
     from django.contrib.auth.forms import UserCreationForm
    -import random
     import string
     import os
     from hashlib import md5
    @@ -16,7 +15,6 @@
     #*****************************************Lab Requirements****************************************************#
 
     from .models import  FAANG,info,login,comments,otp
    -from random import randint
     from xml.dom.pulldom import parseString, START_ELEMENT
     from xml.sax.handler import feature_external_ges
     from xml.sax import make_parser
    @@ -39,6 +37,8 @@
     import logging
     import requests
     import re
    +import secrets
    +
     #*****************************************Login and Registration****************************************************#
 
     def register(request):
    @@ -484,7 +484,7 @@
     def Otp(request):
         if request.method=="GET":
             email=request.GET.get('email')
    -        otpN=randint(100,999)
    +        otpN=secrets.SystemRandom().randint(100,999)
             if email and otpN:
                 if email=="admin@pygoat.com":
                     otp.objects.filter(id=2).update(otp=otpN)
    @@ -668,7 +668,7 @@
     #*********************************************************A11*************************************************#
 
     def gentckt():
    -    return (''.join(random.choices(string.ascii_uppercase + string.ascii_lowercase, k=10)))
    +    return (''.join(secrets.SystemRandom().choices(string.ascii_uppercase + string.ascii_lowercase, k=10)))
 
     def insec_desgine(request):
         if request.user.is_authenticated:

running codemod pixee:python/harden-pyyaml
semgrep command: `semgrep scan --legacy --no-error --dataflow-traces --sarif -o /var/folders/0j/khp_1wm11nb81wbvnjgl865m0000gn/T/semgrep3l9a7n5z.sarif --config /var/folders/0j/khp_1wm11nb81wbvnjgl865m0000gn/T/tmp2dgjl_a1 /Users/danieldavella/pygoat`
changed:
  - introduction/views.py
    --- 
    +++ 
    @@ -548,7 +548,7 @@
                 try :
                     file=request.FILES["file"]
                     try :
    -                    data = yaml.load(file,yaml.Loader)
    +                    data = yaml.load(file,yaml.SafeLoader)
                     
                         return render(request,"Lab/A9/a9_lab.html",{"data":data})
                     except:

  - introduction/lab_code/test.py
    --- 
    +++ 
    @@ -17,7 +17,7 @@
     '''
     import yaml, subprocess
     stream = open('/home/fox/test.yaml', 'r')
    -data = yaml.load(stream)
    +data = yaml.load(stream, yaml.SafeLoader)
 
     '''
     stdout, stderr = data.communicate()

wrote report to output.codetf2

[report]
scanned: 53 files
failed: 0 files (0 unique)
changed: 3 files (2 unique)
report file: output.codetf2
elapsed: 5549 ms
```
