### PR TITLE
separate integration tests in CI

### DIFF
--- a/.github/workflows/integration_test.yml
+++ b/.github/workflows/integration_test.yml
@@ -1,4 +1,4 @@
-name: Unit Tests
+name: Integration Tests
 
 on:
   push:
@@ -33,9 +33,5 @@ jobs:
         run: pip install .
       - name: Install Dependencies
         run: pip install -r requirements/test.txt
-      - name: Run unit tests
-        run: make test
-      - name: Upload coverage reports to Codecov
-        uses: codecov/codecov-action@v3
-        env:
-          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+      - name: Run integration tests
+        run: make integration-test

--- a/.github/workflows/integration_test.yml
+++ b/.github/workflows/integration_test.yml
@@ -11,7 +11,7 @@ on:
       - develop
 
 concurrency:
-  group: ${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,7 +11,7 @@ on:
       - develop
 
 concurrency:
-  group: ${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,7 +18,7 @@ jobs:
   test:
     name: Run pytest
     runs-on: ubuntu-20.04
-    timeout-minutes: 10
+    timeout-minutes: 15
     strategy:
       matrix:
         python-version: ['3.10',  '3.11', '3.12']


### PR DESCRIPTION
## Overview
*Separate unit from integration test in CI to run in parallel*

## Description

* the goal is just to have things run in parallel and finish faster
* no coverage changes since we only calct that in unit tests