### PR TITLE
add name resolution to threading codemod

### DIFF
--- a/src/codemodder/codemods/utils_mixin.py
+++ b/src/codemodder/codemods/utils_mixin.py
@@ -78,7 +78,7 @@ class NameResolutionMixin(MetadataDependent):
         names = []
         scope = self.find_global_scope()
         if scope is None:
-            return []
+            return []  # pragma: no cover
 
         nodes = [x.node for x in scope.assignments]
         for other_nodes in nodes:
@@ -93,7 +93,7 @@ class NameResolutionMixin(MetadataDependent):
         for scope in scopes:
             if isinstance(scope, GlobalScope):
                 return scope
-        return None
+        return None  # pragma: no cover
 
     def find_single_assignment(
         self,

--- a/src/core_codemods/with_threading_lock.py
+++ b/src/core_codemods/with_threading_lock.py
@@ -52,8 +52,10 @@ class WithThreadingLock(SemgrepCodemod, NameResolutionMixin):
         if len(original_node.items) == 1 and self.node_is_selected(
             original_node.items[0]
         ):
-            current_names = self.find_used_names(original_node)
-            value = "lock" if "lock" not in current_names else "lock_"
+            current_names = self.find_used_names_in_module()
+            # arbitrarily choose `lock_cm` if `lock` name is already taken
+            # in hopes that `lock_cm` is very unlikely to be used.
+            value = "lock" if "lock" not in current_names else "lock_cm"
             name = cst.Name(value=value)
             assign = cst.SimpleStatementLine(
                 body=[

--- a/src/core_codemods/with_threading_lock.py
+++ b/src/core_codemods/with_threading_lock.py
@@ -1,9 +1,10 @@
 import libcst as cst
 from codemodder.codemods.base_codemod import ReviewGuidance
 from codemodder.codemods.api import SemgrepCodemod
+from codemodder.codemods.utils_mixin import NameResolutionMixin
 
 
-class WithThreadingLock(SemgrepCodemod):
+class WithThreadingLock(SemgrepCodemod, NameResolutionMixin):
     NAME = "bad-lock-with-statement"
     SUMMARY = "Separate Lock Instantiation from `with` Call"
     DESCRIPTION = (
@@ -51,8 +52,9 @@ class WithThreadingLock(SemgrepCodemod):
         if len(original_node.items) == 1 and self.node_is_selected(
             original_node.items[0]
         ):
-            # TODO: how to avoid name conflicts here?
-            name = cst.Name(value="lock")
+            current_names = self.find_used_names(original_node)
+            value = "lock" if "lock" not in current_names else "lock_"
+            name = cst.Name(value=value)
             assign = cst.SimpleStatementLine(
                 body=[
                     cst.Assign(

--- a/tests/codemods/base_codemod_test.py
+++ b/tests/codemods/base_codemod_test.py
@@ -37,8 +37,9 @@ class BaseCodemodTest:
             [],
             defaultdict(list),
         )
+        wrapper = cst.MetadataWrapper(input_tree)
         command_instance = self.codemod(
-            CodemodContext(),
+            CodemodContext(wrapper=wrapper),
             self.execution_context,
             self.file_context,
         )
@@ -83,8 +84,9 @@ class BaseSemgrepCodemodTest(BaseCodemodTest):
             [],
             results,
         )
+        wrapper = cst.MetadataWrapper(input_tree)
         command_instance = self.codemod(
-            CodemodContext(),
+            CodemodContext(wrapper=wrapper),
             self.execution_context,
             self.file_context,
         )

--- a/tests/codemods/test_with_threading_lock.py
+++ b/tests/codemods/test_with_threading_lock.py
@@ -102,8 +102,8 @@ with Lock():
 """,
                 """from threading import Lock
 lock = 1
-lock_cm = Lock()
-with lock_cm:
+lock_1 = Lock()
+with lock_1:
     ...
 """,
             ),
@@ -115,8 +115,8 @@ with Lock():
 """,
                 """from threading import Lock
 from something import lock
-lock_cm = Lock()
-with lock_cm:
+lock_1 = Lock()
+with lock_1:
     ...
 """,
             ),
@@ -130,8 +130,8 @@ def f(l):
                 """import threading
 lock = 1
 def f(l):
-    lock_cm = threading.Lock()
-    with lock_cm:
+    lock_1 = threading.Lock()
+    with lock_1:
         return [lock_ for lock_ in l]
 """,
             ),
@@ -141,13 +141,20 @@ with threading.Lock():
     int("1")
 with threading.Lock():
     print()
+var = 1
+with threading.Lock():
+    print()
 """,
                 """import threading
 lock = threading.Lock()
 with lock:
     int("1")
-lock = threading.Lock()
-with lock:
+lock_1 = threading.Lock()
+with lock_1:
+    print()
+var = 1
+lock_2 = threading.Lock()
+with lock_2:
     print()
 """,
             ),
@@ -158,8 +165,8 @@ with threading.Lock():
         print()
 """,
                 """import threading
-lock = threading.Lock()
-with lock:
+lock_1 = threading.Lock()
+with lock_1:
     lock = threading.Lock()
     with lock:
         print()

--- a/tests/codemods/test_with_threading_lock.py
+++ b/tests/codemods/test_with_threading_lock.py
@@ -135,6 +135,38 @@ def f(l):
         return [lock_ for lock_ in l]
 """,
             ),
+            (
+                    """import threading
+with threading.Lock():
+    int("1")
+    
+with threading.Lock():
+    print()
+""",
+                    """import threading
+lock = threading.Lock()
+with lock:
+    int("1")
+    
+lock = threading.Lock()
+with lock:
+    print()
+""",
+            ),
+            (
+                    """import threading
+with threading.Lock():
+    with threading.Lock():
+        print()
+""",
+                    """import threading
+lock = threading.Lock()
+with lock:
+    lock = threading.Lock()
+    with lock:
+        print()
+""",
+            ),
         ],
     )
     def test_name_resolution(self, tmpdir, input_code, expected_code):

--- a/tests/codemods/test_with_threading_lock.py
+++ b/tests/codemods/test_with_threading_lock.py
@@ -125,14 +125,14 @@ with lock_1:
 lock = 1
 def f(l):
     with threading.Lock():
-        return [lock_ for lock_ in l]
+        return [lock_1 for lock_1 in l]
 """,
                 """import threading
 lock = 1
 def f(l):
-    lock_1 = threading.Lock()
-    with lock_1:
-        return [lock_ for lock_ in l]
+    lock_2 = threading.Lock()
+    with lock_2:
+        return [lock_1 for lock_1 in l]
 """,
             ),
             (
@@ -170,6 +170,21 @@ with lock_1:
     lock = threading.Lock()
     with lock:
         print()
+""",
+            ),
+            (
+                """import threading
+def my_func():
+    lock = "whatever"
+    with threading.Lock():
+        foo()
+""",
+                """import threading
+def my_func():
+    lock = "whatever"
+    lock_1 = threading.Lock()
+    with lock_1:
+        foo()
 """,
             ),
         ],

--- a/tests/codemods/test_with_threading_lock.py
+++ b/tests/codemods/test_with_threading_lock.py
@@ -86,3 +86,33 @@ with threading.{klass}(), foo():
     ...
 """
         self.run_and_assert(tmpdir, input_code, input_code)
+
+    @each_class
+    def test_name_resolution_var(self, tmpdir, klass):
+        input_code = f"""from threading import {klass}
+lock = 1
+with {klass}():
+    ...
+"""
+        expected = f"""from threading import {klass}
+lock = 1
+lock_ = {klass}()
+with lock_:
+    ...
+"""
+        self.run_and_assert(tmpdir, input_code, expected)
+
+    @each_class
+    def test_name_resolution_import(self, tmpdir, klass):
+        input_code = f"""from threading import {klass}
+from something import lock
+with {klass}():
+    ...
+"""
+        expected = f"""from threading import {klass}
+from something import lock
+lock_ = {klass}()
+with lock_:
+    ...
+"""
+        self.run_and_assert(tmpdir, input_code, expected)

--- a/tests/codemods/test_with_threading_lock.py
+++ b/tests/codemods/test_with_threading_lock.py
@@ -27,8 +27,8 @@ with threading.{klass}():
     ...
 """
         expected = f"""import threading
-lock = threading.{klass}()
-with lock:
+{klass.lower()} = threading.{klass}()
+with {klass.lower()}:
     ...
 """
         self.run_and_assert(tmpdir, input_code, expected)
@@ -40,8 +40,8 @@ with {klass}():
     ...
 """
         expected = f"""from threading import {klass}
-lock = {klass}()
-with lock:
+{klass.lower()} = {klass}()
+with {klass.lower()}:
     ...
 """
         self.run_and_assert(tmpdir, input_code, expected)
@@ -53,8 +53,8 @@ with threading.{klass}() as foo:
     ...
 """
         expected = f"""import threading
-lock = threading.{klass}()
-with lock as foo:
+{klass.lower()} = threading.{klass}()
+with {klass.lower()} as foo:
     ...
 """
         self.run_and_assert(tmpdir, input_code, expected)
@@ -69,8 +69,8 @@ with threading_lock():
     ...
 """
         expected = f"""import threading
-lock = threading.{klass}()
-with lock:
+{klass.lower()} = threading.{klass}()
+with {klass.lower()}:
     ...
 
 with threading_lock():
@@ -136,30 +136,28 @@ def f(l):
 """,
             ),
             (
-                    """import threading
+                """import threading
 with threading.Lock():
     int("1")
-    
 with threading.Lock():
     print()
 """,
-                    """import threading
+                """import threading
 lock = threading.Lock()
 with lock:
     int("1")
-    
 lock = threading.Lock()
 with lock:
     print()
 """,
             ),
             (
-                    """import threading
+                """import threading
 with threading.Lock():
     with threading.Lock():
         print()
 """,
-                    """import threading
+                """import threading
 lock = threading.Lock()
 with lock:
     lock = threading.Lock()


### PR DESCRIPTION
## Overview
*Threading codemod that adds a new variable should name the variable to one that's not already in the module scope*

## Description
- get all the named vars / attrs / imports in the input code and from there determine if we should name the new lock either `lock` or `lock_cm`
- we find the code module's Global scope to find all the used names. We then pick either `lock` or `lock_cm` for the new lock variable, in hopes that either is never used. There may still be a tiny potential for name collusion.
- Finding the global scope for the node's module is sufficient to get all the used names in the module. I tested this against getting used names for all nodes (function scope, class scope, global scope, etc) and turns out global scope contains everything.
