### PR TITLE
Add optional JSON logging

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,6 +13,7 @@ dependencies = [
     "isort~=5.12.0",
     "libcst~=1.1.0",
     "pylint~=3.0.0",
+    "python-json-logger~=2.0.0",
     "PyYAML~=6.0.0",
     "semgrep~=1.45.0",
     "wrapt~=1.15.0",

--- a/src/codemodder/cli.py
+++ b/src/codemodder/cli.py
@@ -143,6 +143,10 @@ def parse_args(argv, codemod_registry):
         help="the format for the log output",
     )
     parser.add_argument(
+        "--project-name",
+        help="optional descriptive name for the project used in log output",
+    )
+    parser.add_argument(
         "--path-exclude",
         action=CsvListAction,
         default=DEFAULT_EXCLUDED_PATHS,

--- a/src/codemodder/cli.py
+++ b/src/codemodder/cli.py
@@ -139,7 +139,7 @@ def parse_args(argv, codemod_registry):
         "--log-format",
         type=OutputFormat,
         default=OutputFormat.HUMAN,
-        choices=[str(x).split(".")[-1].lower() for x in list(OutputFormat)],
+        choices=[OutputFormat.HUMAN, OutputFormat.JSON],
         help="the format for the log output",
     )
     parser.add_argument(

--- a/src/codemodder/codemodder.py
+++ b/src/codemodder/codemodder.py
@@ -129,7 +129,7 @@ def run(original_args) -> int:
         )
         return 1
 
-    configure_logger(argv.verbose, argv.log_format)
+    configure_logger(argv.verbose, argv.log_format, argv.project_name)
 
     log_section("startup")
     logger.info("codemodder: python/%s", __VERSION__)

--- a/src/codemodder/codemodder.py
+++ b/src/codemodder/codemodder.py
@@ -129,7 +129,7 @@ def run(original_args) -> int:
         )
         return 1
 
-    configure_logger(argv.verbose)
+    configure_logger(argv.verbose, argv.log_format)
 
     log_section("startup")
     logger.info("codemodder: python/%s", __VERSION__)

--- a/src/codemodder/logging.py
+++ b/src/codemodder/logging.py
@@ -13,6 +13,10 @@ class OutputFormat(Enum):
     HUMAN = "human"
     JSON = "json"
 
+    def __str__(self):
+        """For rendering properly in argparse help."""
+        return self.value.lower()
+
 
 def log_section(section_name: str):
     """

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -1,0 +1,18 @@
+from pythonjsonlogger import jsonlogger
+
+from codemodder.logging import OutputFormat, configure_logger
+
+
+def test_json_logger(mocker):
+    basic_config = mocker.patch("logging.basicConfig")
+    configure_logger(False, OutputFormat.JSON, "test-project")
+    assert basic_config.call_count == 1
+    assert basic_config.call_args[1]["format"] == "%(message)s"
+    assert isinstance(
+        basic_config.call_args[1]["handlers"][0].formatter,
+        jsonlogger.JsonFormatter,
+    )
+    assert (
+        basic_config.call_args[1]["handlers"][0].formatter.project_name
+        == "test-project"
+    )


### PR DESCRIPTION
## Overview
*Implement JSON logging per the [logging spec](https://github.com/pixee/codemodder-specs/blob/main/logging.md#json-output)*


```
{"timestamp": "2023-10-18 14:36:18,122", "level": "INFO", "message": "\n[startup]", "file": "logging.py", "line": 46}
{"timestamp": "2023-10-18 14:36:18,122", "level": "INFO", "message": "codemodder: python/0.57.0", "file": "codemodder.py", "line": 135}
{"timestamp": "2023-10-18 14:36:18,122", "level": "INFO", "message": "\n[setup]", "file": "logging.py", "line": 46}
{"timestamp": "2023-10-18 14:36:18,122", "level": "INFO", "message": "running:", "file": "logging.py", "line": 53}
```