### PR TITLE
Remove py3.9, use py3.12

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,7 +21,7 @@ jobs:
     timeout-minutes: 15
     strategy:
       matrix:
-        python-version: ['3.9', '3.10',  '3.11']
+        python-version: ['3.10',  '3.11', '3.12']
     steps:
       - name: Set Up Python
         uses: actions/setup-python@v4

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.11
+FROM python:3.12
 WORKDIR /codemodder
 COPY . .
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "setuptools.build_meta"
 [project]
 name = "codemodder-python"
 version = "0.57.0"
-requires-python = ">=3.9.0"
+requires-python = ">=3.10.0"
 readme = "README.md"
 license = {file = "LICENSE"}
 dependencies = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "codemodder-python"
-version = "0.57.0"
+version = "0.60.0"
 requires-python = ">=3.10.0"
 readme = "README.md"
 license = {file = "LICENSE"}

--- a/src/codemodder/registry.py
+++ b/src/codemodder/registry.py
@@ -103,7 +103,7 @@ class CodemodRegistry:
 def load_registered_codemods() -> CodemodRegistry:
     registry = CodemodRegistry()
     logger.debug("loading registered codemod collections")
-    for entry_point in entry_points()["codemods"]:
+    for entry_point in entry_points().select(group="codemods"):
         logger.debug(
             '- loading codemod collection "%s" from "%s"',
             entry_point.name,


### PR DESCRIPTION
## Overview
*PY3.12 recently came out so we will use it and stop using 3.9*

## Description
* just a couple of changes and fixes to get this to work
* I did look to see if we have some obivous code that would benefit from match/case but surprisingly our number of `else:` statements is pretty small

- [ ] need to update PR necessary checks before merging this

