### PR TITLE
Script to automate codemod docs

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -11,7 +11,11 @@ repos:
     rev: 23.9.1
     hooks:
     -   id: black
-        exclude: samples/
+        exclude: |
+          (?x)^(
+              samples/.*|
+              core_codemods/docs/.*
+          )$
 - repo: https://github.com/pre-commit/mirrors-mypy
   rev: v1.5.1
   hooks:

--- a/integration_tests/base_test.py
+++ b/integration_tests/base_test.py
@@ -83,6 +83,7 @@ class BaseIntegrationTest(DependencyTestMixin, CleanRepoMixin):
         assert len(results) == 1
         result = results[0]
         assert result["codemod"] == self.codemod_wrapper.id
+        assert result["references"] == self.codemod_wrapper.references
         assert len(result["changeset"]) == self.num_changed_files
 
         # A codemod may change multiple files. For now we will

--- a/integration_tests/base_test.py
+++ b/integration_tests/base_test.py
@@ -84,6 +84,11 @@ class BaseIntegrationTest(DependencyTestMixin, CleanRepoMixin):
         result = results[0]
         assert result["codemod"] == self.codemod_wrapper.id
         assert result["references"] == self.codemod_wrapper.references
+
+        # TODO: once we add description for each url.
+        for reference in result["references"]:
+            assert reference["url"] == reference["description"]
+
         assert len(result["changeset"]) == self.num_changed_files
 
         # A codemod may change multiple files. For now we will

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,6 +20,8 @@ dependencies = [
 
 [project.scripts]
 codemodder = "codemodder.codemodder:main"
+generate-docs = 'scripts.generate_docs:main'
+
 
 [project.entry-points.codemods]
 core = "core_codemods:registry"

--- a/src/codemodder/codemods/api/__init__.py
+++ b/src/codemodder/codemods/api/__init__.py
@@ -69,6 +69,7 @@ class _CodemodSubclassWithMetadata:
                 cls.DESCRIPTION,  # pylint: disable=no-member
                 cls.NAME,  # pylint: disable=no-member
                 cls.REVIEW_GUIDANCE,  # pylint: disable=no-member
+                cls.REFERENCES,  # pylint: disable=no-member
             )
 
             # This is a little bit hacky, but it also feels like the right solution?

--- a/src/codemodder/codemods/base_codemod.py
+++ b/src/codemodder/codemods/base_codemod.py
@@ -23,6 +23,21 @@ class CodemodMetadata:
     REVIEW_GUIDANCE: ReviewGuidance
     REFERENCES: list = field(default_factory=list)
 
+    # TODO: remove post_init update_references once we add description for each url.
+    def __post_init__(self):
+        object.__setattr__(self, "REFERENCES", self.update_references(self.REFERENCES))
+
+    @staticmethod
+    def update_references(references):
+        updated_references = []
+        for reference in references:
+            updated_reference = dict(
+                reference
+            )  # Create a copy to avoid modifying the original dict
+            updated_reference["description"] = updated_reference["url"]
+            updated_references.append(updated_reference)
+        return updated_references
+
 
 class BaseCodemod:
     # Implementation borrowed from https://stackoverflow.com/a/45250114

--- a/src/codemodder/codemods/base_codemod.py
+++ b/src/codemodder/codemods/base_codemod.py
@@ -1,4 +1,4 @@
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from enum import Enum
 from typing import List, ClassVar
 
@@ -21,6 +21,7 @@ class CodemodMetadata:
     DESCRIPTION: str  # TODO: this field should be optional
     NAME: str
     REVIEW_GUIDANCE: ReviewGuidance
+    REFERENCES: list = field(default_factory=list)
 
 
 class BaseCodemod:

--- a/src/codemodder/context.py
+++ b/src/codemodder/context.py
@@ -82,7 +82,7 @@ class CodemodExecutionContext:  # pylint: disable=too-many-instance-attributes
                 "codemod": codemod.id,
                 "summary": codemod.summary,
                 "description": codemod.description,
-                "references": [],
+                "references": codemod.references,
                 "properties": {},
                 "failedFiles": [],
                 "changeset": [change.to_json() for change in changeset],

--- a/src/codemodder/executor.py
+++ b/src/codemodder/executor.py
@@ -59,6 +59,10 @@ class CodemodExecutorWrapper(CallableObjectProxy):
             return self.METADATA.DESCRIPTION
 
     @property
+    def review_guidance(self):
+        return self.METADATA.REVIEW_GUIDANCE.name.replace("_", " ").title()
+
+    @property
     def yaml_files(self):
         return [
             self.semgrep_config_module / yaml_file

--- a/src/codemodder/executor.py
+++ b/src/codemodder/executor.py
@@ -63,6 +63,10 @@ class CodemodExecutorWrapper(CallableObjectProxy):
         return self.METADATA.REVIEW_GUIDANCE.name.replace("_", " ").title()
 
     @property
+    def references(self):
+        return self.METADATA.REFERENCES
+
+    @property
     def yaml_files(self):
         return [
             self.semgrep_config_module / yaml_file

--- a/src/codemodder/registry.py
+++ b/src/codemodder/registry.py
@@ -61,7 +61,7 @@ class CodemodRegistry:
         for k, v in asdict(codemod.METADATA).items():
             if v is NotImplemented:
                 raise NotImplementedError(f"METADATA.{k} not defined for {codemod}")
-            if not v:
+            if k != "REFERENCES" and not v:
                 raise NotImplementedError(
                     f"METADATA.{k} should not be None or empty for {codemod}"
                 )

--- a/src/core_codemods/django_debug_flag_on.py
+++ b/src/core_codemods/django_debug_flag_on.py
@@ -18,6 +18,16 @@ class DjangoDebugFlagOn(SemgrepCodemod, Codemod):
         DESCRIPTION=("Flips django's debug flag if on."),
         NAME="django-debug-flag-on",
         REVIEW_GUIDANCE=ReviewGuidance.MERGE_AFTER_CURSORY_REVIEW,
+        REFERENCES=[
+            {
+                "url": "https://owasp.org/www-project-top-ten/2017/A3_2017-Sensitive_Data_Exposure",
+                "description": "",
+            },
+            {
+                "url": "https://docs.djangoproject.com/en/4.2/ref/settings/#std-setting-DEBUG",
+                "description": "",
+            },
+        ],
     )
     SUMMARY = CHANGE_DESCRIPTION = "Flip Django debug flag to off"
     YAML_FILES = [

--- a/src/core_codemods/django_debug_flag_on.py
+++ b/src/core_codemods/django_debug_flag_on.py
@@ -15,7 +15,7 @@ from codemodder.codemods.utils import is_django_settings_file
 
 class DjangoDebugFlagOn(SemgrepCodemod, Codemod):
     METADATA = CodemodMetadata(
-        DESCRIPTION=("Flips django's debug flag if on."),
+        DESCRIPTION="Flip Django Debug Flag to Off",
         NAME="django-debug-flag-on",
         REVIEW_GUIDANCE=ReviewGuidance.MERGE_AFTER_CURSORY_REVIEW,
         REFERENCES=[
@@ -29,7 +29,7 @@ class DjangoDebugFlagOn(SemgrepCodemod, Codemod):
             },
         ],
     )
-    SUMMARY = CHANGE_DESCRIPTION = "Flip Django debug flag to off"
+    SUMMARY = CHANGE_DESCRIPTION = METADATA. DESCRIPTION
     YAML_FILES = [
         "django-debug-flag-on.yaml",
     ]

--- a/src/core_codemods/django_debug_flag_on.py
+++ b/src/core_codemods/django_debug_flag_on.py
@@ -15,7 +15,7 @@ from codemodder.codemods.utils import is_django_settings_file
 
 class DjangoDebugFlagOn(SemgrepCodemod, Codemod):
     METADATA = CodemodMetadata(
-        DESCRIPTION="Flip Django Debug Flag to Off",
+        DESCRIPTION="Flip `Django` debug flag to off.",
         NAME="django-debug-flag-on",
         REVIEW_GUIDANCE=ReviewGuidance.MERGE_AFTER_CURSORY_REVIEW,
         REFERENCES=[
@@ -29,7 +29,8 @@ class DjangoDebugFlagOn(SemgrepCodemod, Codemod):
             },
         ],
     )
-    SUMMARY = CHANGE_DESCRIPTION = METADATA.DESCRIPTION
+    SUMMARY = "Disable Django Debug Mode"
+    CHANGE_DESCRIPTION = METADATA.DESCRIPTION
     YAML_FILES = [
         "django-debug-flag-on.yaml",
     ]

--- a/src/core_codemods/django_debug_flag_on.py
+++ b/src/core_codemods/django_debug_flag_on.py
@@ -29,7 +29,7 @@ class DjangoDebugFlagOn(SemgrepCodemod, Codemod):
             },
         ],
     )
-    SUMMARY = CHANGE_DESCRIPTION = METADATA. DESCRIPTION
+    SUMMARY = CHANGE_DESCRIPTION = METADATA.DESCRIPTION
     YAML_FILES = [
         "django-debug-flag-on.yaml",
     ]

--- a/src/core_codemods/django_session_cookie_secure_off.py
+++ b/src/core_codemods/django_session_cookie_secure_off.py
@@ -17,7 +17,7 @@ class DjangoSessionCookieSecureOff(SemgrepCodemod, Codemod):
     METADATA = CodemodMetadata(
         DESCRIPTION=("Sets Django's `SESSION_COOKIE_SECURE` Flag if Off or Missing."),
         NAME="django-session-cookie-secure-off",
-        REVIEW_GUIDANCE=ReviewGuidance.MERGE_AFTER_REVIEW,
+        REVIEW_GUIDANCE=ReviewGuidance.MERGE_AFTER_CURSORY_REVIEW,
         REFERENCES=[
             {
                 "url": "https://owasp.org/www-community/controls/SecureCookieAttribute",
@@ -29,7 +29,7 @@ class DjangoSessionCookieSecureOff(SemgrepCodemod, Codemod):
             },
         ],
     )
-    SUMMARY = "Secure setting for Django `SESSION_COOKIE_SECURE` flag"
+    SUMMARY = "Secure Setting for Django `SESSION_COOKIE_SECURE` flag"
     CHANGE_DESCRIPTION = METADATA.DESCRIPTION
     YAML_FILES = [
         "detect-django-settings.yaml",

--- a/src/core_codemods/django_session_cookie_secure_off.py
+++ b/src/core_codemods/django_session_cookie_secure_off.py
@@ -18,6 +18,16 @@ class DjangoSessionCookieSecureOff(SemgrepCodemod, Codemod):
         DESCRIPTION=("Sets Django's `SESSION_COOKIE_SECURE` flag if off or missing."),
         NAME="django-session-cookie-secure-off",
         REVIEW_GUIDANCE=ReviewGuidance.MERGE_AFTER_REVIEW,
+        REFERENCES=[
+            {
+                "url": "https://owasp.org/www-community/controls/SecureCookieAttribute",
+                "description": "",
+            },
+            {
+                "url": "https://docs.djangoproject.com/en/4.2/ref/settings/#session-cookie-secure",
+                "description": "",
+            },
+        ],
     )
     SUMMARY = "Secure setting for Django `SESSION_COOKIE_SECURE` flag"
     CHANGE_DESCRIPTION = METADATA.DESCRIPTION

--- a/src/core_codemods/django_session_cookie_secure_off.py
+++ b/src/core_codemods/django_session_cookie_secure_off.py
@@ -15,7 +15,7 @@ from codemodder.file_context import FileContext
 
 class DjangoSessionCookieSecureOff(SemgrepCodemod, Codemod):
     METADATA = CodemodMetadata(
-        DESCRIPTION=("Sets Django's `SESSION_COOKIE_SECURE` flag if off or missing."),
+        DESCRIPTION=("Sets Django's `SESSION_COOKIE_SECURE` Flag if Off or Missing."),
         NAME="django-session-cookie-secure-off",
         REVIEW_GUIDANCE=ReviewGuidance.MERGE_AFTER_REVIEW,
         REFERENCES=[

--- a/src/core_codemods/django_session_cookie_secure_off.py
+++ b/src/core_codemods/django_session_cookie_secure_off.py
@@ -15,7 +15,7 @@ from codemodder.file_context import FileContext
 
 class DjangoSessionCookieSecureOff(SemgrepCodemod, Codemod):
     METADATA = CodemodMetadata(
-        DESCRIPTION=("Sets Django's `SESSION_COOKIE_SECURE` Flag if Off or Missing."),
+        DESCRIPTION=("Sets Django's `SESSION_COOKIE_SECURE` flag if off or missing."),
         NAME="django-session-cookie-secure-off",
         REVIEW_GUIDANCE=ReviewGuidance.MERGE_AFTER_CURSORY_REVIEW,
         REFERENCES=[

--- a/src/core_codemods/docs/pixee_python_enable-jinja2-autoescape.md
+++ b/src/core_codemods/docs/pixee_python_enable-jinja2-autoescape.md
@@ -1,6 +1,6 @@
 This codemod enables autoescaping of HTML content in `jinja2`. Unfortunately, the jinja2
 default behavior is to not autoescape when rendering templates, which makes your applications
-vulnerable to Cross-Site Scripting (XSS) attacks.
+potentially vulnerable to Cross-Site Scripting (XSS) attacks.
 
 Our codemod checks if you forgot to enable autoescape or if you explicitly disabled it. The change looks as follows:
 
@@ -13,4 +13,3 @@ Our codemod checks if you forgot to enable autoescape or if you explicitly disab
 + env = Environment(autoescape=True, loader=some_loader)
   ...
 ```
-

--- a/src/core_codemods/docs/pixee_python_jwt-decode-verify.md
+++ b/src/core_codemods/docs/pixee_python_jwt-decode-verify.md
@@ -9,10 +9,8 @@ Our change looks as follows:
 - decoded_payload = jwt.decode(encoded_jwt, SECRET_KEY, algorithms=["HS256"], verify=False)
 + decoded_payload = jwt.decode(encoded_jwt, SECRET_KEY, algorithms=["HS256"], verify=True)
   ...
-- decoded_payload = jwt.decode(
-    encoded_jwt, SECRET_KEY, algorithms=["HS256"], options={"verify_signature": False, "verify_exp": False})
-+ decoded_payload = jwt.decode(
-    encoded_jwt, SECRET_KEY, algorithms=["HS256"], options={"verify_signature": True, "verify_exp": True})
+- decoded_payload = jwt.decode(encoded_jwt, SECRET_KEY, algorithms=["HS256"], options={"verify_signature": False, "verify_exp": False})
++ decoded_payload = jwt.decode(encoded_jwt, SECRET_KEY, algorithms=["HS256"], options={"verify_signature": True, "verify_exp": True})
 ```
 
 Any `verify` parameter not listed relies on the secure `True` default value.

--- a/src/core_codemods/docs/pixee_python_unused-imports.md
+++ b/src/core_codemods/docs/pixee_python_unused-imports.md
@@ -6,5 +6,3 @@ import b
 
 b.function()
 ```
-
-If you have feedback on this codemod, [please let us know](mailto:feedback@pixee.ai)!

--- a/src/core_codemods/enable_jinja2_autoescape.py
+++ b/src/core_codemods/enable_jinja2_autoescape.py
@@ -5,7 +5,7 @@ from codemodder.codemods.api.helpers import NewArg
 
 class EnableJinja2Autoescape(SemgrepCodemod):
     NAME = "enable-jinja2-autoescape"
-    REVIEW_GUIDANCE = ReviewGuidance.MERGE_AFTER_CURSORY_REVIEW
+    REVIEW_GUIDANCE = ReviewGuidance.MERGE_WITHOUT_REVIEW
     SUMMARY = "Enable Jinja2 Autoescape"
     DESCRIPTION = "Sets the `autoescape` parameter in jinja2.Environment to `True`."
     REFERENCES = [

--- a/src/core_codemods/enable_jinja2_autoescape.py
+++ b/src/core_codemods/enable_jinja2_autoescape.py
@@ -8,6 +8,13 @@ class EnableJinja2Autoescape(SemgrepCodemod):
     REVIEW_GUIDANCE = ReviewGuidance.MERGE_AFTER_CURSORY_REVIEW
     SUMMARY = "Enable jinja2 autoescape"
     DESCRIPTION = "Makes the `autoescape` parameter to jinja2.Environment be `True`."
+    REFERENCES = [
+        {"url": "https://owasp.org/www-community/attacks/xss/", "description": ""},
+        {
+            "url": "https://jinja.palletsprojects.com/en/3.1.x/api/#autoescaping",
+            "description": "",
+        },
+    ]
 
     @classmethod
     def rule(cls):

--- a/src/core_codemods/enable_jinja2_autoescape.py
+++ b/src/core_codemods/enable_jinja2_autoescape.py
@@ -6,8 +6,8 @@ from codemodder.codemods.api.helpers import NewArg
 class EnableJinja2Autoescape(SemgrepCodemod):
     NAME = "enable-jinja2-autoescape"
     REVIEW_GUIDANCE = ReviewGuidance.MERGE_AFTER_CURSORY_REVIEW
-    SUMMARY = "Enable jinja2 autoescape"
-    DESCRIPTION = "Makes the `autoescape` parameter to jinja2.Environment be `True`."
+    SUMMARY = "Enable Jinja2 Autoescape"
+    DESCRIPTION = "Sets the `autoescape` parameter in jinja2.Environment to `True`."
     REFERENCES = [
         {"url": "https://owasp.org/www-community/attacks/xss/", "description": ""},
         {

--- a/src/core_codemods/fix_mutable_params.py
+++ b/src/core_codemods/fix_mutable_params.py
@@ -10,7 +10,7 @@ class FixMutableParams(BaseCodemod):
     SUMMARY = "Replace Mutable Default Parameters"
     REVIEW_GUIDANCE = ReviewGuidance.MERGE_WITHOUT_REVIEW
     DESCRIPTION = "Replace mutable parameter with None"
-
+    REFERENCES = []
     _BUILTIN_TO_LITERAL = {
         "list": cst.List(elements=[]),
         "dict": cst.Dict(elements=[]),

--- a/src/core_codemods/fix_mutable_params.py
+++ b/src/core_codemods/fix_mutable_params.py
@@ -9,8 +9,8 @@ class FixMutableParams(BaseCodemod):
     NAME = "fix-mutable-params"
     SUMMARY = "Replace Mutable Default Parameters"
     REVIEW_GUIDANCE = ReviewGuidance.MERGE_WITHOUT_REVIEW
-    DESCRIPTION = "Replace mutable parameter with None"
-    REFERENCES = []
+    DESCRIPTION = "Replace mutable parameter with `None`."
+    REFERENCES: list = []
     _BUILTIN_TO_LITERAL = {
         "list": cst.List(elements=[]),
         "dict": cst.Dict(elements=[]),

--- a/src/core_codemods/harden_pyyaml.py
+++ b/src/core_codemods/harden_pyyaml.py
@@ -7,6 +7,12 @@ class HardenPyyaml(SemgrepCodemod):
     REVIEW_GUIDANCE = ReviewGuidance.MERGE_WITHOUT_REVIEW
     SUMMARY = "Use SafeLoader when loading YAML"
     DESCRIPTION = "Ensures all calls to yaml.load use `SafeLoader`."
+    REFERENCES = [
+        {
+            "url": "https://owasp.org/www-community/vulnerabilities/Deserialization_of_untrusted_data",
+            "description": "",
+        }
+    ]
 
     @classmethod
     def rule(cls):

--- a/src/core_codemods/harden_pyyaml.py
+++ b/src/core_codemods/harden_pyyaml.py
@@ -5,7 +5,7 @@ from codemodder.codemods.api import SemgrepCodemod
 class HardenPyyaml(SemgrepCodemod):
     NAME = "harden-pyyaml"
     REVIEW_GUIDANCE = ReviewGuidance.MERGE_WITHOUT_REVIEW
-    SUMMARY = "Use SafeLoader when loading YAML"
+    SUMMARY = "Use SafeLoader in `yaml.load()` Calls"
     DESCRIPTION = "Ensures all calls to yaml.load use `SafeLoader`."
     REFERENCES = [
         {

--- a/src/core_codemods/harden_ruamel.py
+++ b/src/core_codemods/harden_ruamel.py
@@ -6,7 +6,7 @@ from codemodder.codemods.api.helpers import NewArg
 class HardenRuamel(SemgrepCodemod):
     NAME = "harden-ruamel"
     REVIEW_GUIDANCE = ReviewGuidance.MERGE_WITHOUT_REVIEW
-    SUMMARY = "Use safe YAML loading in ruamel.yaml"
+    SUMMARY = "Use `typ='safe'` in ruamel.yaml() Calls"
     DESCRIPTION = "Ensures all unsafe calls to ruamel.yaml.YAML use `typ='safe'`."
     REFERENCES = [
         {

--- a/src/core_codemods/harden_ruamel.py
+++ b/src/core_codemods/harden_ruamel.py
@@ -8,6 +8,12 @@ class HardenRuamel(SemgrepCodemod):
     REVIEW_GUIDANCE = ReviewGuidance.MERGE_WITHOUT_REVIEW
     SUMMARY = "Use safe YAML loading in ruamel.yaml"
     DESCRIPTION = "Ensures all unsafe calls to ruamel.yaml.YAML use `typ='safe'`."
+    REFERENCES = [
+        {
+            "url": "https://owasp.org/www-community/vulnerabilities/Deserialization_of_untrusted_data",
+            "description": "",
+        }
+    ]
 
     @classmethod
     def rule(cls):

--- a/src/core_codemods/https_connection.py
+++ b/src/core_codemods/https_connection.py
@@ -22,7 +22,7 @@ from libcst.codemod import (
 
 class HTTPSConnection(BaseCodemod, Codemod):
     METADATA = CodemodMetadata(
-        DESCRIPTION=("Enforce HTTPS connection"),
+        DESCRIPTION="Enforce HTTPS Connection for urllib3",
         NAME="https-connection",
         REVIEW_GUIDANCE=ReviewGuidance.MERGE_WITHOUT_REVIEW,
         REFERENCES=[
@@ -36,7 +36,7 @@ class HTTPSConnection(BaseCodemod, Codemod):
             },
         ],
     )
-    CHANGE_DESCRIPTION = "Enforce HTTPS connection"
+    CHANGE_DESCRIPTION = METADATA.DESCRIPTION
     SUMMARY = "Changes HTTPConnectionPool to HTTPSConnectionPool to enforce secure connection."
 
     METADATA_DEPENDENCIES = (PositionProvider,)

--- a/src/core_codemods/https_connection.py
+++ b/src/core_codemods/https_connection.py
@@ -25,6 +25,16 @@ class HTTPSConnection(BaseCodemod, Codemod):
         DESCRIPTION=("Enforce HTTPS connection"),
         NAME="https-connection",
         REVIEW_GUIDANCE=ReviewGuidance.MERGE_WITHOUT_REVIEW,
+        REFERENCES=[
+            {
+                "url": "https://owasp.org/www-community/vulnerabilities/Insecure_Transport",
+                "description": "",
+            },
+            {
+                "url": "https://urllib3.readthedocs.io/en/stable/reference/urllib3.connectionpool.html#urllib3.HTTPConnectionPool",
+                "description": "",
+            },
+        ],
     )
     CHANGE_DESCRIPTION = "Enforce HTTPS connection"
     SUMMARY = "Changes HTTPConnectionPool to HTTPSConnectionPool to enforce secure connection."

--- a/src/core_codemods/https_connection.py
+++ b/src/core_codemods/https_connection.py
@@ -22,7 +22,7 @@ from libcst.codemod import (
 
 class HTTPSConnection(BaseCodemod, Codemod):
     METADATA = CodemodMetadata(
-        DESCRIPTION="Enforce HTTPS Connection for urllib3",
+        DESCRIPTION="Enforce HTTPS connection for `urllib3`.",
         NAME="https-connection",
         REVIEW_GUIDANCE=ReviewGuidance.MERGE_WITHOUT_REVIEW,
         REFERENCES=[

--- a/src/core_codemods/https_connection.py
+++ b/src/core_codemods/https_connection.py
@@ -37,7 +37,9 @@ class HTTPSConnection(BaseCodemod, Codemod):
         ],
     )
     CHANGE_DESCRIPTION = METADATA.DESCRIPTION
-    SUMMARY = "Changes HTTPConnectionPool to HTTPSConnectionPool to enforce secure connection."
+    SUMMARY = (
+        "Changes HTTPConnectionPool to HTTPSConnectionPool to Enforce Secure Connection"
+    )
 
     METADATA_DEPENDENCIES = (PositionProvider,)
 

--- a/src/core_codemods/jwt_decode_verify.py
+++ b/src/core_codemods/jwt_decode_verify.py
@@ -8,8 +8,8 @@ from codemodder.codemods.api.helpers import NewArg
 class JwtDecodeVerify(SemgrepCodemod):
     NAME = "jwt-decode-verify"
     REVIEW_GUIDANCE = ReviewGuidance.MERGE_WITHOUT_REVIEW
-    SUMMARY = "Enable all verifications in `jwt.decode` call."
-    DESCRIPTION = "Makes any of the multiple `verify` parameters to a `jwt.decode` call be `True`."
+    SUMMARY = "Verify JWT Decode"
+    DESCRIPTION = "Enable all verifications in `jwt.decode` call."
     REFERENCES = [
         {"url": "https://pyjwt.readthedocs.io/en/stable/api.html", "description": ""},
         {

--- a/src/core_codemods/jwt_decode_verify.py
+++ b/src/core_codemods/jwt_decode_verify.py
@@ -10,6 +10,13 @@ class JwtDecodeVerify(SemgrepCodemod):
     REVIEW_GUIDANCE = ReviewGuidance.MERGE_WITHOUT_REVIEW
     SUMMARY = "Enable all verifications in `jwt.decode` call."
     DESCRIPTION = "Makes any of the multiple `verify` parameters to a `jwt.decode` call be `True`."
+    REFERENCES = [
+        {"url": "https://pyjwt.readthedocs.io/en/stable/api.html", "description": ""},
+        {
+            "url": "https://owasp.org/www-project-web-security-testing-guide/latest/4-Web_Application_Security_Testing/06-Session_Management_Testing/10-Testing_JSON_Web_Tokens",
+            "description": "",
+        },
+    ]
 
     @classmethod
     def rule(cls):

--- a/src/core_codemods/limit_readline.py
+++ b/src/core_codemods/limit_readline.py
@@ -11,6 +11,9 @@ class LimitReadline(SemgrepCodemod):
     REVIEW_GUIDANCE = ReviewGuidance.MERGE_AFTER_CURSORY_REVIEW
     SUMMARY = "Limit the size of readline() calls"
     DESCRIPTION = "Adds a size limit argument to readline() calls."
+    REFERENCES = [
+        {"url": "https://cwe.mitre.org/data/definitions/400.html", "description": ""}
+    ]
 
     @classmethod
     def rule(cls):

--- a/src/core_codemods/limit_readline.py
+++ b/src/core_codemods/limit_readline.py
@@ -9,7 +9,7 @@ default_limit = "5_000_000"
 class LimitReadline(SemgrepCodemod):
     NAME = "limit-readline"
     REVIEW_GUIDANCE = ReviewGuidance.MERGE_AFTER_CURSORY_REVIEW
-    SUMMARY = "Limit the size of readline() calls"
+    SUMMARY = "Limit readline()"
     DESCRIPTION = "Adds a size limit argument to readline() calls."
     REFERENCES = [
         {"url": "https://cwe.mitre.org/data/definitions/400.html", "description": ""}

--- a/src/core_codemods/lxml_safe_parser_defaults.py
+++ b/src/core_codemods/lxml_safe_parser_defaults.py
@@ -7,7 +7,7 @@ class LxmlSafeParserDefaults(SemgrepCodemod):
     NAME = "safe-lxml-parser-defaults"
     REVIEW_GUIDANCE = ReviewGuidance.MERGE_WITHOUT_REVIEW
     SUMMARY = "Use Safe Defaults for `lxml` Parsers"
-    DESCRIPTION = "Replace `lxml` parser parameters with safe defaults"
+    DESCRIPTION = "Replace `lxml` parser parameters with safe defaults."
     REFERENCES = [
         {
             "url": "https://lxml.de/apidoc/lxml.etree.html#lxml.etree.XMLParser",

--- a/src/core_codemods/lxml_safe_parser_defaults.py
+++ b/src/core_codemods/lxml_safe_parser_defaults.py
@@ -6,8 +6,8 @@ from codemodder.codemods.api.helpers import NewArg
 class LxmlSafeParserDefaults(SemgrepCodemod):
     NAME = "safe-lxml-parser-defaults"
     REVIEW_GUIDANCE = ReviewGuidance.MERGE_WITHOUT_REVIEW
-    SUMMARY = "Use Safe Defaults for lxml Parsers"
-    DESCRIPTION = "Replace lxml parser parameters with safe defaults"
+    SUMMARY = "Use Safe Defaults for `lxml` Parsers"
+    DESCRIPTION = "Replace `lxml` parser parameters with safe defaults"
     REFERENCES = [
         {
             "url": "https://lxml.de/apidoc/lxml.etree.html#lxml.etree.XMLParser",

--- a/src/core_codemods/lxml_safe_parser_defaults.py
+++ b/src/core_codemods/lxml_safe_parser_defaults.py
@@ -6,7 +6,7 @@ from codemodder.codemods.api.helpers import NewArg
 class LxmlSafeParserDefaults(SemgrepCodemod):
     NAME = "safe-lxml-parser-defaults"
     REVIEW_GUIDANCE = ReviewGuidance.MERGE_WITHOUT_REVIEW
-    SUMMARY = "Use safe defaults for lxml parsers"
+    SUMMARY = "Use Safe Defaults for lxml Parsers"
     DESCRIPTION = "Replace lxml parser parameters with safe defaults"
 
     @classmethod

--- a/src/core_codemods/lxml_safe_parser_defaults.py
+++ b/src/core_codemods/lxml_safe_parser_defaults.py
@@ -8,6 +8,20 @@ class LxmlSafeParserDefaults(SemgrepCodemod):
     REVIEW_GUIDANCE = ReviewGuidance.MERGE_WITHOUT_REVIEW
     SUMMARY = "Use Safe Defaults for lxml Parsers"
     DESCRIPTION = "Replace lxml parser parameters with safe defaults"
+    REFERENCES = [
+        {
+            "url": "https://lxml.de/apidoc/lxml.etree.html#lxml.etree.XMLParser",
+            "description": "",
+        },
+        {
+            "url": "https://owasp.org/www-community/vulnerabilities/XML_External_Entity_(XXE)_Processing",
+            "description": "",
+        },
+        {
+            "url": "https://cheatsheetseries.owasp.org/cheatsheets/XML_External_Entity_Prevention_Cheat_Sheet.html",
+            "description": "",
+        },
+    ]
 
     @classmethod
     def rule(cls):

--- a/src/core_codemods/lxml_safe_parsing.py
+++ b/src/core_codemods/lxml_safe_parsing.py
@@ -10,6 +10,20 @@ class LxmlSafeParsing(SemgrepCodemod):
     DESCRIPTION = (
         "Call `lxml.etree.parse` and `lxml.etree.fromstring` with a safe parser"
     )
+    REFERENCES = [
+        {
+            "url": "https://lxml.de/apidoc/lxml.etree.html#lxml.etree.XMLParser",
+            "description": "",
+        },
+        {
+            "url": "https://owasp.org/www-community/vulnerabilities/XML_External_Entity_(XXE)_Processing",
+            "description": "",
+        },
+        {
+            "url": "https://cheatsheetseries.owasp.org/cheatsheets/XML_External_Entity_Prevention_Cheat_Sheet.html",
+            "description": "",
+        },
+    ]
 
     @classmethod
     def rule(cls):

--- a/src/core_codemods/lxml_safe_parsing.py
+++ b/src/core_codemods/lxml_safe_parsing.py
@@ -6,7 +6,7 @@ from codemodder.codemods.api.helpers import NewArg
 class LxmlSafeParsing(SemgrepCodemod):
     NAME = "safe-lxml-parsing"
     REVIEW_GUIDANCE = ReviewGuidance.MERGE_WITHOUT_REVIEW
-    SUMMARY = "Use safe parsers in lxml parsing functions"
+    SUMMARY = "Use Safe Parsers in `lxml` Parsing Functions"
     DESCRIPTION = (
         "Call `lxml.etree.parse` and `lxml.etree.fromstring` with a safe parser"
     )

--- a/src/core_codemods/lxml_safe_parsing.py
+++ b/src/core_codemods/lxml_safe_parsing.py
@@ -8,7 +8,7 @@ class LxmlSafeParsing(SemgrepCodemod):
     REVIEW_GUIDANCE = ReviewGuidance.MERGE_WITHOUT_REVIEW
     SUMMARY = "Use Safe Parsers in `lxml` Parsing Functions"
     DESCRIPTION = (
-        "Call `lxml.etree.parse` and `lxml.etree.fromstring` with a safe parser"
+        "Call `lxml.etree.parse` and `lxml.etree.fromstring` with a safe parser."
     )
     REFERENCES = [
         {

--- a/src/core_codemods/order_imports.py
+++ b/src/core_codemods/order_imports.py
@@ -15,7 +15,7 @@ from libcst.codemod import Codemod, CodemodContext
 
 class OrderImports(BaseCodemod, Codemod):
     METADATA = CodemodMetadata(
-        DESCRIPTION=("Formats and orders imports by categories"),
+        DESCRIPTION=("Formats and orders imports by categories."),
         NAME="order-imports",
         REVIEW_GUIDANCE=ReviewGuidance.MERGE_WITHOUT_REVIEW,
         REFERENCES=[],

--- a/src/core_codemods/order_imports.py
+++ b/src/core_codemods/order_imports.py
@@ -15,12 +15,12 @@ from libcst.codemod import Codemod, CodemodContext
 
 class OrderImports(BaseCodemod, Codemod):
     METADATA = CodemodMetadata(
-        DESCRIPTION=("Formats and order imports by categories"),
+        DESCRIPTION=("Formats and orders imports by categories"),
         NAME="order-imports",
         REVIEW_GUIDANCE=ReviewGuidance.MERGE_WITHOUT_REVIEW,
         REFERENCES=[],
     )
-    SUMMARY = "Order imports by categories"
+    SUMMARY = "Order Imports"
     CHANGE_DESCRIPTION = "Ordered and formatted import block below this line"
 
     METADATA_DEPENDENCIES = (PositionProvider,)

--- a/src/core_codemods/order_imports.py
+++ b/src/core_codemods/order_imports.py
@@ -18,6 +18,7 @@ class OrderImports(BaseCodemod, Codemod):
         DESCRIPTION=("Formats and order imports by categories"),
         NAME="order-imports",
         REVIEW_GUIDANCE=ReviewGuidance.MERGE_WITHOUT_REVIEW,
+        REFERENCES=[],
     )
     SUMMARY = "Order imports by categories"
     CHANGE_DESCRIPTION = "Ordered and formatted import block below this line"

--- a/src/core_codemods/process_creation_sandbox.py
+++ b/src/core_codemods/process_creation_sandbox.py
@@ -10,6 +10,16 @@ class ProcessSandbox(SemgrepCodemod):
     DESCRIPTION = (
         "Replaces subprocess.{func} with more secure safe_command library functions."
     )
+    REFERENCES = [
+        {
+            "url": "https://github.com/pixee/python-security/blob/main/src/security/safe_command/api.py",
+            "description": "",
+        },
+        {
+            "url": "https://cheatsheetseries.owasp.org/cheatsheets/OS_Command_Injection_Defense_Cheat_Sheet.html",
+            "description": "",
+        },
+    ]
 
     @classmethod
     def rule(cls):

--- a/src/core_codemods/process_creation_sandbox.py
+++ b/src/core_codemods/process_creation_sandbox.py
@@ -5,7 +5,7 @@ from codemodder.codemods.api import SemgrepCodemod
 
 class ProcessSandbox(SemgrepCodemod):
     NAME = "sandbox-process-creation"
-    REVIEW_GUIDANCE = ReviewGuidance.MERGE_WITHOUT_REVIEW
+    REVIEW_GUIDANCE = ReviewGuidance.MERGE_AFTER_CURSORY_REVIEW
     SUMMARY = "Sandbox Process Creation"
     DESCRIPTION = (
         "Replaces subprocess.{func} with more secure safe_command library functions."

--- a/src/core_codemods/process_creation_sandbox.py
+++ b/src/core_codemods/process_creation_sandbox.py
@@ -5,7 +5,7 @@ from codemodder.codemods.api import SemgrepCodemod
 
 class ProcessSandbox(SemgrepCodemod):
     NAME = "sandbox-process-creation"
-    REVIEW_GUIDANCE = ReviewGuidance.MERGE_AFTER_CURSORY_REVIEW
+    REVIEW_GUIDANCE = ReviewGuidance.MERGE_WITHOUT_REVIEW
     SUMMARY = "Sandbox Process Creation"
     DESCRIPTION = (
         "Replaces subprocess.{func} with more secure safe_command library functions."

--- a/src/core_codemods/process_creation_sandbox.py
+++ b/src/core_codemods/process_creation_sandbox.py
@@ -6,7 +6,7 @@ from codemodder.codemods.api import SemgrepCodemod
 class ProcessSandbox(SemgrepCodemod):
     NAME = "sandbox-process-creation"
     REVIEW_GUIDANCE = ReviewGuidance.MERGE_AFTER_CURSORY_REVIEW
-    SUMMARY = "Sandbox process creation"
+    SUMMARY = "Sandbox Process Creation"
     DESCRIPTION = (
         "Replaces subprocess.{func} with more secure safe_command library functions."
     )

--- a/src/core_codemods/remove_unnecessary_f_str.py
+++ b/src/core_codemods/remove_unnecessary_f_str.py
@@ -11,7 +11,7 @@ from codemodder.codemods.api import BaseCodemod
 class RemoveUnnecessaryFStr(BaseCodemod, UnnecessaryFormatString):
     NAME = "remove-unnecessary-f-str"
     REVIEW_GUIDANCE = ReviewGuidance.MERGE_WITHOUT_REVIEW
-    SUMMARY = "Remove unnecessary f-strings"
+    SUMMARY = "Remove Unnecessary F-strings"
     DESCRIPTION = UnnecessaryFormatString.DESCRIPTION
     REFERENCES = [
         {

--- a/src/core_codemods/remove_unnecessary_f_str.py
+++ b/src/core_codemods/remove_unnecessary_f_str.py
@@ -13,6 +13,12 @@ class RemoveUnnecessaryFStr(BaseCodemod, UnnecessaryFormatString):
     REVIEW_GUIDANCE = ReviewGuidance.MERGE_WITHOUT_REVIEW
     SUMMARY = "Remove unnecessary f-strings"
     DESCRIPTION = UnnecessaryFormatString.DESCRIPTION
+    REFERENCES = [
+        {
+            "url": "https://github.com/Instagram/LibCST/blob/main/libcst/codemod/commands/unnecessary_format_string.py",
+            "description": "",
+        }
+    ]
 
     def __init__(self, codemod_context: CodemodContext, *codemod_args):
         UnnecessaryFormatString.__init__(self, codemod_context)

--- a/src/core_codemods/remove_unused_imports.py
+++ b/src/core_codemods/remove_unused_imports.py
@@ -28,6 +28,7 @@ class RemoveUnusedImports(BaseCodemod, Codemod):
         DESCRIPTION=("Remove unused imports from a module."),
         NAME="unused-imports",
         REVIEW_GUIDANCE=ReviewGuidance.MERGE_WITHOUT_REVIEW,
+        REFERENCES=[],
     )
     SUMMARY = "Remove unused imports from a module"
     CHANGE_DESCRIPTION = "Unused import."

--- a/src/core_codemods/remove_unused_imports.py
+++ b/src/core_codemods/remove_unused_imports.py
@@ -30,7 +30,7 @@ class RemoveUnusedImports(BaseCodemod, Codemod):
         REVIEW_GUIDANCE=ReviewGuidance.MERGE_WITHOUT_REVIEW,
         REFERENCES=[],
     )
-    SUMMARY = "Remove unused imports from a module"
+    SUMMARY = "Remove Unused Imports"
     CHANGE_DESCRIPTION = "Unused import."
 
     METADATA_DEPENDENCIES = (

--- a/src/core_codemods/requests_verify.py
+++ b/src/core_codemods/requests_verify.py
@@ -10,6 +10,13 @@ class RequestsVerify(SemgrepCodemod):
     DESCRIPTION = (
         "Makes any calls to requests.{func} with `verify=False` to `verify=True`"
     )
+    REFERENCES = [
+        {"url": "https://requests.readthedocs.io/en/latest/api/", "description": ""},
+        {
+            "url": "https://owasp.org/www-community/attacks/Manipulator-in-the-middle_attack",
+            "description": "",
+        },
+    ]
 
     @classmethod
     def rule(cls):

--- a/src/core_codemods/requests_verify.py
+++ b/src/core_codemods/requests_verify.py
@@ -6,7 +6,7 @@ from codemodder.codemods.api.helpers import NewArg
 class RequestsVerify(SemgrepCodemod):
     NAME = "requests-verify"
     REVIEW_GUIDANCE = ReviewGuidance.MERGE_AFTER_CURSORY_REVIEW
-    SUMMARY = "Verify SSL certificates when making requests."
+    SUMMARY = "Verify SSL Certificates for Requests."
     DESCRIPTION = (
         "Makes any calls to requests.{func} with `verify=False` to `verify=True`"
     )

--- a/src/core_codemods/requests_verify.py
+++ b/src/core_codemods/requests_verify.py
@@ -8,7 +8,7 @@ class RequestsVerify(SemgrepCodemod):
     REVIEW_GUIDANCE = ReviewGuidance.MERGE_AFTER_CURSORY_REVIEW
     SUMMARY = "Verify SSL Certificates for Requests."
     DESCRIPTION = (
-        "Makes any calls to requests.{func} with `verify=False` to `verify=True`"
+        "Makes any calls to requests.{func} with `verify=False` to `verify=True`."
     )
     REFERENCES = [
         {"url": "https://requests.readthedocs.io/en/latest/api/", "description": ""},

--- a/src/core_codemods/secure_random.py
+++ b/src/core_codemods/secure_random.py
@@ -7,6 +7,13 @@ class SecureRandom(SemgrepCodemod):
     REVIEW_GUIDANCE = ReviewGuidance.MERGE_WITHOUT_REVIEW
     SUMMARY = "Use secrets.SystemRandom() instead of random"
     DESCRIPTION = "Replaces random.{func} with more secure secrets library functions."
+    REFERENCES = [
+        {
+            "url": "https://owasp.org/www-community/vulnerabilities/Insecure_Randomness",
+            "description": "",
+        },
+        {"url": "https://docs.python.org/3/library/random.html", "description": ""},
+    ]
 
     @classmethod
     def rule(cls):

--- a/src/core_codemods/secure_random.py
+++ b/src/core_codemods/secure_random.py
@@ -5,7 +5,7 @@ from codemodder.codemods.api import SemgrepCodemod
 class SecureRandom(SemgrepCodemod):
     NAME = "secure-random"
     REVIEW_GUIDANCE = ReviewGuidance.MERGE_WITHOUT_REVIEW
-    SUMMARY = "Use secrets.SystemRandom() instead of random"
+    SUMMARY = "Secure Source of Randomness"
     DESCRIPTION = "Replaces random.{func} with more secure secrets library functions."
     REFERENCES = [
         {

--- a/src/core_codemods/secure_random.py
+++ b/src/core_codemods/secure_random.py
@@ -4,7 +4,7 @@ from codemodder.codemods.api import SemgrepCodemod
 
 class SecureRandom(SemgrepCodemod):
     NAME = "secure-random"
-    REVIEW_GUIDANCE = ReviewGuidance.MERGE_WITHOUT_REVIEW
+    REVIEW_GUIDANCE = ReviewGuidance.MERGE_AFTER_CURSORY_REVIEW
     SUMMARY = "Secure Source of Randomness"
     DESCRIPTION = "Replaces random.{func} with more secure secrets library functions."
     REFERENCES = [

--- a/src/core_codemods/tempfile_mktemp.py
+++ b/src/core_codemods/tempfile_mktemp.py
@@ -5,7 +5,7 @@ from codemodder.codemods.api import SemgrepCodemod
 class TempfileMktemp(SemgrepCodemod):
     NAME = "secure-tempfile"
     REVIEW_GUIDANCE = ReviewGuidance.MERGE_WITHOUT_REVIEW
-    SUMMARY = "Use `tempfile.mkstemp` instead of `tempfile.mktemp`"
+    SUMMARY = "Upgrade and Secure Temp File Creation"
     DESCRIPTION = "Replaces `tempfile.mktemp` with `tempfile.mkstemp`."
     REFERENCES = [
         {

--- a/src/core_codemods/tempfile_mktemp.py
+++ b/src/core_codemods/tempfile_mktemp.py
@@ -7,6 +7,12 @@ class TempfileMktemp(SemgrepCodemod):
     REVIEW_GUIDANCE = ReviewGuidance.MERGE_WITHOUT_REVIEW
     SUMMARY = "Use `tempfile.mkstemp` instead of `tempfile.mktemp`"
     DESCRIPTION = "Replaces `tempfile.mktemp` with `tempfile.mkstemp`."
+    REFERENCES = [
+        {
+            "url": "https://docs.python.org/3/library/tempfile.html#tempfile.mktemp",
+            "description": "",
+        }
+    ]
 
     @classmethod
     def rule(cls):

--- a/src/core_codemods/upgrade_sslcontext_minimum_version.py
+++ b/src/core_codemods/upgrade_sslcontext_minimum_version.py
@@ -5,7 +5,7 @@ from codemodder.codemods.api import SemgrepCodemod
 class UpgradeSSLContextMinimumVersion(SemgrepCodemod):
     NAME = "upgrade-sslcontext-minimum-version"
     REVIEW_GUIDANCE = ReviewGuidance.MERGE_WITHOUT_REVIEW
-    SUMMARY = "Upgrade minimum SSL/TLS version for SSLContext"
+    SUMMARY = "Upgrade SSLContext Minimum Version"
     DESCRIPTION = "Replaces minimum SSL/TLS version for SSLContext"
     REFERENCES = [
         {

--- a/src/core_codemods/upgrade_sslcontext_minimum_version.py
+++ b/src/core_codemods/upgrade_sslcontext_minimum_version.py
@@ -6,7 +6,7 @@ class UpgradeSSLContextMinimumVersion(SemgrepCodemod):
     NAME = "upgrade-sslcontext-minimum-version"
     REVIEW_GUIDANCE = ReviewGuidance.MERGE_WITHOUT_REVIEW
     SUMMARY = "Upgrade SSLContext Minimum Version"
-    DESCRIPTION = "Replaces minimum SSL/TLS version for SSLContext"
+    DESCRIPTION = "Replaces minimum SSL/TLS version for SSLContext."
     REFERENCES = [
         {
             "url": "https://docs.python.org/3/library/ssl.html#security-considerations",

--- a/src/core_codemods/upgrade_sslcontext_minimum_version.py
+++ b/src/core_codemods/upgrade_sslcontext_minimum_version.py
@@ -7,6 +7,17 @@ class UpgradeSSLContextMinimumVersion(SemgrepCodemod):
     REVIEW_GUIDANCE = ReviewGuidance.MERGE_WITHOUT_REVIEW
     SUMMARY = "Upgrade minimum SSL/TLS version for SSLContext"
     DESCRIPTION = "Replaces minimum SSL/TLS version for SSLContext"
+    REFERENCES = [
+        {
+            "url": "https://docs.python.org/3/library/ssl.html#security-considerations",
+            "description": "",
+        },
+        {"url": "https://datatracker.ietf.org/doc/rfc8996/", "description": ""},
+        {
+            "url": "https://www.digicert.com/blog/depreciating-tls-1-0-and-1-1",
+            "description": "",
+        },
+    ]
 
     @classmethod
     def rule(cls):

--- a/src/core_codemods/upgrade_sslcontext_tls.py
+++ b/src/core_codemods/upgrade_sslcontext_tls.py
@@ -16,6 +16,17 @@ class UpgradeSSLContextTLS(SemgrepCodemod, BaseTransformer):
         DESCRIPTION="Replaces known insecure TLS/SSL protocol versions in SSLContext with secure ones",
         NAME="upgrade-sslcontext-tls",
         REVIEW_GUIDANCE=ReviewGuidance.MERGE_AFTER_CURSORY_REVIEW,
+        REFERENCES=[
+            {
+                "url": "https://docs.python.org/3/library/ssl.html#security-considerations",
+                "description": "",
+            },
+            {"url": "https://datatracker.ietf.org/doc/rfc8996/", "description": ""},
+            {
+                "url": "https://www.digicert.com/blog/depreciating-tls-1-0-and-1-1",
+                "description": "",
+            },
+        ],
     )
     SUMMARY = "Replace known insecure TLS/SSL protocol versions in SSLContext with secure ones"
     CHANGE_DESCRIPTION = "Upgrade to use a safe version of TLS in SSLContext"

--- a/src/core_codemods/upgrade_sslcontext_tls.py
+++ b/src/core_codemods/upgrade_sslcontext_tls.py
@@ -28,7 +28,7 @@ class UpgradeSSLContextTLS(SemgrepCodemod, BaseTransformer):
             },
         ],
     )
-    SUMMARY = "Replace known insecure TLS/SSL protocol versions in SSLContext with secure ones"
+    SUMMARY = "Upgrade TLS Version In SSLContext"
     CHANGE_DESCRIPTION = "Upgrade to use a safe version of TLS in SSLContext"
     YAML_FILES = [
         "upgrade_sslcontext_tls.yaml",

--- a/src/core_codemods/upgrade_sslcontext_tls.py
+++ b/src/core_codemods/upgrade_sslcontext_tls.py
@@ -13,7 +13,7 @@ from codemodder.file_context import FileContext
 
 class UpgradeSSLContextTLS(SemgrepCodemod, BaseTransformer):
     METADATA = CodemodMetadata(
-        DESCRIPTION="Replaces known insecure TLS/SSL protocol versions in SSLContext with secure ones",
+        DESCRIPTION="Replaces known insecure TLS/SSL protocol versions in SSLContext with secure ones.",
         NAME="upgrade-sslcontext-tls",
         REVIEW_GUIDANCE=ReviewGuidance.MERGE_AFTER_CURSORY_REVIEW,
         REFERENCES=[

--- a/src/core_codemods/url_sandbox.py
+++ b/src/core_codemods/url_sandbox.py
@@ -49,7 +49,7 @@ class UrlSandbox(SemgrepCodemod, Codemod):
             },
         ],
     )
-    SUMMARY = "Ensure that requests are made safely."
+    SUMMARY = "Sandbox URL Creation"
     CHANGE_DESCRIPTION = "Switch use of requests for security.safe_requests"
     YAML_FILES = [
         "sandbox_url_creation.yaml",

--- a/src/core_codemods/url_sandbox.py
+++ b/src/core_codemods/url_sandbox.py
@@ -29,6 +29,25 @@ class UrlSandbox(SemgrepCodemod, Codemod):
         ),
         NAME="url-sandbox",
         REVIEW_GUIDANCE=ReviewGuidance.MERGE_AFTER_CURSORY_REVIEW,
+        REFERENCES=[
+            {
+                "url": "https://github.com/pixee/python-security/blob/main/src/security/safe_requests/api.py",
+                "description": "",
+            },
+            {"url": "https://portswigger.net/web-security/ssrf", "description": ""},
+            {
+                "url": "https://cheatsheetseries.owasp.org/cheatsheets/Server_Side_Request_Forgery_Prevention_Cheat_Sheet.html",
+                "description": "",
+            },
+            {
+                "url": "https://www.rapid7.com/blog/post/2021/11/23/owasp-top-10-deep-dive-defending-against-server-side-request-forgery/",
+                "description": "",
+            },
+            {
+                "url": "https://blog.assetnote.io/2021/01/13/blind-ssrf-chains/",
+                "description": "",
+            },
+        ],
     )
     SUMMARY = "Ensure that requests are made safely."
     CHANGE_DESCRIPTION = "Switch use of requests for security.safe_requests"

--- a/src/core_codemods/use_walrus_if.py
+++ b/src/core_codemods/use_walrus_if.py
@@ -15,7 +15,7 @@ class UseWalrusIf(SemgrepCodemod):
         ScopeProvider,
     )
     NAME = "use-walrus-if"
-    SUMMARY = "Use Assignment Expression in Conditional"
+    SUMMARY = "Use Assignment Expression (Walrus) In Conditional"
     REVIEW_GUIDANCE = ReviewGuidance.MERGE_AFTER_CURSORY_REVIEW
     DESCRIPTION = (
         "Replaces multiple expressions involving `if` operator with 'walrus' operator"

--- a/src/core_codemods/use_walrus_if.py
+++ b/src/core_codemods/use_walrus_if.py
@@ -18,7 +18,7 @@ class UseWalrusIf(SemgrepCodemod):
     SUMMARY = "Use Assignment Expression (Walrus) In Conditional"
     REVIEW_GUIDANCE = ReviewGuidance.MERGE_AFTER_CURSORY_REVIEW
     DESCRIPTION = (
-        "Replaces multiple expressions involving `if` operator with 'walrus' operator"
+        "Replaces multiple expressions involving `if` operator with 'walrus' operator."
     )
     REFERENCES = [
         {

--- a/src/core_codemods/use_walrus_if.py
+++ b/src/core_codemods/use_walrus_if.py
@@ -20,6 +20,12 @@ class UseWalrusIf(SemgrepCodemod):
     DESCRIPTION = (
         "Replaces multiple expressions involving `if` operator with 'walrus' operator"
     )
+    REFERENCES = [
+        {
+            "url": "https://docs.python.org/3/whatsnew/3.8.html#assignment-expressions",
+            "description": "",
+        }
+    ]
 
     @classmethod
     def rule(cls):

--- a/src/core_codemods/with_threading_lock.py
+++ b/src/core_codemods/with_threading_lock.py
@@ -6,7 +6,9 @@ from codemodder.codemods.api import SemgrepCodemod
 class WithThreadingLock(SemgrepCodemod):
     NAME = "bad-lock-with-statement"
     SUMMARY = "Separate Lock Instantiation from `with` Call"
-    DESCRIPTION = "Replace deprecated usage of threading lock classes as context managers."
+    DESCRIPTION = (
+        "Replace deprecated usage of threading lock classes as context managers."
+    )
     REVIEW_GUIDANCE = ReviewGuidance.MERGE_AFTER_CURSORY_REVIEW
     REFERENCES = [
         {

--- a/src/core_codemods/with_threading_lock.py
+++ b/src/core_codemods/with_threading_lock.py
@@ -5,9 +5,9 @@ from codemodder.codemods.api import SemgrepCodemod
 
 class WithThreadingLock(SemgrepCodemod):
     NAME = "bad-lock-with-statement"
-    SUMMARY = "Replace deprecated usage of threading lock classes as context managers"
+    SUMMARY = "Separate Lock Instantiation from `with` Call"
+    DESCRIPTION = "Replace deprecated usage of threading lock classes as context managers."
     REVIEW_GUIDANCE = ReviewGuidance.MERGE_AFTER_CURSORY_REVIEW
-    DESCRIPTION = "Separates threading lock instantiation and call with `with` statement into two steps."
     REFERENCES = [
         {
             "url": "https://pylint.pycqa.org/en/latest/user_guide/messages/warning/useless-with-lock.",

--- a/src/core_codemods/with_threading_lock.py
+++ b/src/core_codemods/with_threading_lock.py
@@ -8,6 +8,16 @@ class WithThreadingLock(SemgrepCodemod):
     SUMMARY = "Replace deprecated usage of threading lock classes as context managers"
     REVIEW_GUIDANCE = ReviewGuidance.MERGE_AFTER_CURSORY_REVIEW
     DESCRIPTION = "Separates threading lock instantiation and call with `with` statement into two steps."
+    REFERENCES = [
+        {
+            "url": "https://pylint.pycqa.org/en/latest/user_guide/messages/warning/useless-with-lock.",
+            "description": "",
+        },
+        {
+            "url": "https://docs.python.org/3/library/threading.html#using-locks-conditions-and-semaphores-in-the-with-statement",
+            "description": "",
+        },
+    ]
 
     @classmethod
     def rule(cls):

--- a/src/scripts/generate_docs.py
+++ b/src/scripts/generate_docs.py
@@ -44,7 +44,8 @@ METADATA = {
         guidance_explained="Support for HTTPS is widespread which, save in some legacy applications, makes this change safe.",
     ),
     "jwt-decode-verify": DocMetadata(
-        importance="SOMETHING", guidance_explained="SOMETHING"
+        importance="High",
+        guidance_explained="This codemod ensures your code uses all available validations when calling `jwt.decode`. We believe this replacement is safe and should not result in any issues.",
     ),
     "limit-readline": DocMetadata(
         importance="Medium",
@@ -58,10 +59,10 @@ METADATA = {
         importance="High",
         guidance_explained="We believe this change is safe, effective, and protects your code against very serious security attacks.",
     ),
-    # "order-imports": DocMetadata(
-    #     importance="Low",
-    #     guidance_explained="",
-    # ),
+    "order-imports": DocMetadata(
+        importance="Low",
+        guidance_explained="TODO SKIP FOR NOW",
+    ),
     "sandbox-process-creation": DocMetadata(
         importance="High",
         guidance_explained="We believe this change is safe and effective. The behavior of sandboxing `subprocess.run` and `subprocess.call` calls will only throw `SecurityException` if they see behavior involved in malicious code execution, which is extremely unlikely to happen in normal operation.",
@@ -87,7 +88,8 @@ METADATA = {
         guidance_explained="We believe this codemod is safe and will cause no unexpected errors.",
     ),
     "upgrade-sslcontext-minimum-version": DocMetadata(
-        importance="SOMETHING", guidance_explained="SOMETHING"
+        importance="High",
+        guidance_explained="This codemod updates the minimum supported version of TLS. Since this is an important security fix and since all modern servers offer TLSv1.2, we believe this change can be safely merged without review.",
     ),
     "upgrade-sslcontext-tls": DocMetadata(
         importance="High",
@@ -112,9 +114,9 @@ If you want to allow those protocols, change the incoming PR to look more like t
         importance="Low",
         guidance_explained="We believe that using the walrus operator is an improvement in terms of clarity and readability. However, this change is only compatible with codebases that support Python 3.8 and later, so it requires quick validation before merging.",
     ),
-    # "bad-lock-with-statement": DocMetadata(
-    #     importance="Low", guidance_explained="TODO AFTER PR MERGE"
-    # ),
+    "bad-lock-with-statement": DocMetadata(
+        importance="Low", guidance_explained="TODO AFTER PR MERGE"
+    ),
 }
 
 
@@ -124,6 +126,11 @@ def generate_docs(codemod):
     except KeyError as exc:
         raise KeyError(f"Must add {codemod.name} to METADATA") from exc
 
+    formatted_references = [
+        f"* [{ref['description']}]({ref['url']})" for ref in codemod.references
+    ]
+    markdown_references = "\n".join(formatted_references) or "N/A"
+
     output = f"""---
 title: {codemod.summary}
 sidebar_position: 1
@@ -131,12 +138,11 @@ sidebar_position: 1
 
 ## {codemod.id}
 
-| Importance | Review Guidance      | Requires SARIF Tool |
-|------------|----------------------|---------------------|
- | {codemod_data.importance}       | {codemod.review_guidance} | {codemod_data.need_sarif}                  |
+| Importance | Review Guidance            | Requires SARIF Tool |
+|------------|----------------------------|---------------------|
+| {codemod_data.importance}       | {codemod.review_guidance} | {codemod_data.need_sarif}                  |
 
 {codemod.description}
-
 If you have feedback on this codemod, [please let us know](mailto:feedback@pixee.ai)!
 
 ## F.A.Q.
@@ -150,10 +156,8 @@ If you have feedback on this codemod, [please let us know](mailto:feedback@pixee
 N/A
 
 ## References
-* [https://lxml.de/apidoc/lxml.etree.html#lxml.etree.XMLParser](https://lxml.de/apidoc/lxml.etree.html#lxml.etree.XMLParser)
-* [https://owasp.org/www-community/vulnerabilities/XML_External_Entity_(XXE)_Processing](https://owasp.org/www-community/vulnerabilities/XML_External_Entity_(XXE)_Processing)
-* [https://cheatsheetseries.owasp.org/cheatsheets/XML_External_Entity_Prevention_Cheat_Sheet.html](https://cheatsheetseries.owasp.org/cheatsheets/XML_External_Entity_Prevention_Cheat_Sheet.html)
-#codemod.references
+
+{markdown_references}
 """
     return output
 

--- a/src/scripts/generate_docs.py
+++ b/src/scripts/generate_docs.py
@@ -1,0 +1,51 @@
+from codemodder.registry import load_registered_codemods
+
+def generate_docs(codemod):
+    breakpoint()
+    output = f"""
+---
+title: Safe lxml Parsing
+sidebar_position: 1
+---
+
+## {codemod.id}
+
+| Importance | Review Guidance      | Requires SARIF Tool |
+|------------|----------------------|---------------------|
+ | High       | Merge Without Review | No                  |
+
+This codemod sets the `parser` parameter in calls to  `lxml.etree.parse`  and `lxml.etree.fromstring`
+if omitted or set to `None` (the default value). Unfortunately, the default `parser=None` means `lxml`
+will rely on an unsafe parser, making your code potentially vulnerable to entity expansion
+attacks and external entity (XXE) attacks.
+
+The changes look as follows:
+
+```diff
+  import lxml.etree
+- lxml.etree.parse("path_to_file")
+- lxml.etree.fromstring("xml_str")
++ lxml.etree.parse("path_to_file", parser=lxml.etree.XMLParser(resolve_entities=False))
++ lxml.etree.fromstring("xml_str", parser=lxml.etree.XMLParser(resolve_entities=False))
+```
+
+If you have feedback on this codemod, [please let us know](mailto:feedback@pixee.ai)!
+
+## F.A.Q. 
+
+### Why is this codemod marked as Merge Without Review?
+
+We believe this change is safe, effective, and protects your code against very serious security attacks.
+
+## References
+* [https://lxml.de/apidoc/lxml.etree.html#lxml.etree.XMLParser](https://lxml.de/apidoc/lxml.etree.html#lxml.etree.XMLParser)
+* [https://owasp.org/www-community/vulnerabilities/XML_External_Entity_(XXE)_Processing](https://owasp.org/www-community/vulnerabilities/XML_External_Entity_(XXE)_Processing)
+* [https://cheatsheetseries.owasp.org/cheatsheets/XML_External_Entity_Prevention_Cheat_Sheet.html](https://cheatsheetseries.owasp.org/cheatsheets/XML_External_Entity_Prevention_Cheat_Sheet.html)    
+"""
+    codemod._get_description()
+
+def main():
+    # todo: get dir path
+    registry = load_registered_codemods()
+    for codemod in registry.codemods:
+        generate_docs(codemod)

--- a/src/scripts/generate_docs.py
+++ b/src/scripts/generate_docs.py
@@ -1,10 +1,131 @@
+import argparse
+from dataclasses import dataclass
 from codemodder.registry import load_registered_codemods
+from pathlib import Path
+
+
+@dataclass
+class DocMetadata:
+    """Codemod specific metadata only for documentation"""
+
+    importance: str
+    guidance_explained: str
+    need_sarif: str = "No"
+
+
+# codemod-specific metadata that's used only for docs, not for codemod API
+METADATA = {
+    "django-debug-flag-on": DocMetadata(
+        importance="Medium",
+        guidance_explained="Django's `DEBUG` flag may be overridden somewhere else or the runtime settings file may be set with the `DJANGO_SETTINGS_MODULE` environment variable. This means that the `DEBUG` flag may intentionally be left on as a development aid.",
+    ),
+    "django-session-cookie-secure-off": DocMetadata(
+        importance="Medium",
+        guidance_explained="Django's `SESSION_COOKIE_SECURE` flag may be overridden somewhere else or the runtime settings file may be set with the `DJANGO_SETTINGS_MODULE` environment variable. This means that the flag may intentionally be left off or missing. Also some applications may still want to support pure http. This is often the case for legacy apps.",
+    ),
+    "enable-jinja2-autoescape": DocMetadata(
+        importance="High",
+        guidance_explained="This codemod protects your applications against XSS attacks. We believe using the default behavior is unsafe.",
+    ),
+    "fix-mutable-params": DocMetadata(
+        importance="Medium",
+        guidance_explained="We believe that this codemod fixes an unsafe practice and that the changes themselves are safe and reliable.",
+    ),
+    "harden-pyyaml": DocMetadata(
+        importance="Medium",
+        guidance_explained="This codemod replaces any unsafe loaders with the `SafeLoader`, which is already the recommended replacement suggested in `yaml` documentation. We believe this replacement is safe and should not result in any issues.",
+    ),
+    "harden-ruamel": DocMetadata(
+        importance="Medium",
+        guidance_explained="This codemod replaces any unsafe `typ` argument with `typ='safe'`, which makes safety explicit and is one of the recommended uses suggested in `ruamel` documentation. We believe this replacement is safe and should not result in any issues.",
+    ),
+    "https-connection": DocMetadata(
+        importance="High",
+        guidance_explained="Support for HTTPS is widespread which, save in some legacy applications, makes this change safe.",
+    ),
+    "jwt-decode-verify": DocMetadata(
+        importance="SOMETHING", guidance_explained="SOMETHING"
+    ),
+    "limit-readline": DocMetadata(
+        importance="Medium",
+        guidance_explained="This codemod sets a maximum of 5MB allowed per line read by default. It is unlikely but possible that your code may receive lines that are greater than 5MB _and_ you'd still be interested in reading them, so there is some nominal risk of exceptional cases.",
+    ),
+    "safe-lxml-parser-defaults": DocMetadata(
+        importance="High",
+        guidance_explained="We believe this change is safe, effective, and protects your code against very serious security attacks.",
+    ),
+    "safe-lxml-parsing": DocMetadata(
+        importance="High",
+        guidance_explained="We believe this change is safe, effective, and protects your code against very serious security attacks.",
+    ),
+    "order-imports": DocMetadata(
+        importance="Low",
+        guidance_explained="We believe this codemod is safe and will not cause any issues. It is important to note that importing modules may have side-effects that alter the behavior, even if unused, but we believe those cases are rare enough to be safe.",
+    ),
+    "sandbox-process-creation": DocMetadata(
+        importance="High",
+        guidance_explained="We believe this change is safe and effective. The behavior of sandboxing `subprocess.run` and `subprocess.call` calls will only throw `SecurityException` if they see behavior involved in malicious code execution, which is extremely unlikely to happen in normal operation.",
+    ),
+    "remove-unnecessary-f-str": DocMetadata(
+        importance="Low",
+        guidance_explained="We believe this codemod is safe and will not cause any issues.",
+    ),
+    "unused-imports": DocMetadata(
+        importance="Low",
+        guidance_explained="We believe this codemod is safe and will not cause any issues. It is important to note that importing modules may have side-effects that alter the behavior, even if unused, but we believe those cases are rare enough to be safe.",
+    ),
+    "requests-verify": DocMetadata(
+        importance="High",
+        guidance_explained="There may be times when setting `verify=False` is useful for testing though we discourage it. \nYou may also decide to set `verify=/path/to/ca/bundle`. This codemod will not attempt to modify the `verify` value if you do set it to a path.",
+    ),
+    "secure-random": DocMetadata(
+        importance="High",
+        guidance_explained="While most of the functions in the `random` module aren't cryptographically secure, there are still valid use cases for `random.random()` such as for simulations or games.",
+    ),
+    "secure-tempfile": DocMetadata(
+        importance="High",
+        guidance_explained="We believe this codemod is safe and will cause no unexpected errors.",
+    ),
+    "upgrade-sslcontext-minimum-version": DocMetadata(
+        importance="SOMETHING", guidance_explained="SOMETHING"
+    ),
+    "upgrade-sslcontext-tls": DocMetadata(
+        importance="High",
+        guidance_explained="This codemod updates the minimum supported version of TLS. Since this is an important security fix and since all modern servers offer TLSv1.2, we believe this change can be safely merged without review.",
+    ),
+    "url-sandbox": DocMetadata(
+        importance="High",
+        guidance_explained="""By default, the protection only weaves in 2 checks, which we believe will not cause any issues with the vast majority of code:
+1. The given URL must be HTTP/HTTPS.
+2. The given URL must not point to a "well-known infrastructure target", which includes things like AWS Metadata Service endpoints, and internal routers (e.g., 192.168.1.1) which are common targets of attacks.
+
+However, on rare occasions an application may use a URL protocol like "file://" or "ftp://" in backend or middleware code.
+
+If you want to allow those protocols, change the incoming PR to look more like this and get the best security possible:
+
+```diff
+-resp = requests.get(url)
++resp = safe_requests.get.get(url, allowed_protocols=("ftp",))
+```""",
+    ),
+    "use-walrus-if": DocMetadata(
+        importance="Low",
+        guidance_explained="We believe that using the walrus operator is an improvement in terms of clarity and readability. However, this change is only compatible with codebases that support Python 3.8 and later, so it requires quick validation before merging.",
+    ),
+    # "bad-lock-with-statement": DocMetadata(
+    #     importance="Low", guidance_explained="TODO AFTER PR MERGE"
+    # ),
+}
+
 
 def generate_docs(codemod):
-    breakpoint()
-    output = f"""
----
-title: Safe lxml Parsing
+    try:
+        codemod_data = METADATA[codemod.name]
+    except KeyError as exc:
+        raise KeyError(f"Must add {codemod.name} to METADATA") from exc
+
+    output = f"""---
+title: {codemod.summary}
 sidebar_position: 1
 ---
 
@@ -12,40 +133,45 @@ sidebar_position: 1
 
 | Importance | Review Guidance      | Requires SARIF Tool |
 |------------|----------------------|---------------------|
- | High       | Merge Without Review | No                  |
+ | {codemod_data.importance}       | {codemod.review_guidance} | {codemod_data.need_sarif}                  |
 
-This codemod sets the `parser` parameter in calls to  `lxml.etree.parse`  and `lxml.etree.fromstring`
-if omitted or set to `None` (the default value). Unfortunately, the default `parser=None` means `lxml`
-will rely on an unsafe parser, making your code potentially vulnerable to entity expansion
-attacks and external entity (XXE) attacks.
-
-The changes look as follows:
-
-```diff
-  import lxml.etree
-- lxml.etree.parse("path_to_file")
-- lxml.etree.fromstring("xml_str")
-+ lxml.etree.parse("path_to_file", parser=lxml.etree.XMLParser(resolve_entities=False))
-+ lxml.etree.fromstring("xml_str", parser=lxml.etree.XMLParser(resolve_entities=False))
-```
+{codemod.description}
 
 If you have feedback on this codemod, [please let us know](mailto:feedback@pixee.ai)!
 
-## F.A.Q. 
+## F.A.Q.
 
-### Why is this codemod marked as Merge Without Review?
+### Why is this codemod marked as {codemod.review_guidance}?
 
-We believe this change is safe, effective, and protects your code against very serious security attacks.
+{codemod_data.guidance_explained}
+
+## Codemod Settings
+
+N/A
 
 ## References
 * [https://lxml.de/apidoc/lxml.etree.html#lxml.etree.XMLParser](https://lxml.de/apidoc/lxml.etree.html#lxml.etree.XMLParser)
 * [https://owasp.org/www-community/vulnerabilities/XML_External_Entity_(XXE)_Processing](https://owasp.org/www-community/vulnerabilities/XML_External_Entity_(XXE)_Processing)
-* [https://cheatsheetseries.owasp.org/cheatsheets/XML_External_Entity_Prevention_Cheat_Sheet.html](https://cheatsheetseries.owasp.org/cheatsheets/XML_External_Entity_Prevention_Cheat_Sheet.html)    
+* [https://cheatsheetseries.owasp.org/cheatsheets/XML_External_Entity_Prevention_Cheat_Sheet.html](https://cheatsheetseries.owasp.org/cheatsheets/XML_External_Entity_Prevention_Cheat_Sheet.html)
+#codemod.references
 """
-    codemod._get_description()
+    return output
+
 
 def main():
-    # todo: get dir path
+    parser = argparse.ArgumentParser(
+        description="Generate public docs for registered codemods."
+    )
+
+    parser.add_argument(
+        "directory", type=str, help="directory path where to create doc files"
+    )
+    argv = parser.parse_args()
+    parent_dir = Path(argv.directory)
+
     registry = load_registered_codemods()
     for codemod in registry.codemods:
-        generate_docs(codemod)
+        doc = generate_docs(codemod)
+        codemod_doc_name = f"{codemod.id.replace(':', '_').replace('/', '_')}.md"
+        with open(parent_dir / codemod_doc_name, "w", encoding="utf-8") as f:
+            f.write(doc)

--- a/src/scripts/generate_docs.py
+++ b/src/scripts/generate_docs.py
@@ -58,10 +58,10 @@ METADATA = {
         importance="High",
         guidance_explained="We believe this change is safe, effective, and protects your code against very serious security attacks.",
     ),
-    "order-imports": DocMetadata(
-        importance="Low",
-        guidance_explained="We believe this codemod is safe and will not cause any issues. It is important to note that importing modules may have side-effects that alter the behavior, even if unused, but we believe those cases are rare enough to be safe.",
-    ),
+    # "order-imports": DocMetadata(
+    #     importance="Low",
+    #     guidance_explained="",
+    # ),
     "sandbox-process-creation": DocMetadata(
         importance="High",
         guidance_explained="We believe this change is safe and effective. The behavior of sandboxing `subprocess.run` and `subprocess.call` calls will only throw `SecurityException` if they see behavior involved in malicious code execution, which is extremely unlikely to happen in normal operation.",

--- a/tests/test_codemod_docs.py
+++ b/tests/test_codemod_docs.py
@@ -9,7 +9,12 @@ def pytest_generate_tests(metafunc):
         metafunc.parametrize("codemod", registry.codemods)
 
 
-def test_load_codemod_description(codemod):
+def test_load_codemod_docs_info(codemod):
     if codemod.name in ["order-imports"]:
         pytest.xfail(reason="order-imports has no description")
     assert codemod._get_description() is not None  # pylint: disable=protected-access
+    assert codemod.review_guidance in (
+        "Merge After Review",
+        "Merge After Cursory Review",
+        "Merge Without Review",
+    )


### PR DESCRIPTION
## Overview
*Create a script that will automatically create docs for each codemod.*

## Description
- the new script can now be run with `generate-docs ~/docs/docs/codemods/python/` Where the argument is a path to a dir, such as our docs repo. 
- With this output, I created [this PR](https://github.com/pixee/docs/pull/92) which should be reviewed in parallel
- I also added the references field to all codemods and added references for all codemods by copying the urls already listed in each codemod doc. For now the description is just the url but there is a task to come back and actually write descriptions
- With the script running I was able to correct some discrepancies between codemod metadata and docs data, such as review guidance. This should now be prevented!
- I updated codemod summaries (titles) to follow the pattern of "Verb something Noun"
- in general, if you see changes in review guidance or wording it's because the docs repo had the "correct" data

**From now on, any changes to codemod docs should be updated in this repo and the `generate-script` should be run against the local docs repo path and then a PR created**

