### PR TITLE
Fix pragma error in RemoveUnusedImports

### DIFF
--- a/src/codemodder/project_analysis/python_repo_manager.py
+++ b/src/codemodder/project_analysis/python_repo_manager.py
@@ -26,5 +26,7 @@ class PythonRepoManager:
     def _parse_all_stores(self) -> list[PackageStore]:
         discovered_pkg_stores: list[PackageStore] = []
         for store in self._potential_stores:
-            discovered_pkg_stores.extend(store(self.parent_directory).parse())
+            discovered_pkg_stores.extend(
+                store(self.parent_directory).parse()  # type: ignore
+            )
         return discovered_pkg_stores

--- a/src/core_codemods/remove_unused_imports.py
+++ b/src/core_codemods/remove_unused_imports.py
@@ -45,6 +45,9 @@ class RemoveUnusedImports(BaseCodemod, Codemod):
         BaseCodemod.__init__(self, *codemod_args)
 
     def transform_module_impl(self, tree: cst.Module) -> cst.Module:
+        # Do nothing in __init__.py files
+        if self.file_context.file_path.name == "__init__.py":
+            return tree
         gather_unused_visitor = GatherUnusedImportsVisitor(self.context)
         tree.visit(gather_unused_visitor)
         # filter the gathered imports by line excludes/includes

--- a/tests/codemods/base_codemod_test.py
+++ b/tests/codemods/base_codemod_test.py
@@ -23,7 +23,7 @@ class BaseCodemodTest:
         self.file_context = None
 
     def run_and_assert(self, tmpdir, input_code, expected):
-        tmp_file_path = tmpdir / "code.py"
+        tmp_file_path = Path(tmpdir / "code.py")
         self.run_and_assert_filepath(tmpdir, tmp_file_path, input_code, expected)
 
     def run_and_assert_filepath(self, root, file_path, input_code, expected):

--- a/tests/codemods/test_remove_unused_imports.py
+++ b/tests/codemods/test_remove_unused_imports.py
@@ -120,3 +120,15 @@ a.something
         tmp_file_path = Path(tmpdir / "__init__.py")
         self.run_and_assert_filepath(tmpdir, tmp_file_path, before, before)
         assert len(self.file_context.codemod_changes) == 0
+
+    def test_no_pyling_pragma_in_comment_trailing(self, tmpdir):
+        before = "import a # bogus: no-pragma"
+        after = ""
+        self.run_and_assert(tmpdir, before, after)
+        assert len(self.file_context.codemod_changes) == 1
+
+    def test_no_pyling_pragma_in_comment_before(self, tmpdir):
+        before = "#header\nprint('hello')\n# bogus: no-pragma\nimport a "
+        after = "#header\nprint('hello')"
+        self.run_and_assert(tmpdir, before, after)
+        assert len(self.file_context.codemod_changes) == 1

--- a/tests/codemods/test_remove_unused_imports.py
+++ b/tests/codemods/test_remove_unused_imports.py
@@ -1,3 +1,4 @@
+from pathlib import Path
 from core_codemods.remove_unused_imports import RemoveUnusedImports
 from tests.codemods.base_codemod_test import BaseCodemodTest
 from textwrap import dedent
@@ -112,4 +113,10 @@ a.something
             "import a\n#   pylint: disable-next=no-member, unused-import\nimport b\na()"
         )
         self.run_and_assert(tmpdir, before, before)
+        assert len(self.file_context.codemod_changes) == 0
+
+    def test_ignore_init_files(self, tmpdir):
+        before = "import a"
+        tmp_file_path = Path(tmpdir / "__init__.py")
+        self.run_and_assert_filepath(tmpdir, tmp_file_path, before, before)
         assert len(self.file_context.codemod_changes) == 0

--- a/tests/codemods/test_remove_unused_imports.py
+++ b/tests/codemods/test_remove_unused_imports.py
@@ -1,5 +1,6 @@
 from core_codemods.remove_unused_imports import RemoveUnusedImports
 from tests.codemods.base_codemod_test import BaseCodemodTest
+from textwrap import dedent
 
 
 class TestRemoveUnusedImports(BaseCodemodTest):
@@ -87,6 +88,17 @@ a.something
 
     def test_dont_remove_if_noqa_trailing(self, tmpdir):
         before = "import a\nimport b # noqa\na()"
+        self.run_and_assert(tmpdir, before, before)
+        assert len(self.file_context.codemod_changes) == 0
+
+    def test_dont_remove_if_noqa_trailing_multiline(self, tmpdir):
+        before = dedent(
+            """\
+        from _pytest.assertion.util import (  # noqa: F401
+            format_explanation as _format_explanation,
+        )"""
+        )
+
         self.run_and_assert(tmpdir, before, before)
         assert len(self.file_context.codemod_changes) == 0
 


### PR DESCRIPTION
## Overview
Fixes errors with pragma parsing in RemoveUnusedImports. Also added a check to ignore `__init__.py` files.

