### PR TITLE
Only run semgrep for codemods with initial results

### DIFF
--- a/src/codemodder/sarifs.py
+++ b/src/codemodder/sarifs.py
@@ -1,7 +1,6 @@
 from collections import defaultdict
 import json
-from pathlib import Path
-from typing import List, Union
+from typing import Union
 
 
 def extract_rule_id(result, sarif_run) -> Union[str, None]:
@@ -43,15 +42,3 @@ def results_by_path_and_rule_id(sarif_file):
                     rule_id_dict.setdefault(rule_id, []).append(r)
             path_and_ruleid_dict[path].update(rule_id_dict)
     return path_and_ruleid_dict
-
-
-def parse_sarif_files(sarifs: List[Path]) -> defaultdict[str, defaultdict[str, List]]:
-    """
-    Parse sarif files organize their results into a dict of dicts organized by path and id.
-    """
-    path_id_dict: defaultdict[str, defaultdict[str, List]] = defaultdict(
-        lambda: defaultdict(list)
-    )
-    for path in sarifs:
-        path_id_dict.update(results_by_path_and_rule_id(Path(path)))
-    return path_id_dict

--- a/src/codemodder/semgrep.py
+++ b/src/codemodder/semgrep.py
@@ -1,14 +1,14 @@
 import subprocess
 import itertools
 from tempfile import NamedTemporaryFile
-from typing import List
+from typing import Iterable
 from pathlib import Path
 from codemodder.context import CodemodExecutionContext
 from codemodder.sarifs import results_by_path_and_rule_id
 from codemodder.logging import logger
 
 
-def run(execution_context: CodemodExecutionContext, yaml_files: List[Path]) -> dict:
+def run(execution_context: CodemodExecutionContext, yaml_files: Iterable[Path]) -> dict:
     """
     Runs Semgrep and outputs a dict with the results organized by rule_id.
     """


### PR DESCRIPTION
## Overview
*Only run semgrep for codemods with initial results*

## Description

* This is an optimization that is intended to reduce runtime for the case where many/all codemods are requested
* The idea is to run semgrep once up-front to gather a list of applicable codemods and then to only run semgrep for those codemods that were identified in the initial pass
* There are further optimizations available here but this is a simple change intended to improve performance for this particular case
* Unfortunately this comes at the expense of doubling the semgrep cost of running a single codemod. We will address this later as it is not currently the bottleneck in performance.
