### PR TITLE
Add contextual comments to CodeTF when adding dependencies

### DIFF
--- a/integration_tests/base_test.py
+++ b/integration_tests/base_test.py
@@ -101,7 +101,7 @@ class BaseIntegrationTest(DependencyTestMixin, CleanRepoMixin):
 
         assert len(change["changes"]) == self.num_changes
         line_change = change["changes"][0]
-        assert line_change["lineNumber"] == self.expected_line_change
+        assert line_change["lineNumber"] == str(self.expected_line_change)
         assert line_change["description"] == self.change_description
         assert line_change["packageActions"] == []
         assert line_change["properties"] == {}

--- a/integration_tests/test_process_sandbox.py
+++ b/integration_tests/test_process_sandbox.py
@@ -26,4 +26,4 @@ class TestProcessSandbox(BaseIntegrationTest):
 
     requirements_path = "tests/samples/requirements.txt"
     original_requirements = "# file used to test dependency management\nrequests==2.31.0\nblack==23.7.*\nmypy~=1.4\npylint>1\n"
-    expected_new_reqs = "# file used to test dependency management\nrequests==2.31.0\nblack==23.7.*\nmypy~=1.4\npylint>1\nsecurity==1.0.1"
+    expected_new_reqs = "# file used to test dependency management\nrequests==2.31.0\nblack==23.7.*\nmypy~=1.4\npylint>1\nsecurity~=1.2.0"

--- a/integration_tests/test_url_sandbox.py
+++ b/integration_tests/test_url_sandbox.py
@@ -23,4 +23,4 @@ class TestUrlSandbox(BaseIntegrationTest):
 
     requirements_path = "tests/samples/requirements.txt"
     original_requirements = "# file used to test dependency management\nrequests==2.31.0\nblack==23.7.*\nmypy~=1.4\npylint>1\n"
-    expected_new_reqs = "# file used to test dependency management\nrequests==2.31.0\nblack==23.7.*\nmypy~=1.4\npylint>1\nsecurity==1.0.1"
+    expected_new_reqs = "# file used to test dependency management\nrequests==2.31.0\nblack==23.7.*\nmypy~=1.4\npylint>1\nsecurity~=1.2.0"

--- a/src/codemodder/change.py
+++ b/src/codemodder/change.py
@@ -1,4 +1,30 @@
 from dataclasses import dataclass, field
+from enum import Enum
+
+
+class Action(Enum):
+    ADD = "add"
+    REMOVE = "remove"
+
+
+class Result(Enum):
+    COMPLETED = "completed"
+    FAILED = "failed"
+    SKIPPED = "skipped"
+
+
+@dataclass
+class PackageAction:
+    action: Action
+    result: Result
+    package: str
+
+    def to_json(self):
+        return {
+            "action": self.action.value,
+            "result": self.result.value,
+            "package": self.package,
+        }
 
 
 @dataclass
@@ -6,7 +32,7 @@ class Change:
     lineNumber: int
     description: str
     properties: dict = field(default_factory=dict)
-    packageActions: list = field(default_factory=list)
+    packageActions: list[PackageAction] = field(default_factory=list)
 
     def to_json(self):
         return {
@@ -14,7 +40,7 @@ class Change:
             "lineNumber": str(self.lineNumber),
             "description": self.description,
             "properties": self.properties,
-            "packageActions": self.packageActions,
+            "packageActions": [pa.to_json() for pa in self.packageActions],
         }
 
 

--- a/src/codemodder/change.py
+++ b/src/codemodder/change.py
@@ -3,14 +3,15 @@ from dataclasses import dataclass, field
 
 @dataclass
 class Change:
-    lineNumber: str
+    lineNumber: int
     description: str
     properties: dict = field(default_factory=dict)
     packageActions: list = field(default_factory=list)
 
     def to_json(self):
         return {
-            "lineNumber": self.lineNumber,
+            # Not sure why this is a string but it's in the spec
+            "lineNumber": str(self.lineNumber),
             "description": self.description,
             "properties": self.properties,
             "packageActions": self.packageActions,
@@ -26,4 +27,8 @@ class ChangeSet:
     changes: list[Change]
 
     def to_json(self):
-        return {"path": self.path, "diff": self.diff, "changes": self.changes}
+        return {
+            "path": self.path,
+            "diff": self.diff,
+            "changes": [x.to_json() for x in self.changes],
+        }

--- a/src/codemodder/codemods/api/__init__.py
+++ b/src/codemodder/codemods/api/__init__.py
@@ -96,7 +96,7 @@ class BaseCodemod(
     def report_change(self, original_node):
         line_number = self.lineno_for_node(original_node)
         self.file_context.codemod_changes.append(
-            Change(str(line_number), self.CHANGE_DESCRIPTION).to_json()
+            Change(line_number, self.CHANGE_DESCRIPTION)
         )
 
 

--- a/src/codemodder/codemods/base_codemod.py
+++ b/src/codemodder/codemods/base_codemod.py
@@ -43,7 +43,8 @@ class BaseCodemod:
     # Implementation borrowed from https://stackoverflow.com/a/45250114
     METADATA: ClassVar[CodemodMetadata] = NotImplemented
     SUMMARY: ClassVar[str] = NotImplemented
-    is_semgrep = False
+    is_semgrep: bool = False
+    adds_dependency: bool = False
 
     execution_context: CodemodExecutionContext
     file_context: FileContext

--- a/src/codemodder/codemods/base_codemod.py
+++ b/src/codemodder/codemods/base_codemod.py
@@ -86,7 +86,7 @@ class BaseCodemod:
             Change(
                 lineNumber=position.start.line,
                 description=description,
-            ).to_json()
+            )
         )
 
     def lineno_for_node(self, node):

--- a/src/codemodder/codemods/base_codemod.py
+++ b/src/codemodder/codemods/base_codemod.py
@@ -6,6 +6,7 @@ from libcst._position import CodeRange
 
 from codemodder.change import Change
 from codemodder.context import CodemodExecutionContext
+from codemodder.dependency import Dependency
 from codemodder.file_context import FileContext
 from codemodder.semgrep import run as semgrep_run
 
@@ -100,7 +101,7 @@ class BaseCodemod:
     def line_include(self):
         return self.file_context.line_include
 
-    def add_dependency(self, dependency: str):
+    def add_dependency(self, dependency: Dependency):
         self.file_context.add_dependency(dependency)
 
 

--- a/src/codemodder/codemods/imported_call_modifier.py
+++ b/src/codemodder/codemods/imported_call_modifier.py
@@ -35,7 +35,7 @@ class ImportedCallModifier(
         self.line_include = file_context.line_include
         self.matching_functions: FunctionMatchType = matching_functions
         self.change_description = change_description
-        self.changes_in_file: list[Mapping] = []
+        self.changes_in_file: list[Change] = []
 
     def updated_args(self, original_args: Sequence[cst.Arg]):
         return original_args
@@ -71,7 +71,7 @@ class ImportedCallModifier(
                 and true_name in self.matching_functions
             ):
                 self.changes_in_file.append(
-                    Change(str(line_number), self.change_description).to_json()
+                    Change(line_number, self.change_description)
                 )
 
                 new_args = self.updated_args(updated_node.args)

--- a/src/codemodder/context.py
+++ b/src/codemodder/context.py
@@ -4,6 +4,7 @@ import itertools
 from textwrap import indent
 
 from codemodder.change import ChangeSet
+from codemodder.dependency import Dependency
 from codemodder.dependency_manager import DependencyManager
 from codemodder.executor import CodemodExecutorWrapper
 from codemodder.logging import logger, log_list
@@ -26,7 +27,7 @@ these files manually before accepting this change.
 class CodemodExecutionContext:  # pylint: disable=too-many-instance-attributes
     _results_by_codemod: dict[str, list[ChangeSet]] = {}
     _failures_by_codemod: dict[str, list[Path]] = {}
-    dependencies: dict[str, set[str]] = {}
+    dependencies: dict[str, set[Dependency]] = {}
     directory: Path
     dry_run: bool = False
     verbose: bool = False
@@ -53,7 +54,7 @@ class CodemodExecutionContext:  # pylint: disable=too-many-instance-attributes
     def add_failure(self, codemod_name, file_path):
         self._failures_by_codemod.setdefault(codemod_name, []).append(file_path)
 
-    def add_dependencies(self, codemod_id: str, dependencies: set[str]):
+    def add_dependencies(self, codemod_id: str, dependencies: set[Dependency]):
         self.dependencies.setdefault(codemod_id, set()).update(dependencies)
 
     def get_results(self, codemod_name):

--- a/src/codemodder/dependency.py
+++ b/src/codemodder/dependency.py
@@ -1,0 +1,63 @@
+from dataclasses import dataclass
+
+from packaging.requirements import Requirement
+
+
+@dataclass
+class License:
+    name: str
+    url: str
+
+
+@dataclass
+class Dependency:
+    requirement: Requirement
+    description: str
+    _license: License
+    oss_link: str
+    package_link: str
+
+    @property
+    def name(self) -> str:
+        return self.requirement.name
+
+    @property
+    def version(self) -> str:
+        return self.requirement.specifier.__str__().strip()
+
+    def build_description(self) -> str:
+        return f"""{self.description}
+
+License: [{self._license.name}]({self._license.url}) ✅ \
+[Open Source]({self.oss_link}) ✅ \
+[More facts]({self.package_link})
+"""
+
+    def __hash__(self):
+        return hash(self.requirement)
+
+
+DefusedXML = Dependency(
+    Requirement("defusedxml~=0.7.1"),
+    description="""\
+This package is [recommended by the Python community](https://docs.python.org/3/library/xml.html#the-defusedxml-package) \
+to protect against XML vulnerabilities.\
+""",
+    _license=License(
+        "PSF-2.0",
+        "https://opensource.org/license/python-2-0/",
+    ),
+    oss_link="https://github.com/tiran/defusedxml",
+    package_link="https://pypi.org/project/defusedxml/",
+)
+
+Security = Dependency(
+    Requirement("security~=1.2.0"),
+    description="""This library holds security tools for protecting Python API calls.""",
+    _license=License(
+        "MIT",
+        "https://opensource.org/license/MIT/",
+    ),
+    oss_link="https://github.com/pixee/python-security",
+    package_link="https://pypi.org/project/security/",
+)

--- a/src/codemodder/dependency_manager.py
+++ b/src/codemodder/dependency_manager.py
@@ -5,7 +5,7 @@ from typing import Optional
 import difflib
 from packaging.requirements import Requirement
 
-from codemodder.change import Change, ChangeSet
+from codemodder.change import Action, Change, ChangeSet, PackageAction, Result
 from codemodder.dependency import Dependency
 
 
@@ -48,6 +48,9 @@ class DependencyManager:
                 lineNumber=len(self._lines) + i + 1,
                 description=dep.build_description(),
                 properties={"contextual_description": True},
+                packageActions=[
+                    PackageAction(Action.ADD, Result.COMPLETED, str(dep.requirement))
+                ],
             )
             for i, dep in enumerate(self._new_requirements)
         ]

--- a/src/codemodder/file_context.py
+++ b/src/codemodder/file_context.py
@@ -2,6 +2,8 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Dict, List
 
+from codemodder.change import Change
+
 
 @dataclass
 class FileContext:
@@ -10,17 +12,11 @@ class FileContext:
     """
 
     file_path: Path
-    line_exclude: List[int]
-    line_include: List[int]
-    results_by_id: Dict
+    line_exclude: List[int] = field(default_factory=list)
+    line_include: List[int] = field(default_factory=list)
+    results_by_id: Dict = field(default_factory=dict)
     dependencies: set[str] = field(default_factory=set)
-
-    def __post_init__(self):
-        if self.line_include is None:
-            self.line_include = []
-        if self.line_exclude is None:
-            self.line_exclude = []
-        self.codemod_changes = []
+    codemod_changes: List[Change] = field(default_factory=list)
 
     def add_dependency(self, dependency: str):
         self.dependencies.add(dependency)

--- a/src/codemodder/file_context.py
+++ b/src/codemodder/file_context.py
@@ -3,6 +3,7 @@ from pathlib import Path
 from typing import Dict, List
 
 from codemodder.change import Change
+from codemodder.dependency import Dependency
 
 
 @dataclass
@@ -15,8 +16,8 @@ class FileContext:
     line_exclude: List[int] = field(default_factory=list)
     line_include: List[int] = field(default_factory=list)
     results_by_id: Dict = field(default_factory=dict)
-    dependencies: set[str] = field(default_factory=set)
+    dependencies: set[Dependency] = field(default_factory=set)
     codemod_changes: List[Change] = field(default_factory=list)
 
-    def add_dependency(self, dependency: str):
+    def add_dependency(self, dependency: Dependency):
         self.dependencies.add(dependency)

--- a/src/core_codemods/django_debug_flag_on.py
+++ b/src/core_codemods/django_debug_flag_on.py
@@ -74,7 +74,7 @@ class DebugFlagTransformer(BaseTransformer):
         ) and self.filter_by_path_includes_or_excludes(pos_to_match):
             line_number = pos_to_match.start.line
             self.changes_in_file.append(
-                Change(str(line_number), DjangoDebugFlagOn.CHANGE_DESCRIPTION).to_json()
+                Change(line_number, DjangoDebugFlagOn.CHANGE_DESCRIPTION)
             )
             return updated_node.with_changes(value=cst.Name("False"))
         return updated_node

--- a/src/core_codemods/django_session_cookie_secure_off.py
+++ b/src/core_codemods/django_session_cookie_secure_off.py
@@ -79,9 +79,7 @@ class SessionCookieSecureTransformer(BaseTransformer):
         pos_to_match = self.node_position(original_node)
         line_number = pos_to_match.end.line
         self.changes_in_file.append(
-            Change(
-                str(line_number), DjangoSessionCookieSecureOff.CHANGE_DESCRIPTION
-            ).to_json()
+            Change(line_number, DjangoSessionCookieSecureOff.CHANGE_DESCRIPTION)
         )
         final_line = cst.parse_statement("SESSION_COOKIE_SECURE = True")
         new_body = updated_node.body + (final_line,)
@@ -104,9 +102,7 @@ class SessionCookieSecureTransformer(BaseTransformer):
             # SESSION_COOKIE_SECURE = anything other than True
             line_number = pos_to_match.start.line
             self.changes_in_file.append(
-                Change(
-                    str(line_number), DjangoSessionCookieSecureOff.CHANGE_DESCRIPTION
-                ).to_json()
+                Change(line_number, DjangoSessionCookieSecureOff.CHANGE_DESCRIPTION)
             )
             return updated_node.with_changes(value=cst.Name("True"))
         return updated_node

--- a/src/core_codemods/order_imports.py
+++ b/src/core_codemods/order_imports.py
@@ -53,7 +53,7 @@ class OrderImports(BaseCodemod, Codemod):
                         top_imports_visitor.top_imports_blocks[i][0]
                     ).start.line
                     self.file_context.codemod_changes.append(
-                        Change(str(line_number), self.CHANGE_DESCRIPTION).to_json()
+                        Change(line_number, self.CHANGE_DESCRIPTION)
                     )
             return result_tree
         return tree

--- a/src/core_codemods/process_creation_sandbox.py
+++ b/src/core_codemods/process_creation_sandbox.py
@@ -1,6 +1,7 @@
 import libcst as cst
 from codemodder.codemods.base_codemod import ReviewGuidance
 from codemodder.codemods.api import SemgrepCodemod
+from codemodder.dependency import Security
 
 
 class ProcessSandbox(SemgrepCodemod):
@@ -42,7 +43,7 @@ class ProcessSandbox(SemgrepCodemod):
 
     def on_result_found(self, original_node, updated_node):
         self.add_needed_import("security", "safe_command")
-        self.add_dependency("security==1.0.1")
+        self.add_dependency(Security)
         return self.update_call_target(
             updated_node,
             "safe_command",

--- a/src/core_codemods/process_creation_sandbox.py
+++ b/src/core_codemods/process_creation_sandbox.py
@@ -21,6 +21,8 @@ class ProcessSandbox(SemgrepCodemod):
         },
     ]
 
+    adds_dependency = True
+
     @classmethod
     def rule(cls):
         return """

--- a/src/core_codemods/remove_unused_imports.py
+++ b/src/core_codemods/remove_unused_imports.py
@@ -54,7 +54,7 @@ class RemoveUnusedImports(BaseCodemod, Codemod):
             if self.filter_by_path_includes_or_excludes(pos):
                 if not self._is_disabled_by_linter(importt):
                     self.file_context.codemod_changes.append(
-                        Change(pos.start.line, self.CHANGE_DESCRIPTION).to_json()
+                        Change(pos.start.line, self.CHANGE_DESCRIPTION)
                     )
                     filtered_unused_imports.add((import_alias, importt))
         return tree.visit(RemoveUnusedImportsTransformer(filtered_unused_imports))

--- a/src/core_codemods/upgrade_sslcontext_tls.py
+++ b/src/core_codemods/upgrade_sslcontext_tls.py
@@ -71,7 +71,7 @@ class UpgradeSSLContextTLS(SemgrepCodemod, BaseTransformer):
         ) and self.filter_by_path_includes_or_excludes(pos_to_match):
             line_number = pos_to_match.start.line
             self.file_context.codemod_changes.append(
-                Change(str(line_number), self.CHANGE_DESCRIPTION).to_json()
+                Change(line_number, self.CHANGE_DESCRIPTION)
             )
 
             return updated_node.with_changes(

--- a/src/core_codemods/url_sandbox.py
+++ b/src/core_codemods/url_sandbox.py
@@ -57,6 +57,8 @@ class UrlSandbox(SemgrepCodemod, Codemod):
 
     METADATA_DEPENDENCIES = (PositionProvider, ScopeProvider)
 
+    adds_dependency = True
+
     def __init__(self, codemod_context: CodemodContext, *args):
         Codemod.__init__(self, codemod_context)
         SemgrepCodemod.__init__(self, *args)

--- a/src/core_codemods/url_sandbox.py
+++ b/src/core_codemods/url_sandbox.py
@@ -17,8 +17,8 @@ from codemodder.codemods.base_visitor import BaseVisitor
 from codemodder.codemods.transformations.remove_unused_imports import (
     RemoveUnusedImportsCodemod,
 )
+from codemodder.dependency import Security
 
-replacement_package = "security"
 replacement_import = "safe_requests"
 
 
@@ -74,7 +74,7 @@ class UrlSandbox(SemgrepCodemod, Codemod):
                 find_requests_visitor.changes_in_file
             )
             new_tree = tree.visit(ReplaceNodes(find_requests_visitor.nodes_to_change))
-            self.add_dependency("security==1.0.1")
+            self.add_dependency(Security)
             # if it finds any request.get(...), try to remove the imports
             if any(
                 (
@@ -84,7 +84,7 @@ class UrlSandbox(SemgrepCodemod, Codemod):
             ):
                 new_tree = AddImportsVisitor(
                     self.context,
-                    [ImportItem(replacement_package, replacement_import, None, 0)],
+                    [ImportItem(Security.name, replacement_import, None, 0)],
                 ).transform_module(new_tree)
                 new_tree = RemoveUnusedImportsCodemod(self.context).transform_module(
                     new_tree
@@ -122,7 +122,7 @@ class FindRequestCallsAndImports(BaseVisitor):
                         {
                             maybe_node: cst.ImportFrom(
                                 module=cst.parse_expression(
-                                    replacement_package + "." + replacement_import
+                                    f"{Security.name}.{replacement_import}"
                                 ),
                                 names=maybe_node.names,
                             )

--- a/src/core_codemods/url_sandbox.py
+++ b/src/core_codemods/url_sandbox.py
@@ -129,9 +129,7 @@ class FindRequestCallsAndImports(BaseVisitor):
                         }
                     )
                     self.changes_in_file.append(
-                        Change(
-                            str(line_number), UrlSandbox.CHANGE_DESCRIPTION
-                        ).to_json()
+                        Change(line_number, UrlSandbox.CHANGE_DESCRIPTION)
                     )
 
             # case req.get(...)
@@ -145,7 +143,7 @@ class FindRequestCallsAndImports(BaseVisitor):
                     }
                 )
                 self.changes_in_file.append(
-                    Change(str(line_number), UrlSandbox.CHANGE_DESCRIPTION).to_json()
+                    Change(line_number, UrlSandbox.CHANGE_DESCRIPTION)
                 )
 
     def _find_assignments(self, node: CSTNode):

--- a/src/core_codemods/use_defused_xml.py
+++ b/src/core_codemods/use_defused_xml.py
@@ -7,6 +7,7 @@ from libcst.codemod.visitors import AddImportsVisitor, RemoveImportsVisitor
 from codemodder.codemods.base_codemod import ReviewGuidance
 from codemodder.codemods.api import BaseCodemod
 from codemodder.codemods.imported_call_modifier import ImportedCallModifier
+from codemodder.dependency import DefusedXML
 
 
 class DefusedXmlModifier(ImportedCallModifier[Mapping[str, str]]):
@@ -93,6 +94,6 @@ class UseDefusedXml(BaseCodemod):
         result_tree = visitor.transform_module(tree)
         self.file_context.codemod_changes.extend(visitor.changes_in_file)
         if visitor.changes_in_file:
-            self.add_dependency("defusedxml")  # TODO: which version?
+            self.add_dependency(DefusedXML)
 
         return result_tree

--- a/src/core_codemods/use_defused_xml.py
+++ b/src/core_codemods/use_defused_xml.py
@@ -65,6 +65,8 @@ class UseDefusedXml(BaseCodemod):
         },
     ]
 
+    adds_dependency = True
+
     @cached_property
     def matching_functions(self) -> dict[str, str]:
         """Build a mapping of functions to their defusedxml imports"""

--- a/tests/codemods/base_codemod_test.py
+++ b/tests/codemods/base_codemod_test.py
@@ -10,6 +10,7 @@ from libcst.codemod import CodemodContext
 import mock
 
 from codemodder.context import CodemodExecutionContext
+from codemodder.dependency import Dependency
 from codemodder.file_context import FileContext
 from codemodder.registry import CodemodRegistry, CodemodCollection
 from codemodder.semgrep import run as semgrep_run
@@ -49,7 +50,7 @@ class BaseCodemodTest:
 
         assert output_tree.code == dedent(expected)
 
-    def assert_dependency(self, dependency: str):
+    def assert_dependency(self, dependency: Dependency):
         assert self.file_context and self.file_context.dependencies == set([dependency])
 
 

--- a/tests/codemods/test_process_creation_sandbox.py
+++ b/tests/codemods/test_process_creation_sandbox.py
@@ -1,4 +1,5 @@
 import pytest
+from codemodder.dependency import Security
 from core_codemods.process_creation_sandbox import ProcessSandbox
 from tests.codemods.base_codemod_test import BaseSemgrepCodemodTest
 
@@ -22,7 +23,7 @@ safe_command.run(subprocess.run, "echo 'hi'", shell=True)
 var = "hello"
 """
         self.run_and_assert(tmpdir, input_code, expected)
-        self.assert_dependency("security==1.0.1")
+        self.assert_dependency(Security)
 
     def test_import_alias(self, tmpdir):
         input_code = """import subprocess as sub
@@ -37,7 +38,7 @@ safe_command.run(sub.run, "echo 'hi'", shell=True)
 var = "hello"
 """
         self.run_and_assert(tmpdir, input_code, expected)
-        self.assert_dependency("security==1.0.1")
+        self.assert_dependency(Security)
 
     def test_from_subprocess(self, tmpdir):
         input_code = """from subprocess import run
@@ -52,7 +53,7 @@ safe_command.run(run, "echo 'hi'", shell=True)
 var = "hello"
 """
         self.run_and_assert(tmpdir, input_code, expected)
-        self.assert_dependency("security==1.0.1")
+        self.assert_dependency(Security)
 
     def test_subprocess_nameerror(self, tmpdir):
         input_code = """subprocess.run("echo 'hi'", shell=True)
@@ -97,7 +98,7 @@ excel
     )
     def test_other_import_untouched(self, tmpdir, input_code, expected):
         self.run_and_assert(tmpdir, input_code, expected)
-        self.assert_dependency("security==1.0.1")
+        self.assert_dependency(Security)
 
     def test_multifunctions(self, tmpdir):
         # Test that subprocess methods that aren't part of the codemod are not changed.
@@ -115,7 +116,7 @@ safe_command.run(subprocess.run, "echo 'hi'", shell=True)
 subprocess.check_output(["ls", "-l"])"""
 
         self.run_and_assert(tmpdir, input_code, expected)
-        self.assert_dependency("security==1.0.1")
+        self.assert_dependency(Security)
 
     def test_custom_run(self, tmpdir):
         input_code = """from app_funcs import run

--- a/tests/codemods/test_url_sandbox.py
+++ b/tests/codemods/test_url_sandbox.py
@@ -1,4 +1,6 @@
 import pytest
+
+from codemodder.dependency import Security
 from core_codemods.url_sandbox import UrlSandbox
 from tests.codemods.base_codemod_test import BaseSemgrepCodemodTest
 
@@ -21,7 +23,7 @@ safe_requests.get("www.google.com")
 var = "hello"
 """
         self.run_and_assert(tmpdir, input_code, expected)
-        self.assert_dependency("security==1.0.1")
+        self.assert_dependency(Security)
 
     def test_from_requests(self, tmpdir):
         input_code = """from requests import get
@@ -35,7 +37,7 @@ get("www.google.com")
 var = "hello"
 """
         self.run_and_assert(tmpdir, input_code, expected)
-        self.assert_dependency("security==1.0.1")
+        self.assert_dependency(Security)
 
     def test_requests_nameerror(self, tmpdir):
         input_code = """requests.get("www.google.com")
@@ -78,7 +80,7 @@ excel
     )
     def test_requests_other_import_untouched(self, tmpdir, input_code, expected):
         self.run_and_assert(tmpdir, input_code, expected)
-        self.assert_dependency("security==1.0.1")
+        self.assert_dependency(Security)
 
     def test_requests_multifunctions(self, tmpdir):
         # Test that `requests` import isn't removed if code uses part of the requests
@@ -96,7 +98,7 @@ safe_requests.get("www.google.com")
 requests.status_codes.codes.FORBIDDEN"""
 
         self.run_and_assert(tmpdir, input_code, expected)
-        self.assert_dependency("security==1.0.1")
+        self.assert_dependency(Security)
 
     def test_custom_get(self, tmpdir):
         input_code = """from app_funcs import get
@@ -127,7 +129,7 @@ got("www.google.com")
 var = "hello"
 """
         self.run_and_assert(tmpdir, input_code, expected)
-        self.assert_dependency("security==1.0.1")
+        self.assert_dependency(Security)
 
     def test_requests_with_alias(self, tmpdir):
         input_code = """import requests as req
@@ -141,4 +143,4 @@ safe_requests.get("www.google.com")
 var = "hello"
 """
         self.run_and_assert(tmpdir, input_code, expected)
-        self.assert_dependency("security==1.0.1")
+        self.assert_dependency(Security)

--- a/tests/codemods/test_use_defused_xml.py
+++ b/tests/codemods/test_use_defused_xml.py
@@ -1,5 +1,6 @@
 import pytest
 
+from codemodder.dependency import DefusedXML
 from core_codemods.use_defused_xml import (
     DOM_METHODS,
     ETREE_METHODS,
@@ -29,7 +30,7 @@ class TestUseDefusedXml(BaseCodemodTest):
         """
 
         self.run_and_assert(tmpdir, original_code, new_code)
-        self.assert_dependency("defusedxml")
+        self.assert_dependency(DefusedXML)
 
     @pytest.mark.parametrize("method", ETREE_METHODS)
     @pytest.mark.parametrize("module", ["ElementTree", "cElementTree"])
@@ -47,7 +48,7 @@ class TestUseDefusedXml(BaseCodemodTest):
         """
 
         self.run_and_assert(tmpdir, original_code, new_code)
-        self.assert_dependency("defusedxml")
+        self.assert_dependency(DefusedXML)
 
     def test_etree_elementtree_with_alias(self, tmpdir):
         original_code = """
@@ -63,7 +64,7 @@ class TestUseDefusedXml(BaseCodemodTest):
         """
 
         self.run_and_assert(tmpdir, original_code, new_code)
-        self.assert_dependency("defusedxml")
+        self.assert_dependency(DefusedXML)
 
     def test_etree_parse_with_alias(self, tmpdir):
         original_code = """
@@ -79,7 +80,7 @@ class TestUseDefusedXml(BaseCodemodTest):
         """
 
         self.run_and_assert(tmpdir, original_code, new_code)
-        self.assert_dependency("defusedxml")
+        self.assert_dependency(DefusedXML)
 
     @pytest.mark.parametrize("method", SAX_METHODS)
     def test_sax_simple_call(self, tmpdir, method):
@@ -96,7 +97,7 @@ class TestUseDefusedXml(BaseCodemodTest):
         """
 
         self.run_and_assert(tmpdir, original_code, new_code)
-        self.assert_dependency("defusedxml")
+        self.assert_dependency(DefusedXML)
 
     @pytest.mark.parametrize("method", SAX_METHODS)
     def test_sax_attribute_call(self, tmpdir, method):
@@ -113,7 +114,7 @@ class TestUseDefusedXml(BaseCodemodTest):
         """
 
         self.run_and_assert(tmpdir, original_code, new_code)
-        self.assert_dependency("defusedxml")
+        self.assert_dependency(DefusedXML)
 
     @pytest.mark.parametrize("method", DOM_METHODS)
     @pytest.mark.parametrize("module", ["minidom", "pulldom"])
@@ -131,4 +132,4 @@ class TestUseDefusedXml(BaseCodemodTest):
         """
 
         self.run_and_assert(tmpdir, original_code, new_code)
-        self.assert_dependency("defusedxml")
+        self.assert_dependency(DefusedXML)

--- a/tests/test_dependency_manager.py
+++ b/tests/test_dependency_manager.py
@@ -2,10 +2,8 @@ from pathlib import Path
 
 import pytest
 
-from codemodder.dependency_manager import (
-    DependencyManager,
-    Requirement,
-)
+from codemodder.dependency import DefusedXML
+from codemodder.dependency_manager import DependencyManager, Requirement
 
 
 @pytest.fixture(autouse=True, scope="module")
@@ -30,11 +28,11 @@ class TestDependencyManager:
         dependency_file.write_text(contents, encoding="utf-8")
 
         dm = DependencyManager(Path(tmpdir))
-        dm.add(["defusedxml"])
+        dm.add([DefusedXML])
         changeset = dm.write(dry_run=dry_run)
 
         assert dependency_file.read_text(encoding="utf-8") == (
-            contents if dry_run else "# comment\n\nrequests\ndefusedxml"
+            contents if dry_run else "# comment\n\nrequests\ndefusedxml~=0.7.1"
         )
 
         assert changeset is not None
@@ -46,6 +44,9 @@ class TestDependencyManager:
             " # comment\n"
             " \n"
             " requests\n"
-            "+defusedxml+\n"
+            "+defusedxml~=0.7.1+\n"
         )
-        assert changeset.changes == []
+        assert len(changeset.changes) == 1
+        assert changeset.changes[0].lineNumber == 4
+        assert changeset.changes[0].description == DefusedXML.build_description()
+        assert changeset.changes[0].properties == {"contextual_description": True}

--- a/tests/test_file_context.py
+++ b/tests/test_file_context.py
@@ -1,7 +1,7 @@
 from codemodder.file_context import FileContext
 
 
-def test_file_context():
-    file_context = FileContext(None, None, None, None)
+def test_file_context(mocker):
+    file_context = FileContext(mocker.MagicMock())
     assert file_context.line_exclude == []
     assert file_context.line_include == []


### PR DESCRIPTION
## Overview
*Add contextual comments to CodeTF when adding dependencies*

## Description

* This is used by the platform to provide context for dependency updates
* This also cleans up the JSON translation layer for `Change` and `ChangeSet`
* We also now add `packageActions`, but there are some additional changes required in order to support this properly
