### PR TITLE
Add ChangeSet to CodeTF when adding dependency to requirements.txt

### DIFF
--- a/integration_tests/test_process_sandbox.py
+++ b/integration_tests/test_process_sandbox.py
@@ -21,10 +21,9 @@ class TestProcessSandbox(BaseIntegrationTest):
     expected_diff = '--- \n+++ \n@@ -1,10 +1,11 @@\n import subprocess\n+from security import safe_command\n \n-subprocess.run("echo \'hi\'", shell=True)\n-subprocess.run(["ls", "-l"])\n+safe_command.run(subprocess.run, "echo \'hi\'", shell=True)\n+safe_command.run(subprocess.run, ["ls", "-l"])\n \n-subprocess.call("echo \'hi\'", shell=True)\n-subprocess.call(["ls", "-l"])\n+safe_command.call(subprocess.call, "echo \'hi\'", shell=True)\n+safe_command.call(subprocess.call, ["ls", "-l"])\n \n subprocess.check_output(["ls", "-l"])\n \n'
     expected_line_change = "3"
     num_changes = 4
+    num_changed_files = 2
     change_description = ProcessSandbox.CHANGE_DESCRIPTION
 
     requirements_path = "tests/samples/requirements.txt"
     original_requirements = "# file used to test dependency management\nrequests==2.31.0\nblack==23.7.*\nmypy~=1.4\npylint>1\n"
-    expected_new_reqs = (
-        "requests==2.31.0\nblack==23.7.*\nmypy~=1.4\npylint>1\nsecurity==1.0.1"
-    )
+    expected_new_reqs = "# file used to test dependency management\nrequests==2.31.0\nblack==23.7.*\nmypy~=1.4\npylint>1\nsecurity==1.0.1"

--- a/integration_tests/test_url_sandbox.py
+++ b/integration_tests/test_url_sandbox.py
@@ -19,10 +19,8 @@ class TestUrlSandbox(BaseIntegrationTest):
     expected_diff = '--- \n+++ \n@@ -1,4 +1,4 @@\n-import requests\n+from security import safe_requests\n \n-requests.get("https://www.google.com")\n+safe_requests.get("https://www.google.com")\n var = "hello"\n'
     expected_line_change = "3"
     change_description = UrlSandbox.CHANGE_DESCRIPTION
-    num_changed_files = 1
+    num_changed_files = 2
 
     requirements_path = "tests/samples/requirements.txt"
     original_requirements = "# file used to test dependency management\nrequests==2.31.0\nblack==23.7.*\nmypy~=1.4\npylint>1\n"
-    expected_new_reqs = (
-        "requests==2.31.0\nblack==23.7.*\nmypy~=1.4\npylint>1\nsecurity==1.0.1"
-    )
+    expected_new_reqs = "# file used to test dependency management\nrequests==2.31.0\nblack==23.7.*\nmypy~=1.4\npylint>1\nsecurity==1.0.1"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,9 +9,9 @@ requires-python = ">=3.10.0"
 readme = "README.md"
 license = {file = "LICENSE"}
 dependencies = [
-    "dependency-manager @ git+https://github.com/pixee/python-dependency-manager#egg=dependency-manager",
     "isort~=5.12.0",
     "libcst~=1.1.0",
+    "packaging~=23.0.0",
     "pylint~=3.0.0",
     "python-json-logger~=2.0.0",
     "PyYAML~=6.0.0",

--- a/src/codemodder/change.py
+++ b/src/codemodder/change.py
@@ -15,3 +15,15 @@ class Change:
             "properties": self.properties,
             "packageActions": self.packageActions,
         }
+
+
+@dataclass
+class ChangeSet:
+    """A set of changes made to a file at `path`"""
+
+    path: str
+    diff: str
+    changes: list[Change]
+
+    def to_json(self):
+        return {"path": self.path, "diff": self.diff, "changes": self.changes}

--- a/src/codemodder/codemodder.py
+++ b/src/codemodder/codemodder.py
@@ -77,6 +77,7 @@ def analyze_files(
     cli_args,
 ):
     for idx, file_path in enumerate(files_to_analyze):
+        logger.debug("scanning file %s", file_path)
         if idx and idx % 100 == 0:
             logger.info("scanned %s files...", idx)  # pragma: no cover
 

--- a/src/codemodder/codemods/base_codemod.py
+++ b/src/codemodder/codemods/base_codemod.py
@@ -99,6 +99,9 @@ class BaseCodemod:
     def line_include(self):
         return self.file_context.line_include
 
+    def add_dependency(self, dependency: str):
+        self.file_context.add_dependency(dependency)
+
 
 class SemgrepCodemod(BaseCodemod):
     YAML_FILES: ClassVar[List[str]] = NotImplemented

--- a/src/codemodder/dependency_manager.py
+++ b/src/codemodder/dependency_manager.py
@@ -1,25 +1,82 @@
-import sys
-import io
-
-from dependency_manager import DependencyManagerAbstract
+from functools import cached_property
 from pathlib import Path
+from typing import Optional
 
-from codemodder.context import CodemodExecutionContext
+import difflib
+from packaging.requirements import Requirement
+
+from codemodder.change import ChangeSet
 
 
-def write_dependencies(execution_context: CodemodExecutionContext):
-    class DependencyManager(DependencyManagerAbstract):
-        def get_parent_dir(self):
-            return Path(execution_context.directory)
+class DependencyManager:
+    parent_directory: Path
+    _lines: list[str]
+    _new_requirements: list[str]
 
-    dm = DependencyManager()
-    dm.add(list(execution_context.dependencies))
+    def __init__(self, parent_directory: Path):
+        """One-time class initialization."""
+        self.parent_directory = parent_directory
+        self.dependency_file_changed = False
+        self._lines = []
+        self._new_requirements = []
 
-    try:
-        # Hacky solution to prevent the dependency manager from writing to stdout
-        sys.stdout = io.StringIO()
-        dm.write(dry_run=execution_context.dry_run)
-    finally:
-        sys.stdout = sys.__stdout__
+    def add(self, dependencies: list[str]):
+        """add any number of dependencies to the end of list of dependencies."""
+        for dep_str in dependencies:
+            dep = Requirement(dep_str)
+            if dep not in self.dependencies:
+                self.dependencies.update({dep: None})
+                self._new_requirements.append(str(dep))
 
-    return dm
+    def write(self, dry_run: bool = False) -> Optional[ChangeSet]:
+        """
+        Write the updated dependency files if any changes were made.
+        """
+        if not (self.dependency_file and self._new_requirements):
+            return None
+
+        updated = self._lines + self._new_requirements + ["\n"]
+
+        diff = "".join(difflib.unified_diff(self._lines, updated))
+        # TODO: add a change entry for each new requirement
+        # TODO: make sure to set the contextual_description=True in the properties bag
+
+        if not dry_run:
+            with open(self.dependency_file, "w", encoding="utf-8") as f:
+                f.writelines(self._lines)
+                f.writelines(self._new_requirements)
+
+        self.dependency_file_changed = True
+        return ChangeSet(str(self.dependency_file), diff, changes=[])
+
+    @property
+    def found_dependency_file(self) -> bool:
+        return self.dependency_file is not None
+
+    @cached_property
+    def dependency_file(self) -> Optional[Path]:
+        try:
+            # For now for simplicity only return the first file
+            return next(Path(self.parent_directory).rglob("requirements.txt"))
+        except StopIteration:
+            pass
+        return None
+
+    @cached_property
+    def dependencies(self) -> dict[Requirement, None]:
+        """
+        Extract list of dependencies from requirements.txt file.
+        Same order of requirements is maintained, no alphabetical sorting is done.
+        """
+        if not self.dependency_file:
+            return {}
+
+        with open(self.dependency_file, "r", encoding="utf-8") as f:
+            self._lines = f.readlines()
+
+        return {
+            Requirement(line): None
+            for x in self._lines
+            # Skip empty lines and comments
+            if (line := x.strip()) and not line.startswith("#")
+        }

--- a/src/codemodder/file_context.py
+++ b/src/codemodder/file_context.py
@@ -1,4 +1,4 @@
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Dict, List
 
@@ -13,6 +13,7 @@ class FileContext:
     line_exclude: List[int]
     line_include: List[int]
     results_by_id: Dict
+    dependencies: set[str] = field(default_factory=set)
 
     def __post_init__(self):
         if self.line_include is None:
@@ -20,3 +21,6 @@ class FileContext:
         if self.line_exclude is None:
             self.line_exclude = []
         self.codemod_changes = []
+
+    def add_dependency(self, dependency: str):
+        self.dependencies.add(dependency)

--- a/src/core_codemods/process_creation_sandbox.py
+++ b/src/core_codemods/process_creation_sandbox.py
@@ -40,7 +40,7 @@ class ProcessSandbox(SemgrepCodemod):
 
     def on_result_found(self, original_node, updated_node):
         self.add_needed_import("security", "safe_command")
-        self.execution_context.add_dependency("security==1.0.1")
+        self.add_dependency("security==1.0.1")
         return self.update_call_target(
             updated_node,
             "safe_command",

--- a/src/core_codemods/url_sandbox.py
+++ b/src/core_codemods/url_sandbox.py
@@ -72,7 +72,7 @@ class UrlSandbox(SemgrepCodemod, Codemod):
                 find_requests_visitor.changes_in_file
             )
             new_tree = tree.visit(ReplaceNodes(find_requests_visitor.nodes_to_change))
-            self.execution_context.add_dependency("security==1.0.1")
+            self.add_dependency("security==1.0.1")
             # if it finds any request.get(...), try to remove the imports
             if any(
                 (

--- a/src/core_codemods/use_defused_xml.py
+++ b/src/core_codemods/use_defused_xml.py
@@ -91,6 +91,6 @@ class UseDefusedXml(BaseCodemod):
         result_tree = visitor.transform_module(tree)
         self.file_context.codemod_changes.extend(visitor.changes_in_file)
         if visitor.changes_in_file:
-            self.execution_context.add_dependency("defusedxml")
+            self.add_dependency("defusedxml")  # TODO: which version?
 
         return result_tree

--- a/tests/codemods/base_codemod_test.py
+++ b/tests/codemods/base_codemod_test.py
@@ -49,6 +49,9 @@ class BaseCodemodTest:
 
         assert output_tree.code == dedent(expected)
 
+    def assert_dependency(self, dependency: str):
+        assert self.file_context and self.file_context.dependencies == set([dependency])
+
 
 class BaseSemgrepCodemodTest(BaseCodemodTest):
     @classmethod

--- a/tests/codemods/test_process_creation_sandbox.py
+++ b/tests/codemods/test_process_creation_sandbox.py
@@ -22,6 +22,7 @@ safe_command.run(subprocess.run, "echo 'hi'", shell=True)
 var = "hello"
 """
         self.run_and_assert(tmpdir, input_code, expected)
+        self.assert_dependency("security==1.0.1")
 
     def test_import_alias(self, tmpdir):
         input_code = """import subprocess as sub
@@ -36,6 +37,7 @@ safe_command.run(sub.run, "echo 'hi'", shell=True)
 var = "hello"
 """
         self.run_and_assert(tmpdir, input_code, expected)
+        self.assert_dependency("security==1.0.1")
 
     def test_from_subprocess(self, tmpdir):
         input_code = """from subprocess import run
@@ -50,6 +52,7 @@ safe_command.run(run, "echo 'hi'", shell=True)
 var = "hello"
 """
         self.run_and_assert(tmpdir, input_code, expected)
+        self.assert_dependency("security==1.0.1")
 
     def test_subprocess_nameerror(self, tmpdir):
         input_code = """subprocess.run("echo 'hi'", shell=True)
@@ -94,6 +97,7 @@ excel
     )
     def test_other_import_untouched(self, tmpdir, input_code, expected):
         self.run_and_assert(tmpdir, input_code, expected)
+        self.assert_dependency("security==1.0.1")
 
     def test_multifunctions(self, tmpdir):
         # Test that subprocess methods that aren't part of the codemod are not changed.
@@ -111,6 +115,7 @@ safe_command.run(subprocess.run, "echo 'hi'", shell=True)
 subprocess.check_output(["ls", "-l"])"""
 
         self.run_and_assert(tmpdir, input_code, expected)
+        self.assert_dependency("security==1.0.1")
 
     def test_custom_run(self, tmpdir):
         input_code = """from app_funcs import run

--- a/tests/codemods/test_url_sandbox.py
+++ b/tests/codemods/test_url_sandbox.py
@@ -21,6 +21,7 @@ safe_requests.get("www.google.com")
 var = "hello"
 """
         self.run_and_assert(tmpdir, input_code, expected)
+        self.assert_dependency("security==1.0.1")
 
     def test_from_requests(self, tmpdir):
         input_code = """from requests import get
@@ -34,6 +35,7 @@ get("www.google.com")
 var = "hello"
 """
         self.run_and_assert(tmpdir, input_code, expected)
+        self.assert_dependency("security==1.0.1")
 
     def test_requests_nameerror(self, tmpdir):
         input_code = """requests.get("www.google.com")
@@ -76,6 +78,7 @@ excel
     )
     def test_requests_other_import_untouched(self, tmpdir, input_code, expected):
         self.run_and_assert(tmpdir, input_code, expected)
+        self.assert_dependency("security==1.0.1")
 
     def test_requests_multifunctions(self, tmpdir):
         # Test that `requests` import isn't removed if code uses part of the requests
@@ -93,6 +96,7 @@ safe_requests.get("www.google.com")
 requests.status_codes.codes.FORBIDDEN"""
 
         self.run_and_assert(tmpdir, input_code, expected)
+        self.assert_dependency("security==1.0.1")
 
     def test_custom_get(self, tmpdir):
         input_code = """from app_funcs import get
@@ -123,6 +127,7 @@ got("www.google.com")
 var = "hello"
 """
         self.run_and_assert(tmpdir, input_code, expected)
+        self.assert_dependency("security==1.0.1")
 
     def test_requests_with_alias(self, tmpdir):
         input_code = """import requests as req
@@ -136,3 +141,4 @@ safe_requests.get("www.google.com")
 var = "hello"
 """
         self.run_and_assert(tmpdir, input_code, expected)
+        self.assert_dependency("security==1.0.1")

--- a/tests/codemods/test_use_defused_xml.py
+++ b/tests/codemods/test_use_defused_xml.py
@@ -29,6 +29,7 @@ class TestUseDefusedXml(BaseCodemodTest):
         """
 
         self.run_and_assert(tmpdir, original_code, new_code)
+        self.assert_dependency("defusedxml")
 
     @pytest.mark.parametrize("method", ETREE_METHODS)
     @pytest.mark.parametrize("module", ["ElementTree", "cElementTree"])
@@ -46,6 +47,7 @@ class TestUseDefusedXml(BaseCodemodTest):
         """
 
         self.run_and_assert(tmpdir, original_code, new_code)
+        self.assert_dependency("defusedxml")
 
     def test_etree_elementtree_with_alias(self, tmpdir):
         original_code = """
@@ -61,6 +63,7 @@ class TestUseDefusedXml(BaseCodemodTest):
         """
 
         self.run_and_assert(tmpdir, original_code, new_code)
+        self.assert_dependency("defusedxml")
 
     def test_etree_parse_with_alias(self, tmpdir):
         original_code = """
@@ -76,6 +79,7 @@ class TestUseDefusedXml(BaseCodemodTest):
         """
 
         self.run_and_assert(tmpdir, original_code, new_code)
+        self.assert_dependency("defusedxml")
 
     @pytest.mark.parametrize("method", SAX_METHODS)
     def test_sax_simple_call(self, tmpdir, method):
@@ -92,6 +96,7 @@ class TestUseDefusedXml(BaseCodemodTest):
         """
 
         self.run_and_assert(tmpdir, original_code, new_code)
+        self.assert_dependency("defusedxml")
 
     @pytest.mark.parametrize("method", SAX_METHODS)
     def test_sax_attribute_call(self, tmpdir, method):
@@ -108,6 +113,7 @@ class TestUseDefusedXml(BaseCodemodTest):
         """
 
         self.run_and_assert(tmpdir, original_code, new_code)
+        self.assert_dependency("defusedxml")
 
     @pytest.mark.parametrize("method", DOM_METHODS)
     @pytest.mark.parametrize("module", ["minidom", "pulldom"])
@@ -125,3 +131,4 @@ class TestUseDefusedXml(BaseCodemodTest):
         """
 
         self.run_and_assert(tmpdir, original_code, new_code)
+        self.assert_dependency("defusedxml")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -44,9 +44,7 @@ def disable_write_dependencies():
     """
     Unit tests should not write any dependency files
     """
-    dm_write = mock.patch(
-        "codemodder.dependency_manager.DependencyManagerAbstract._write"
-    )
+    dm_write = mock.patch("codemodder.dependency_manager.DependencyManager.write")
 
     dm_write.start()
     yield


### PR DESCRIPTION
## Overview
*Dependency updates now result in new `ChangeSet` entry in CodeTF*

## Description

* Whenever we add a dependency the change needs to be reflected as a `ChangeSet` entry in CodeTF
* Each codemod that introduces a dependency will contain its own `ChangeSet` entry
* This required some changes to the `DependencyManager` since it needs to be able to generate a diff and provide some contextual information
  * It is much easier to iterate on `DependencyManager` if it's in the same git source tree. 
  * We can revisit whether this belongs in a separate package at a later date.
  * There is going to be some more iteration on this component as we add support for other dependency locations
* `use-defusedxml` now adds a dependency but there is still additional work before it can be enabled
* We also need to add contextual comments for dependency changes so that they are available to the platform