### PR TITLE
Fix case where no semgrep codemods are available

### DIFF
--- a/src/codemodder/codemodder.py
+++ b/src/codemodder/codemodder.py
@@ -36,9 +36,14 @@ def find_semgrep_results(
     codemods: list[CodemodExecutorWrapper],
 ) -> set[str]:
     """Run semgrep once with all configuration files from all codemods and return a set of applicable rule IDs"""
-    yaml_files = itertools.chain.from_iterable(
-        [codemod.yaml_files for codemod in codemods if codemod.yaml_files]
+    yaml_files = list(
+        itertools.chain.from_iterable(
+            [codemod.yaml_files for codemod in codemods if codemod.yaml_files]
+        )
     )
+    if not yaml_files:
+        return set()
+
     results = run_semgrep(context, yaml_files)
     return {rule_id for file_changes in results.values() for rule_id in file_changes}
 

--- a/tests/test_codemodder.py
+++ b/tests/test_codemodder.py
@@ -1,6 +1,6 @@
 import mock
 import pytest
-from codemodder.codemodder import run
+from codemodder.codemodder import run, find_semgrep_results
 from codemodder.semgrep import run as semgrep_run
 from codemodder.registry import load_registered_codemods
 
@@ -174,3 +174,18 @@ class TestExitCode:
         with pytest.raises(SystemExit) as err:
             run(args)
         assert err.value.args[0] == 3
+
+    def test_find_semgrep_results(self, mocker):
+        run_semgrep = mocker.patch("codemodder.codemodder.run_semgrep")
+        codemods = load_registered_codemods()
+        find_semgrep_results(mocker.MagicMock(), codemods.codemods)
+        assert run_semgrep.call_count == 1
+
+    def test_find_semgrep_results_no_yaml(self, mocker):
+        run_semgrep = mocker.patch("codemodder.codemodder.run_semgrep")
+        codemods = load_registered_codemods().match_codemods(
+            codemod_include=["use-defusedxml"]
+        )
+        result = find_semgrep_results(mocker.MagicMock(), codemods)
+        assert result == set()
+        assert run_semgrep.call_count == 0


### PR DESCRIPTION
## Overview
*Fix bug introduced in #107*

## Description

* Previous PR introduced a bug when codemodder runs with no semgrep-enabled codemods
