### PR TITLE
Implement file-level parallelization

### DIFF
--- a/src/codemodder/cli.py
+++ b/src/codemodder/cli.py
@@ -158,6 +158,12 @@ def parse_args(argv, codemod_registry):
         default=DEFAULT_INCLUDED_PATHS,
         help="Comma-separated set of UNIX glob patterns to include",
     )
+    parser.add_argument(
+        "--max-workers",
+        type=int,
+        default=1,
+        help="maximum number of workers (threads) to use for processing files in parallel",
+    )
 
     # At this time we don't do anything with the sarif arg.
     parser.add_argument(

--- a/src/codemodder/codemods/api/__init__.py
+++ b/src/codemodder/codemods/api/__init__.py
@@ -16,7 +16,6 @@ from codemodder.codemods.base_codemod import (
 
 from codemodder.codemods.base_visitor import BaseTransformer
 from codemodder.change import Change
-from codemodder.context import CodemodExecutionContext
 from codemodder.file_context import FileContext
 from .helpers import Helpers
 
@@ -84,13 +83,8 @@ class BaseCodemod(
     BaseTransformer,
     Helpers,
 ):
-    def __init__(
-        self,
-        codemod_context: CodemodContext,
-        execution_context: CodemodExecutionContext,
-        file_context: FileContext,
-    ):
-        _BaseCodemod.__init__(self, execution_context, file_context)
+    def __init__(self, codemod_context: CodemodContext, file_context: FileContext):
+        _BaseCodemod.__init__(self, file_context)
         BaseTransformer.__init__(self, codemod_context, [])
 
     def report_change(self, original_node):
@@ -112,14 +106,9 @@ class SemgrepCodemod(
         super().__init_subclass__()
         cls.YAML_FILES = _create_temp_yaml_file(cls, cls.METADATA)
 
-    def __init__(
-        self,
-        codemod_context: CodemodContext,
-        execution_context: CodemodExecutionContext,
-        file_context: FileContext,
-    ):
-        BaseCodemod.__init__(self, codemod_context, execution_context, file_context)
-        _SemgrepCodemod.__init__(self, execution_context, file_context)
+    def __init__(self, codemod_context: CodemodContext, file_context: FileContext):
+        BaseCodemod.__init__(self, codemod_context, file_context)
+        _SemgrepCodemod.__init__(self, file_context)
         BaseTransformer.__init__(self, codemod_context, self._results)
 
     def _new_or_updated_node(self, original_node, updated_node):

--- a/src/codemodder/codemods/base_codemod.py
+++ b/src/codemodder/codemods/base_codemod.py
@@ -5,7 +5,6 @@ from typing import List, ClassVar
 from libcst._position import CodeRange
 
 from codemodder.change import Change
-from codemodder.context import CodemodExecutionContext
 from codemodder.dependency import Dependency
 from codemodder.file_context import FileContext
 from codemodder.semgrep import run as semgrep_run
@@ -46,12 +45,9 @@ class BaseCodemod:
     SUMMARY: ClassVar[str] = NotImplemented
     is_semgrep: bool = False
     adds_dependency: bool = False
-
-    execution_context: CodemodExecutionContext
     file_context: FileContext
 
-    def __init__(self, execution_context: CodemodExecutionContext, file_context):
-        self.execution_context = execution_context
+    def __init__(self, file_context: FileContext):
         self.file_context = file_context
 
     @classmethod

--- a/src/codemodder/file_context.py
+++ b/src/codemodder/file_context.py
@@ -2,22 +2,31 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Dict, List
 
-from codemodder.change import Change
+from codemodder.change import Change, ChangeSet
 from codemodder.dependency import Dependency
 
 
 @dataclass
-class FileContext:
+class FileContext:  # pylint: disable=too-many-instance-attributes
     """
     Extra context for running codemods on a given file based on the cli parameters.
     """
 
+    base_directory: Path
     file_path: Path
     line_exclude: List[int] = field(default_factory=list)
     line_include: List[int] = field(default_factory=list)
     results_by_id: Dict = field(default_factory=dict)
     dependencies: set[Dependency] = field(default_factory=set)
     codemod_changes: List[Change] = field(default_factory=list)
+    results: List[ChangeSet] = field(default_factory=list)
+    failures: List[Path] = field(default_factory=list)
 
     def add_dependency(self, dependency: Dependency):
         self.dependencies.add(dependency)
+
+    def add_result(self, result: ChangeSet):
+        self.results.append(result)
+
+    def add_failure(self, filename: Path):
+        self.failures.append(filename)

--- a/src/core_codemods/order_imports.py
+++ b/src/core_codemods/order_imports.py
@@ -42,7 +42,8 @@ class OrderImports(BaseCodemod, Codemod):
                 filtered_blocks.append(block)
         if filtered_blocks:
             order_transformer = OrderImportsBlocksTransform(
-                self.execution_context.directory, filtered_blocks
+                self.file_context.base_directory,
+                filtered_blocks,
             )
             result_tree = tree.visit(order_transformer)
 

--- a/src/core_codemods/sql_parameterization.py
+++ b/src/core_codemods/sql_parameterization.py
@@ -23,7 +23,6 @@ from codemodder.codemods.transformations.remove_empty_string_concatenation impor
 )
 from codemodder.codemods.utils import Append, ReplaceNodes, get_function_name_node
 from codemodder.codemods.utils_mixin import NameResolutionMixin
-from codemodder.context import CodemodExecutionContext
 from codemodder.file_context import FileContext
 
 parameter_token = "?"
@@ -61,14 +60,13 @@ class SQLQueryParameterization(BaseCodemod, UtilsMixin, Codemod):
     def __init__(
         self,
         context: CodemodContext,
-        execution_context: CodemodExecutionContext,
         file_context: FileContext,
         *codemod_args,
     ) -> None:
         self.changed_nodes: dict[
             cst.CSTNode, cst.CSTNode | cst.RemovalSentinel | cst.FlattenSentinel
         ] = {}
-        BaseCodemod.__init__(self, execution_context, file_context, *codemod_args)
+        BaseCodemod.__init__(self, file_context, *codemod_args)
         UtilsMixin.__init__(self, context, {})
         Codemod.__init__(self, context)
 

--- a/src/core_codemods/upgrade_sslcontext_tls.py
+++ b/src/core_codemods/upgrade_sslcontext_tls.py
@@ -7,7 +7,6 @@ from codemodder.codemods.base_codemod import (
     ReviewGuidance,
 )
 from codemodder.change import Change
-from codemodder.context import CodemodExecutionContext
 from codemodder.file_context import FileContext
 
 
@@ -43,13 +42,8 @@ class UpgradeSSLContextTLS(SemgrepCodemod, BaseTransformer):
     PROTOCOL_ARG_INDEX = 0
     PROTOCOL_KWARG_NAME = "protocol"
 
-    def __init__(
-        self,
-        codemod_context: CodemodContext,
-        execution_context: CodemodExecutionContext,
-        file_context: FileContext,
-    ):
-        SemgrepCodemod.__init__(self, execution_context, file_context)
+    def __init__(self, codemod_context: CodemodContext, file_context: FileContext):
+        SemgrepCodemod.__init__(self, file_context)
         BaseTransformer.__init__(self, codemod_context, self._results)
 
         # TODO: apply unused import remover

--- a/tests/codemods/base_codemod_test.py
+++ b/tests/codemods/base_codemod_test.py
@@ -36,6 +36,7 @@ class BaseCodemodTest:
             repo_manager=mock.MagicMock(),
         )
         self.file_context = FileContext(
+            root,
             file_path,
             [],
             [],
@@ -44,7 +45,6 @@ class BaseCodemodTest:
         wrapper = cst.MetadataWrapper(input_tree)
         command_instance = self.codemod(
             CodemodContext(wrapper=wrapper),
-            self.execution_context,
             self.file_context,
         )
         output_tree = command_instance.transform_module(input_tree)
@@ -87,6 +87,7 @@ class BaseSemgrepCodemodTest(BaseCodemodTest):
         all_results = self.results_by_id_filepath(input_code, file_path)
         results = all_results[str(file_path)]
         self.file_context = FileContext(
+            root,
             file_path,
             [],
             [],
@@ -95,7 +96,6 @@ class BaseSemgrepCodemodTest(BaseCodemodTest):
         wrapper = cst.MetadataWrapper(input_tree)
         command_instance = self.codemod(
             CodemodContext(wrapper=wrapper),
-            self.execution_context,
             self.file_context,
         )
         output_tree = command_instance.transform_module(input_tree)

--- a/tests/codemods/test_base_codemod.py
+++ b/tests/codemods/test_base_codemod.py
@@ -32,7 +32,6 @@ class TestEmptyResults:
         command_instance = DoNothingCodemod(
             CodemodContext(),
             mock.MagicMock(),
-            mock.MagicMock(),
         )
         output_tree = command_instance.transform_module(input_tree)
 

--- a/tests/test_file_context.py
+++ b/tests/test_file_context.py
@@ -2,6 +2,10 @@ from codemodder.file_context import FileContext
 
 
 def test_file_context(mocker):
-    file_context = FileContext(mocker.MagicMock())
+    directory = mocker.MagicMock()
+    path = mocker.MagicMock()
+    file_context = FileContext(directory, path)
+    assert file_context.base_directory is directory
+    assert file_context.file_path is path
     assert file_context.line_exclude == []
     assert file_context.line_include == []


### PR DESCRIPTION
## Overview
*Implement (optional) per-codemod file-level parallelization*

## Description

* This PR enables files to be processed in parallel for each codemod
* There is no parallelism _between_ codemods since we need to preserve strict ordering
* The default behavior for now is to use a single thread, so there is no difference from the previous behavior
* All per-file codemod state is now managed by `FileContext` and then aggregated at the end of each codemod pass
* This will enable us to perform testing in more resource constrained environments where more threads might be useful. In particular, we suspect that environments that are highly limited by IO bandwidth will benefit from parallelization