### PR TITLE
Ignore tests and other files by default

### DIFF
--- a/integration_tests/base_test.py
+++ b/integration_tests/base_test.py
@@ -154,6 +154,7 @@ class BaseIntegrationTest(DependencyTestMixin, CleanRepoMixin):
         completed_process = subprocess.run(
             command,
             check=False,
+            shell=False,
         )
         assert completed_process.returncode == 0
 

--- a/integration_tests/test_multiple_codemods.py
+++ b/integration_tests/test_multiple_codemods.py
@@ -27,12 +27,14 @@ class TestMultipleCodemods:
             "--output",
             str(codetf_path),
             f"--codemod-include={codemods}",
-            f"--path-include={source_file_name}",
+            "--path-include",
+            f"**/{source_file_name}",
         ]
 
         completed_process = subprocess.run(
             command,
             check=False,
+            shell=False,
         )
 
         assert completed_process.returncode == 0

--- a/src/codemodder/cli.py
+++ b/src/codemodder/cli.py
@@ -2,6 +2,7 @@ import argparse
 import sys
 
 from codemodder import __VERSION__
+from codemodder.code_directory import DEFAULT_INCLUDED_PATHS, DEFAULT_EXCLUDED_PATHS
 from codemodder.logging import OutputFormat, logger
 
 
@@ -144,13 +145,13 @@ def parse_args(argv, codemod_registry):
     parser.add_argument(
         "--path-exclude",
         action=CsvListAction,
-        default="",
+        default=DEFAULT_EXCLUDED_PATHS,
         help="Comma-separated set of UNIX glob patterns to exclude",
     )
     parser.add_argument(
         "--path-include",
         action=CsvListAction,
-        default="**/*.py",
+        default=DEFAULT_INCLUDED_PATHS,
         help="Comma-separated set of UNIX glob patterns to include",
     )
 

--- a/src/codemodder/logging.py
+++ b/src/codemodder/logging.py
@@ -21,6 +21,15 @@ def log_section(section_name: str):
     logger.info("\n[%s]", section_name)
 
 
+def log_list(level: int, header: str, items: list, predicate=None):
+    """
+    Log a list of items.
+    """
+    logger.log(level, "%s:", header)
+    for item in items:
+        logger.log(level, "  - %s", predicate(item) if predicate else item)
+
+
 def configure_logger(verbose: bool):
     """
     Configure the logger based on the verbosity level.

--- a/tests/test_code_directory.py
+++ b/tests/test_code_directory.py
@@ -7,8 +7,8 @@ from codemodder.code_directory import file_line_patterns, match_files
 
 @pytest.fixture(scope="module")
 def dir_structure(tmp_path_factory):
-    tests_dir = tmp_path_factory.mktemp("tests")
-    samples_dir = tests_dir / "samples"
+    base_dir = tmp_path_factory.mktemp("foo")
+    samples_dir = base_dir / "samples"
     samples_dir.mkdir()
     (samples_dir / "make_request.py").touch()
     (samples_dir / "insecure_random.py").touch()
@@ -18,9 +18,14 @@ def dir_structure(tmp_path_factory):
     (more_samples_dir / "empty_for_testing.py").touch()
     (more_samples_dir / "empty_for_testing.txt").touch()
 
-    assert len(list(tests_dir.rglob("*"))) == 6
+    tests_dir = base_dir / "tests"
+    tests_dir.mkdir()
+    (tests_dir / "test_make_request.py").touch()
+    (tests_dir / "test_insecure_random.py").touch()
 
-    return tests_dir
+    assert len(list(base_dir.rglob("*"))) == 9
+
+    return base_dir
 
 
 class TestMatchFiles:
@@ -37,45 +42,49 @@ class TestMatchFiles:
 
     def test_match_excluded(self, dir_structure):
         expected = ["empty_for_testing.py", "insecure_random.py"]
-        files = match_files(dir_structure, ["*request.py"])
+        files = match_files(dir_structure, ["**/tests/**", "*request.py"])
         self._assert_expected(files, expected)
 
     def test_match_included_file_with_line(self, dir_structure):
         expected = ["insecure_random.py"]
-        files = match_files(dir_structure, include_paths=["insecure_random.py:2"])
+        files = match_files(dir_structure, include_paths=["**/insecure_random.py:2"])
         self._assert_expected(files, expected)
 
     def test_match_excluded_line(self, dir_structure):
         expected = ["empty_for_testing.py", "insecure_random.py", "make_request.py"]
-        files = match_files(dir_structure, exclude_paths=["insecure_random.py:2"])
+        files = match_files(
+            dir_structure, exclude_paths=["**/tests/**", "**/insecure_random.py:2"]
+        )
         self._assert_expected(files, expected)
 
     def test_match_included_line_and_glob(self, dir_structure):
         expected = ["insecure_random.py"]
-        files = match_files(dir_structure, include_paths=["insecure*.py:3"])
+        files = match_files(dir_structure, include_paths=["**/insecure*.py:3"])
         self._assert_expected(files, expected)
 
     def test_match_excluded_line_and_glob(self, dir_structure):
         expected = ["empty_for_testing.py", "insecure_random.py", "make_request.py"]
-        files = match_files(dir_structure, exclude_paths=["insecure*.py:3"])
+        files = match_files(
+            dir_structure, exclude_paths=["**/tests/**", "**/insecure*.py:3"]
+        )
         self._assert_expected(files, expected)
 
     def test_match_excluded_dir_incorrect_glob(self, dir_structure):
         incorrect_glob = "more_samples"
         expected = ["empty_for_testing.py", "insecure_random.py", "make_request.py"]
-        files = match_files(dir_structure, [incorrect_glob])
+        files = match_files(dir_structure, ["**/tests/**", incorrect_glob])
         self._assert_expected(files, expected)
 
     def test_match_excluded_dir_correct_glob(self, dir_structure):
         correct_globs = ["**/more_samples/**", "*/more_samples/*"]
         for correct_glob in correct_globs:
             expected = ["insecure_random.py", "make_request.py"]
-            files = match_files(dir_structure, [correct_glob])
+            files = match_files(dir_structure, ["**/tests/**", correct_glob])
             self._assert_expected(files, expected)
 
     def test_match_excluded_multiple(self, dir_structure):
         expected = ["insecure_random.py"]
-        files = match_files(dir_structure, ["*request.py", "*empty*"])
+        files = match_files(dir_structure, ["**/tests/**", "*request.py", "*empty*"])
         self._assert_expected(files, expected)
 
     def test_match_included(self, dir_structure):
@@ -87,10 +96,45 @@ class TestMatchFiles:
         expected = ["empty_for_testing.py", "insecure_random.py"]
         files = match_files(
             dir_structure,
-            exclude_paths=["*request.py"],
+            exclude_paths=["**/tests/**", "*request.py"],
             include_paths=["*request.py", "*empty*.py", "*random.py"],
         )
         self._assert_expected(files, expected)
+
+    def test_test_directory_not_excluded(self, dir_structure):
+        expected = ["test_insecure_random.py", "test_make_request.py"]
+        files = match_files(
+            dir_structure, exclude_paths=["**/samples/**", "**/more_samples/**"]
+        )
+        self._assert_expected(files, expected)
+
+    def test_include_test_overridden_by_default_excludes(self, mocker):
+        mocker.patch(
+            "codemodder.code_directory.Path.rglob",
+            return_value=[
+                "foo/tests/test_insecure_random.py",
+                "foo/tests/test_make_request.py",
+            ],
+        )
+        mocker.patch(
+            "codemodder.code_directory.Path.is_file",
+            return_value=True,
+        )
+        files = match_files(Path("."), include_paths=["**/tests/**"])
+        self._assert_expected(files, [])
+
+    def test_include_test_without_default_includes(self, mocker):
+        files = ["foo/tests/test_insecure_random.py", "foo/tests/test_make_request.py"]
+        mocker.patch(
+            "codemodder.code_directory.Path.rglob",
+            return_value=files,
+        )
+        mocker.patch(
+            "codemodder.code_directory.Path.is_file",
+            return_value=True,
+        )
+        result = match_files(Path("."), exclude_paths=[])
+        assert result == [Path(x) for x in files]
 
     def test_extract_line_from_pattern(self):
         lines = file_line_patterns(Path("insecure_random.py"), ["insecure_*.py:3"])


### PR DESCRIPTION
## Overview
*Ensure test directories and other non-source directories are ignored by default*

## Description

* We now ignore a variety of directories by default
* We also make sure that we respect unix-style glob patterns
