### PR TITLE
Dependency manager: handle missing terminating newline

### DIFF
--- a/src/codemodder/dependency_manager.py
+++ b/src/codemodder/dependency_manager.py
@@ -57,6 +57,9 @@ class DependencyManager:
         if not dry_run:
             with open(self.dependency_file, "w", encoding="utf-8") as f:
                 f.writelines(self._lines)
+                if not self._lines[-1].endswith("\n"):
+                    f.write("\n")
+
                 f.writelines([f"{line}\n" for line in self.new_requirements])
 
         self.dependency_file_changed = True

--- a/tests/test_dependency_manager.py
+++ b/tests/test_dependency_manager.py
@@ -89,3 +89,15 @@ class TestDependencyManager:
         assert dependency_file.read_text(encoding="utf-8") == (
             f"requests\nsecurity~={version}\n"
         )
+
+    def test_dependency_file_no_terminating_newline(self, tmpdir):
+        dependency_file = Path(tmpdir) / "requirements.txt"
+        dependency_file.write_text("requests\nwhatever", encoding="utf-8")
+
+        dm = DependencyManager(Path(tmpdir))
+        dm.add([Security])
+        dm.write()
+
+        assert dependency_file.read_text(encoding="utf-8") == (
+            "requests\nwhatever\nsecurity~=1.2.0\n"
+        )


### PR DESCRIPTION
## Overview
*Properly handle the case when the original `requirements.txt` file does not have a terminating newline*
