### PR TITLE
Report failed parsing

### DIFF
--- a/.github/workflows/codemod_pygoat.yml
+++ b/.github/workflows/codemod_pygoat.yml
@@ -38,4 +38,4 @@ jobs:
       - name: Run Codemodder
         run: codemodder --output output.codetf pygoat
       - name: Check PyGoat Findings
-        run: make webgoat-test
+        run: make pygoat-test

--- a/Makefile
+++ b/Makefile
@@ -8,8 +8,8 @@ test:
 integration-test:
 	${PYTEST} integration_tests
 
-webgoat-test:
-	${PYTEST} -v ci_tests/test_webgoat_findings.py
+pygoat-test:
+	${PYTEST} -v ci_tests/test_pygoat_findings.py
 
 lint:
 	pylint -v codemodder core_codemods tests integration_tests

--- a/ci_tests/test_pygoat_findings.py
+++ b/ci_tests/test_pygoat_findings.py
@@ -17,17 +17,17 @@ EXPECTED_FINDINGS = [
 
 
 @pytest.fixture(scope="session")
-def webgoat_findings():
+def pygoat_findings():
     with open("output.codetf") as ff:
         results = json.load(ff)
 
-    yield set([x["codemod"] for x in results["results"]])
+    yield set([x["codemod"] for x in results["results"] if x["changeset"]])
 
 
-def test_num_webgoat_findings(webgoat_findings):
-    assert len(webgoat_findings) == len(EXPECTED_FINDINGS)
+def test_num_pygoat_findings(pygoat_findings):
+    assert len(pygoat_findings) == len(EXPECTED_FINDINGS)
 
 
 @pytest.mark.parametrize("finding", EXPECTED_FINDINGS)
-def test_webgoat_findings(webgoat_findings, finding):
-    assert finding in webgoat_findings
+def test_pygoat_findings(pygoat_findings, finding):
+    assert finding in pygoat_findings

--- a/integration_tests/base_test.py
+++ b/integration_tests/base_test.py
@@ -175,7 +175,7 @@ class BaseIntegrationTest(DependencyTestMixin, CleanRepoMixin):
         if pathlib.Path(self.output_path).exists():
             with open(self.output_path, "r", encoding="utf-8") as f:
                 codetf = json.load(f)
-            assert codetf["results"] == []
+            assert codetf["results"][0]["changeset"] == []
 
         with open(self.code_path, "r", encoding="utf-8") as f:
             still_new_code = f.read()

--- a/src/codemodder/context.py
+++ b/src/codemodder/context.py
@@ -75,17 +75,16 @@ class CodemodExecutionContext:  # pylint: disable=too-many-instance-attributes
     def compile_results(self, codemods: list[CodemodExecutorWrapper]):
         results = []
         for codemod in codemods:
-            if not (changeset := self._results_by_codemod.get(codemod.id)):
-                continue
-
             data = {
                 "codemod": codemod.id,
                 "summary": codemod.summary,
                 "description": codemod.description,
                 "references": codemod.references,
                 "properties": {},
-                "failedFiles": [],
-                "changeset": [change.to_json() for change in changeset],
+                "failedFiles": [str(file) for file in self.get_failures(codemod.id)],
+                "changeset": [
+                    change.to_json() for change in self.get_results(codemod.id)
+                ],
             }
 
             results.append(data)

--- a/tests/test_codemodder.py
+++ b/tests/test_codemodder.py
@@ -50,7 +50,7 @@ class TestRun:
         assert results_by_codemod != []
 
         requests_report = results_by_codemod[0]
-        requests_report["changeset"] == []
+        assert requests_report["changeset"] == []
         assert len(requests_report["failedFiles"]) == 2
         assert sorted(requests_report["failedFiles"]) == [
             "tests/samples/make_request.py",
@@ -90,10 +90,9 @@ class TestRun:
         args_to_reporting = mock_reporting.call_args_list[0][0]
         assert len(args_to_reporting) == 4
         _, _, _, results_by_codemod = args_to_reporting
-        # assert len(results_by_codemod) == 2
 
-        for codemod_results in results_by_codemod:
-            assert len(codemod_results["changeset"]) > 0
+        registry = load_registered_codemods()
+        assert len(results_by_codemod) == len(registry.codemods)
 
     @mock.patch("codemodder.codemods.base_codemod.semgrep_run")
     def test_no_codemods_to_run(self, mock_semgrep_run):


### PR DESCRIPTION
## Overview
*Codetf report should include list of fails that filed to be cst parsed ~or codemod-transformed~*

## Description

* previously we have been skipping reporting for a codemod if it had no results, however this doesn't really align with having a list of failed files. All files could fail so there would be no results. We should report anyway
* @drdavella I do need confirmation that this is ok with pixeebot - that a codemod without anything in changeset will still be in the report.
* we now also report fails that were either not correctly cst parsed (already handled) ~and not able to be transformed by a codemod (new)~
* added corresponding test cases to demonstrate.
