### PR TITLE
Alias detection solution for codemods

### DIFF
--- a/src/codemodder/codemods/utils_mixin.py
+++ b/src/codemodder/codemods/utils_mixin.py
@@ -86,19 +86,18 @@ class NameResolutionMixin(MetadataDependent):
                                 return (import_node, alias)
         return None
 
-    def get_aliased_prefix_name(self, node: cst.CSTNode, name: str):
+    def get_aliased_prefix_name(self, node: cst.CSTNode, name: str) -> Optional[str]:
         """
         Returns the alias of name if name is imported and used as a prefix for this node.
         """
         maybe_import = self.get_imported_prefix(node)
         maybe_name = None
-        if maybe_import:
-            imp, ia = maybe_import
-            match imp:
-                case cst.Import():
-                    imp_name = get_full_name_for_node(ia.name)
-                    if imp_name == name and ia.asname:
-                        maybe_name = ia.asname.name.value
+        if maybe_import and matchers.matches(maybe_import[0], matchers.Import()):
+            _, ia = maybe_import
+            imp_name = get_full_name_for_node(ia.name)
+            if imp_name == name and ia.asname:
+                # AsName is always a Name for ImportAlias
+                maybe_name = ia.asname.name.value
         return maybe_name
 
     def find_assignments(

--- a/src/core_codemods/harden_pyyaml.py
+++ b/src/core_codemods/harden_pyyaml.py
@@ -50,7 +50,7 @@ class HardenPyyaml(SemgrepCodemod, NameResolutionMixin):
     def on_result_found(self, original_node, updated_node):
         maybe_name = self.get_aliased_prefix_name(original_node, self._module_name)
         maybe_name = maybe_name or self._module_name
-        if maybe_name and maybe_name == self._module_name:
+        if maybe_name == self._module_name:
             self.add_needed_import(self._module_name)
         new_args = [
             *updated_node.args[:1],

--- a/src/core_codemods/harden_pyyaml.py
+++ b/src/core_codemods/harden_pyyaml.py
@@ -15,6 +15,8 @@ class HardenPyyaml(SemgrepCodemod, NameResolutionMixin):
         }
     ]
 
+    _module_name = "yaml"
+
     @classmethod
     def rule(cls):
         return """
@@ -46,12 +48,10 @@ class HardenPyyaml(SemgrepCodemod, NameResolutionMixin):
         """
 
     def on_result_found(self, original_node, updated_node):
-        maybe_name = self.find_import_alias_in_nodes_scope_from_name(
-            "yaml", original_node
-        )
-        if not maybe_name:
-            self.add_needed_import("yaml")
-        maybe_name = maybe_name or "yaml"
+        maybe_name = self.get_aliased_prefix_name(original_node, self._module_name)
+        maybe_name = maybe_name or self._module_name
+        if maybe_name and maybe_name == self._module_name:
+            self.add_needed_import(self._module_name)
         new_args = [
             *updated_node.args[:1],
             self.parse_expression(f"{maybe_name}.SafeLoader"),

--- a/src/core_codemods/tempfile_mktemp.py
+++ b/src/core_codemods/tempfile_mktemp.py
@@ -1,8 +1,9 @@
 from codemodder.codemods.base_codemod import ReviewGuidance
 from codemodder.codemods.api import SemgrepCodemod
+from codemodder.codemods.utils_mixin import NameResolutionMixin
 
 
-class TempfileMktemp(SemgrepCodemod):
+class TempfileMktemp(SemgrepCodemod, NameResolutionMixin):
     NAME = "secure-tempfile"
     REVIEW_GUIDANCE = ReviewGuidance.MERGE_WITHOUT_REVIEW
     SUMMARY = "Upgrade and Secure Temp File Creation"
@@ -13,6 +14,8 @@ class TempfileMktemp(SemgrepCodemod):
             "description": "",
         }
     ]
+
+    _module_name = "tempfile"
 
     @classmethod
     def rule(cls):
@@ -26,6 +29,9 @@ class TempfileMktemp(SemgrepCodemod):
         """
 
     def on_result_found(self, original_node, updated_node):
+        maybe_name = self.get_aliased_prefix_name(original_node, self._module_name)
+        maybe_name = maybe_name or self._module_name
+        if maybe_name and maybe_name == self._module_name:
+            self.add_needed_import(self._module_name)
         self.remove_unused_import(original_node)
-        self.add_needed_import("tempfile")
-        return self.update_call_target(updated_node, "tempfile", "mkstemp")
+        return self.update_call_target(updated_node, maybe_name, "mkstemp")

--- a/src/core_codemods/tempfile_mktemp.py
+++ b/src/core_codemods/tempfile_mktemp.py
@@ -31,7 +31,7 @@ class TempfileMktemp(SemgrepCodemod, NameResolutionMixin):
     def on_result_found(self, original_node, updated_node):
         maybe_name = self.get_aliased_prefix_name(original_node, self._module_name)
         maybe_name = maybe_name or self._module_name
-        if maybe_name and maybe_name == self._module_name:
+        if maybe_name == self._module_name:
             self.add_needed_import(self._module_name)
         self.remove_unused_import(original_node)
         return self.update_call_target(updated_node, maybe_name, "mkstemp")

--- a/src/core_codemods/upgrade_sslcontext_minimum_version.py
+++ b/src/core_codemods/upgrade_sslcontext_minimum_version.py
@@ -52,7 +52,7 @@ class UpgradeSSLContextMinimumVersion(SemgrepCodemod, NameResolutionMixin):
             original_node.value, self._module_name
         )
         maybe_name = maybe_name or self._module_name
-        if maybe_name and maybe_name == self._module_name:
+        if maybe_name == self._module_name:
             self.add_needed_import(self._module_name)
         self.remove_unused_import(original_node)
         return self.update_assign_rhs(updated_node, f"{maybe_name}.TLSVersion.TLSv1_2")

--- a/tests/codemods/test_harden_pyyaml.py
+++ b/tests/codemods/test_harden_pyyaml.py
@@ -46,7 +46,6 @@ deserialized_data = yaml.load(data, yaml.SafeLoader)
 """
         self.run_and_assert(tmpdir, input_code, expected)
 
-    @pytest.mark.skip()
     def test_import_alias(self, tmpdir):
         input_code = """import yaml as yam
 from yaml import Loader
@@ -54,8 +53,10 @@ from yaml import Loader
 data = b'!!python/object/apply:subprocess.Popen \\n- ls'
 deserialized_data = yam.load(data, Loader=Loader)
 """
-        expected = """import yaml
+        expected = """import yaml as yam
+from yaml import Loader
+
 data = b'!!python/object/apply:subprocess.Popen \\n- ls'
-deserialized_data = yaml.load(data, yaml.SafeLoader)
+deserialized_data = yam.load(data, yam.SafeLoader)
 """
         self.run_and_assert(tmpdir, input_code, expected)

--- a/tests/codemods/test_harden_ruamel.py
+++ b/tests/codemods/test_harden_ruamel.py
@@ -51,14 +51,13 @@ serializer = ruamel.yaml.YAML(typ="safe")
 """
         self.run_and_assert(tmpdir, input_code, expected)
 
-    @pytest.mark.skip()
     @pytest.mark.parametrize("loader", ["YAML(typ='base')", "YAML(typ='unsafe')"])
     def test_import_alias(self, tmpdir, loader):
         input_code = f"""from ruamel import yaml as yam
 serializer = yam.{loader}
 """
 
-        expected = """import ruamel
+        expected = """from ruamel import yaml as yam
 serializer = yam.YAML(typ="safe")
 """
 

--- a/tests/codemods/test_https_connection.py
+++ b/tests/codemods/test_https_connection.py
@@ -25,6 +25,18 @@ urllib3.HTTPSConnectionPool("localhost", "80")
         self.run_and_assert(tmpdir, before, after)
         assert len(self.file_context.codemod_changes) == 1
 
+    def test_module_alias(self, tmpdir):
+        before = r"""import urllib3 as module
+
+module.HTTPConnectionPool("localhost", "80")
+"""
+        after = r"""import urllib3 as module
+
+module.HTTPSConnectionPool("localhost", "80")
+"""
+        self.run_and_assert(tmpdir, before, after)
+        assert len(self.file_context.codemod_changes) == 1
+
     def test_alias(self, tmpdir):
         before = r"""from urllib3 import HTTPConnectionPool as something
 

--- a/tests/codemods/test_tempfile_mktemp.py
+++ b/tests/codemods/test_tempfile_mktemp.py
@@ -1,4 +1,4 @@
-import pytest
+import pytest  # pylint: disable=unused-import
 from core_codemods.tempfile_mktemp import TempfileMktemp
 from tests.codemods.base_codemod_test import BaseSemgrepCodemodTest
 
@@ -50,7 +50,6 @@ var = "hello"
 """
         self.run_and_assert(tmpdir, input_code, expected_output)
 
-    @pytest.mark.skip()
     def test_import_alias(self, tmpdir):
         input_code = """import tempfile as _tempfile
 

--- a/tests/codemods/test_tempfile_mktemp.py
+++ b/tests/codemods/test_tempfile_mktemp.py
@@ -1,4 +1,3 @@
-import pytest  # pylint: disable=unused-import
 from core_codemods.tempfile_mktemp import TempfileMktemp
 from tests.codemods.base_codemod_test import BaseSemgrepCodemodTest
 
@@ -59,6 +58,19 @@ var = "hello"
         expected_output = """import tempfile as _tempfile
 
 _tempfile.mkstemp()
+var = "hello"
+"""
+        self.run_and_assert(tmpdir, input_code, expected_output)
+
+    def test_import_method_alias(self, tmpdir):
+        input_code = """from tempfile import mktemp as get_temp_file
+
+get_temp_file()
+var = "hello"
+"""
+        expected_output = """import tempfile
+
+tempfile.mkstemp()
 var = "hello"
 """
         self.run_and_assert(tmpdir, input_code, expected_output)

--- a/tests/codemods/test_upgrade_sslcontext_minimum_version.py
+++ b/tests/codemods/test_upgrade_sslcontext_minimum_version.py
@@ -13,7 +13,7 @@ INSECURE_VERSIONS = [
 ]
 
 
-class TestUpgradeSSLContextMininumVersion(BaseSemgrepCodemodTest):
+class TestUpgradeSSLContextMinimumVersion(BaseSemgrepCodemodTest):
     codemod = UpgradeSSLContextMinimumVersion
 
     @pytest.mark.parametrize("version", INSECURE_VERSIONS)
@@ -64,10 +64,9 @@ context = whatever.SSLContext()
 context.minimum_version = whatever.TLSVersion.SSLv3
 """
         expected_output = """import ssl as whatever
-import ssl
 
 context = whatever.SSLContext()
-context.minimum_version = ssl.TLSVersion.TLSv1_2
+context.minimum_version = whatever.TLSVersion.TLSv1_2
 """
         self.run_and_assert(tmpdir, input_code, expected_output)
 

--- a/tests/codemods/test_use_defused_xml.py
+++ b/tests/codemods/test_use_defused_xml.py
@@ -33,6 +33,26 @@ class TestUseDefusedXml(BaseCodemodTest):
         self.assert_dependency(DefusedXML)
 
     @pytest.mark.parametrize("method", ETREE_METHODS)
+    def test_etree_module_alias(self, tmpdir, method):
+        original_code = f"""
+            import xml.etree.ElementTree as alias
+            import xml.etree.cElementTree as calias
+
+            et = alias.{method}('some.xml')
+            cet = calias.{method}('some.xml')
+        """
+
+        new_code = f"""
+            import defusedxml.ElementTree
+
+            et = defusedxml.ElementTree.{method}('some.xml')
+            cet = defusedxml.ElementTree.{method}('some.xml')
+        """
+
+        self.run_and_assert(tmpdir, original_code, new_code)
+        self.assert_dependency(DefusedXML)
+
+    @pytest.mark.parametrize("method", ETREE_METHODS)
     @pytest.mark.parametrize("module", ["ElementTree", "cElementTree"])
     def test_etree_attribute_call(self, tmpdir, module, method):
         original_code = f"""

--- a/tests/test_nameresolution_mixin.py
+++ b/tests/test_nameresolution_mixin.py
@@ -1,0 +1,104 @@
+import libcst as cst
+from libcst.codemod import Codemod, CodemodContext
+from codemodder.codemods.utils_mixin import NameResolutionMixin
+from textwrap import dedent
+
+
+class TestNameResolutionMixin:
+    def test_imported_prefix(self):
+        class TestCodemod(Codemod, NameResolutionMixin):
+            def transform_module_impl(self, tree: cst.Module) -> cst.Module:
+                stmt = cst.ensure_type(tree.body[-1], cst.SimpleStatementLine)
+                expr = cst.ensure_type(stmt.body[0], cst.Expr)
+                node = expr.value
+
+                maybe_name = self.get_aliased_prefix_name(node, "a.b")
+                assert maybe_name == "alias"
+                return tree
+
+        input_code = dedent(
+            """\
+        import a.b as alias
+        alias.c[0].d()
+        """
+        )
+        tree = cst.parse_module(input_code)
+        TestCodemod(CodemodContext()).transform_module(tree)
+
+    def test_no_imported_prefix(self):
+        class TestCodemod(Codemod, NameResolutionMixin):
+            def transform_module_impl(self, tree: cst.Module) -> cst.Module:
+                stmt = cst.ensure_type(tree.body[-1], cst.SimpleStatementLine)
+                expr = cst.ensure_type(stmt.body[0], cst.Expr)
+                node = expr.value
+
+                maybe_name = self.get_aliased_prefix_name(node, "a.b")
+                assert maybe_name is None
+                return tree
+
+        input_code = dedent(
+            """\
+        c[0].d()
+        """
+        )
+        tree = cst.parse_module(input_code)
+        TestCodemod(CodemodContext()).transform_module(tree)
+
+    def test_get_base_name_from_import(self):
+        class TestCodemod(Codemod, NameResolutionMixin):
+            def transform_module_impl(self, tree: cst.Module) -> cst.Module:
+                stmt = cst.ensure_type(tree.body[-1], cst.SimpleStatementLine)
+                expr = cst.ensure_type(stmt.body[0], cst.Expr)
+                node = expr.value
+
+                maybe_name = self.find_base_name(node.func)
+                assert maybe_name == "sys.executable.capitalize"
+                return tree
+
+        input_code = dedent(
+            """\
+        from sys import executable as exec
+        exec.capitalize()
+        """
+        )
+        tree = cst.parse_module(input_code)
+        TestCodemod(CodemodContext()).transform_module(tree)
+
+    def test_get_base_name_import(self):
+        class TestCodemod(Codemod, NameResolutionMixin):
+            def transform_module_impl(self, tree: cst.Module) -> cst.Module:
+                stmt = cst.ensure_type(tree.body[-1], cst.SimpleStatementLine)
+                expr = cst.ensure_type(stmt.body[0], cst.Expr)
+                node = expr.value
+
+                maybe_name = self.find_base_name(node.func)
+                assert maybe_name == "sys.executable.capitalize"
+                return tree
+
+        input_code = dedent(
+            """\
+        import sys.executable as exec
+        exec.capitalize()
+        """
+        )
+        tree = cst.parse_module(input_code)
+        TestCodemod(CodemodContext()).transform_module(tree)
+
+    def test_get_base_name_no_import(self):
+        class TestCodemod(Codemod, NameResolutionMixin):
+            def transform_module_impl(self, tree: cst.Module) -> cst.Module:
+                stmt = cst.ensure_type(tree.body[-1], cst.SimpleStatementLine)
+                expr = cst.ensure_type(stmt.body[0], cst.Expr)
+                node = expr.value
+
+                maybe_name = self.find_base_name(node.func)
+                assert maybe_name == "exec.capitalize"
+                return tree
+
+        input_code = dedent(
+            """\
+        exec.capitalize()
+        """
+        )
+        tree = cst.parse_module(input_code)
+        TestCodemod(CodemodContext()).transform_module(tree)


### PR DESCRIPTION
## Overview
Added new alias detection solution for a few codemods.

## Description
Added new alias detection solution for a few codemods (`harden-pyyaml`, `secure-tempfile`, and `upgrade-ssl-context-minimum-version`). This solution will detect whenever a module is aliased and prefer to use the alias for new references to module attributes. Those use a more general tool now included in `NameResolutionMixin`.

The `harden-ruamel` and `https-connection` codemods had  working solutions. I've enabled / added new tests for these.

Other codemods (`url-sandbox`, `use-defusedxml`) will replace module calls with another call from a drop-in replacement module. 
Those will ignore aliases and refer to the replacement module call directly. Since we are referring a third-party module on those, I've elected not to leave the current solution to make the change more explicit.