### PR TITLE
Collect fine-grained timing data

### DIFF
--- a/src/codemodder/codemodder.py
+++ b/src/codemodder/codemodder.py
@@ -196,6 +196,13 @@ def run(original_args) -> int:
     for codemod in codemods_to_run:
         logger.info("running codemod %s", codemod.id)
         results = codemod.apply(context)
+        if codemod.is_semgrep and not results:
+            logger.debug(
+                "no results from semgrep for %s, skipping analysis",
+                codemod.id,
+            )
+            continue
+
         analyze_files(
             context,
             files_to_analyze,

--- a/src/codemodder/codemods/base_codemod.py
+++ b/src/codemodder/codemods/base_codemod.py
@@ -122,7 +122,8 @@ class SemgrepCodemod(BaseCodemod):
         Apply semgrep to gather rule results
         """
         del args, kwargs
-        return semgrep_run(context, yaml_files)
+        with context.timer.measure("semgrep"):
+            return semgrep_run(context, yaml_files)
 
     @property
     def should_transform(self):

--- a/src/codemodder/context.py
+++ b/src/codemodder/context.py
@@ -12,6 +12,7 @@ from codemodder.file_context import FileContext
 from codemodder.logging import logger, log_list
 from codemodder.registry import CodemodRegistry
 from codemodder.project_analysis.python_repo_manager import PythonRepoManager
+from codemodder.utils.timer import Timer
 
 
 DEPENDENCY_NOTIFICATION = """```
@@ -36,6 +37,7 @@ class CodemodExecutionContext:  # pylint: disable=too-many-instance-attributes
     verbose: bool = False
     registry: CodemodRegistry
     repo_manager: PythonRepoManager
+    timer: Timer
 
     def __init__(
         self,
@@ -53,6 +55,7 @@ class CodemodExecutionContext:  # pylint: disable=too-many-instance-attributes
         self.dependencies = {}
         self.registry = registry
         self.repo_manager = repo_manager
+        self.timer = Timer()
 
     def add_results(self, codemod_name: str, change_sets: List[ChangeSet]):
         self._results_by_codemod.setdefault(codemod_name, []).extend(change_sets)
@@ -112,6 +115,7 @@ class CodemodExecutionContext:  # pylint: disable=too-many-instance-attributes
             self.add_results(codemod_id, file_context.results)
             self.add_failures(codemod_id, file_context.failures)
             self.add_dependencies(codemod_id, file_context.dependencies)
+            self.timer.aggregate(file_context.timer)
 
     def compile_results(self, codemods: list[CodemodExecutorWrapper]):
         results = []

--- a/src/codemodder/file_context.py
+++ b/src/codemodder/file_context.py
@@ -4,6 +4,7 @@ from typing import Dict, List
 
 from codemodder.change import Change, ChangeSet
 from codemodder.dependency import Dependency
+from codemodder.utils.timer import Timer
 
 
 @dataclass
@@ -21,6 +22,7 @@ class FileContext:  # pylint: disable=too-many-instance-attributes
     codemod_changes: List[Change] = field(default_factory=list)
     results: List[ChangeSet] = field(default_factory=list)
     failures: List[Path] = field(default_factory=list)
+    timer: Timer = field(default_factory=Timer)
 
     def add_dependency(self, dependency: Dependency):
         self.dependencies.add(dependency)

--- a/src/codemodder/utils/timer.py
+++ b/src/codemodder/utils/timer.py
@@ -1,0 +1,31 @@
+from collections import defaultdict
+from contextlib import contextmanager
+import time
+
+from typing_extensions import Self
+
+
+class Timer:
+    _times: defaultdict
+
+    def __init__(self):
+        self._times = defaultdict(float)
+
+    @contextmanager
+    def measure(self, name: str):
+        start = time.monotonic()
+        try:
+            yield
+        finally:
+            end = time.monotonic()
+            self._add_time(name, end - start)
+
+    def _add_time(self, name: str, val: float) -> None:
+        self._times[name] = self._times.get(name, 0) + val
+
+    def get_time_ms(self, name: str) -> int:
+        return int(self._times.get(name, 0) * 1000)
+
+    def aggregate(self, other: Self) -> None:
+        for key, val in other._times.items():
+            self._add_time(key, val)


### PR DESCRIPTION
## Overview
*Collect fine-grained timing data*

## Description

* This will enable more detailed performance investigations
* Log output now looks like this:
```
[report]
scanned: 53 files
failed: 0 files (0 unique)
changed: 12 files (7 unique)
report file: output.codetf
total elapsed: 32912 ms
semgrep:       11055 ms
parse:         1681 ms
transform:     14992 ms
write:         0 ms
```