### PR TITLE
Use setuptools_scm to implement tag-based versioning

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -2,6 +2,7 @@
 source = codemodder
 omit =
     */codemodder/scripts/*
+    */codemodder/_version.py
 
 [paths]
 codemodder =

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -31,7 +31,7 @@ jobs:
       - name: Install Dependencies
         run: pip install -r requirements/lint.txt
       - name: Black Format Check
-        run: black --check . --exclude samples/
+        run: black --check .
       - name: Run pylint
         run: make lint
 

--- a/.gitignore
+++ b/.gitignore
@@ -134,3 +134,6 @@ dmypy.json
 # CodeTF and sarif files
 *.codetf*
 *.sarif
+
+# version
+src/codemodder/_version.py

--- a/integration_tests/base_test.py
+++ b/integration_tests/base_test.py
@@ -5,7 +5,7 @@ import os
 import pathlib
 import subprocess
 
-from codemodder import __VERSION__
+from codemodder import __version__
 from codemodder import registry
 from tests.validations import execute_code
 
@@ -70,7 +70,7 @@ class BaseIntegrationTest(DependencyTestMixin, CleanRepoMixin):
     def _assert_run_fields(self, run, output_path):
         assert run["vendor"] == "pixee"
         assert run["tool"] == "codemodder-python"
-        assert run["version"] == __VERSION__
+        assert run["version"] == __version__
         assert run["elapsed"] != ""
         assert (
             run["commandLine"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,10 +1,10 @@
 [build-system]
-requires = ["setuptools"]
+requires = ["setuptools", "setuptools_scm>=8"]
 build-backend = "setuptools.build_meta"
 
 [project]
+dynamic = ["version"]
 name = "codemodder-python"
-version = "0.60.0"
 requires-python = ">=3.10.0"
 readme = "README.md"
 license = {file = "LICENSE"}
@@ -33,6 +33,9 @@ core = "core_codemods:registry"
 [tool.setuptools.package-data]
 "core_codemods.semgrep" = ["src/core_codemods/semgrep/*.yaml"]
 "core_codemods.docs" = ["src/core_codemods/docs/*.md"]
+
+[tool.setuptools_scm]
+version_file = "src/codemodder/_version.py"
 
 [tool.pytest.ini_options]
 # Ignore integration tests and ci tests by default

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,3 +40,11 @@ version_file = "src/codemodder/_version.py"
 [tool.pytest.ini_options]
 # Ignore integration tests and ci tests by default
 testpaths = ["tests"]
+
+[tool.black]
+extend-exclude = '''
+/(
+  tests/samples |
+  src/codemodder/_version.py
+)/
+'''

--- a/src/codemodder/__init__.py
+++ b/src/codemodder/__init__.py
@@ -1,2 +1,4 @@
-# TODO: use tag-based versioning
-__VERSION__ = "0.57.0"
+try:
+    from ._version import __version__
+except ImportError:  # pragma: no cover
+    __version__ = "unknown"

--- a/src/codemodder/cli.py
+++ b/src/codemodder/cli.py
@@ -1,7 +1,7 @@
 import argparse
 import sys
 
-from codemodder import __VERSION__
+from codemodder import __version__
 from codemodder.code_directory import DEFAULT_INCLUDED_PATHS, DEFAULT_EXCLUDED_PATHS
 from codemodder.logging import OutputFormat, logger
 
@@ -111,7 +111,7 @@ def parse_args(argv, codemod_registry):
         help="Comma-separated set of codemod ID(s) to include",
     )
 
-    parser.add_argument("--version", action="version", version=__VERSION__)
+    parser.add_argument("--version", action="version", version=__version__)
     parser.add_argument(
         "--list",
         action=build_list_action(codemod_registry),

--- a/src/codemodder/codemodder.py
+++ b/src/codemodder/codemodder.py
@@ -11,7 +11,7 @@ import libcst as cst
 from libcst.codemod import CodemodContext
 from codemodder.file_context import FileContext
 
-from codemodder import registry, __VERSION__
+from codemodder import registry, __version__
 from codemodder.logging import configure_logger, logger, log_section, log_list
 from codemodder.cli import parse_args
 from codemodder.change import ChangeSet
@@ -176,7 +176,7 @@ def run(original_args) -> int:
     configure_logger(argv.verbose, argv.log_format, argv.project_name)
 
     log_section("startup")
-    logger.info("codemodder: python/%s", __VERSION__)
+    logger.info("codemodder: python/%s", __version__)
 
     repo_manager = PythonRepoManager(Path(argv.directory))
     context = CodemodExecutionContext(

--- a/src/codemodder/report/codetf_reporter.py
+++ b/src/codemodder/report/codetf_reporter.py
@@ -1,6 +1,6 @@
 import json
 from os.path import abspath
-from codemodder import __VERSION__
+from codemodder import __version__
 from codemodder.logging import logger
 
 
@@ -9,7 +9,7 @@ def base_report():
         "run": {
             "vendor": "pixee",
             "tool": "codemodder-python",
-            "version": __VERSION__,
+            "version": __version__,
             "sarifs": [],
         },
         "results": [],

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -2,7 +2,7 @@ import mock
 import pytest
 
 from codemodder.cli import parse_args
-from codemodder import __VERSION__
+from codemodder import __version__
 from codemodder.registry import load_registered_codemods
 
 
@@ -61,7 +61,7 @@ class TestParseArgs:
         with pytest.raises(SystemExit) as err:
             parse_args(cli_args, self.registry)
 
-        assert mock_print_msg.call_args_list[0][0][0].strip() == __VERSION__
+        assert mock_print_msg.call_args_list[0][0][0].strip() == __version__
         assert err.value.args[0] == 0
 
     @pytest.mark.parametrize(

--- a/tests/test_version.py
+++ b/tests/test_version.py
@@ -1,0 +1,5 @@
+from codemodder import __version__
+
+
+def test_version():
+    assert __version__ != "unknown"


### PR DESCRIPTION
## Overview
*Use `setuptools_scm` to implement tag-based versioning*

## Description
* This is the first step towards supporting tag-based releases (to PyPI)
