### PR TITLE
Use tag-based release to publish to AWS

### DIFF
--- a/.github/workflows/image_to_aws.yml
+++ b/.github/workflows/image_to_aws.yml
@@ -4,7 +4,9 @@ env:
   AWS_REGION: 'us-east-1'
 
 on:
-  workflow_dispatch:
+  push:
+    tags:
+      - "[0-9]+.[0-9]+.[0-9]+"
 
 jobs:
   push:


### PR DESCRIPTION
## Overview
*Enable tag-based releases for publishing docker to AWS*

## Description

* Eventually this step will trigger a deployment to PyPI
* For now this will ensure that every release to AWS is associated with a new version