### PR TITLE
Filter semgrep results based on initial findings

### DIFF
--- a/src/codemodder/codemods/api/__init__.py
+++ b/src/codemodder/codemods/api/__init__.py
@@ -109,7 +109,7 @@ class SemgrepCodemod(
     def __init__(self, codemod_context: CodemodContext, file_context: FileContext):
         BaseCodemod.__init__(self, codemod_context, file_context)
         _SemgrepCodemod.__init__(self, file_context)
-        BaseTransformer.__init__(self, codemod_context, self._results)
+        BaseTransformer.__init__(self, codemod_context, file_context.findings)
 
     def _new_or_updated_node(self, original_node, updated_node):
         if self.node_is_selected(original_node):

--- a/src/codemodder/codemods/base_codemod.py
+++ b/src/codemodder/codemods/base_codemod.py
@@ -112,8 +112,9 @@ class SemgrepCodemod(BaseCodemod):
         Apply semgrep to gather rule results
         """
         yaml_files = kwargs.get("yaml_files") or args[0]
+        files_to_analyze = kwargs.get("files_to_analyze") or args[1]
         with context.timer.measure("semgrep"):
-            return semgrep_run(context, yaml_files)
+            return semgrep_run(context, yaml_files, files_to_analyze)
 
     @property
     def should_transform(self):

--- a/src/codemodder/executor.py
+++ b/src/codemodder/executor.py
@@ -1,4 +1,5 @@
 from importlib.abc import Traversable
+from pathlib import Path
 
 from wrapt import CallableObjectProxy
 
@@ -22,13 +23,17 @@ class CodemodExecutorWrapper(CallableObjectProxy):
         self.docs_module = docs_module
         self.semgrep_config_module = semgrep_config_module
 
-    def apply(self, context):
+    def apply(self, context, files: list[Path]):
         """
         Wraps the codemod's apply method to inject additional arguments.
 
         Not all codemods will need these arguments.
         """
-        return self.apply_rule(context, yaml_files=self.yaml_files)
+        return self.apply_rule(
+            context,
+            yaml_files=self.yaml_files,
+            files_to_analyze=files,
+        )
 
     @property
     def name(self):

--- a/src/codemodder/file_context.py
+++ b/src/codemodder/file_context.py
@@ -1,9 +1,10 @@
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Dict, List
+from typing import List
 
 from codemodder.change import Change, ChangeSet
 from codemodder.dependency import Dependency
+from codemodder.result import Result
 from codemodder.utils.timer import Timer
 
 
@@ -17,7 +18,7 @@ class FileContext:  # pylint: disable=too-many-instance-attributes
     file_path: Path
     line_exclude: List[int] = field(default_factory=list)
     line_include: List[int] = field(default_factory=list)
-    results_by_id: Dict = field(default_factory=dict)
+    findings: List[Result] = field(default_factory=list)
     dependencies: set[Dependency] = field(default_factory=set)
     codemod_changes: List[Change] = field(default_factory=list)
     results: List[ChangeSet] = field(default_factory=list)

--- a/src/codemodder/result.py
+++ b/src/codemodder/result.py
@@ -34,13 +34,16 @@ class Result(ABCDataclass):
     locations: list[Location]
 
 
-class ResultSet(dict[str, list[Result]]):
+class ResultSet(dict[str, dict[Path, list[Result]]]):
     def add_result(self, result: Result):
-        self.setdefault(result.rule_id, []).append(result)
+        for loc in result.locations:
+            self.setdefault(result.rule_id, {}).setdefault(loc.file, []).append(result)
 
     def results_for_rule_and_file(self, rule_id: str, file: Path) -> list[Result]:
-        return [
-            result
-            for result in self.get(rule_id, [])
-            if result.locations[0].file == file
-        ]
+        return self.get(rule_id, {}).get(file, [])
+
+    def files_for_rule(self, rule_id: str) -> list[Path]:
+        return list(self.get(rule_id, {}).keys())
+
+    def all_rule_ids(self) -> list[str]:
+        return list(self.keys())

--- a/src/codemodder/sarifs.py
+++ b/src/codemodder/sarifs.py
@@ -1,9 +1,13 @@
-from collections import defaultdict
 import json
-from typing import Union
+from pathlib import Path
+from typing import Optional
+
+from typing_extensions import Self
+
+from .result import ResultSet, Result, Location, LineInfo
 
 
-def extract_rule_id(result, sarif_run) -> Union[str, None]:
+def extract_rule_id(result, sarif_run) -> Optional[str]:
     if "ruleId" in result:
         # semgrep preprends the folders into the rule-id, we want the base name only
         return result["ruleId"].rsplit(".")[-1]
@@ -17,28 +21,48 @@ def extract_rule_id(result, sarif_run) -> Union[str, None]:
     return None
 
 
-def results_by_path_and_rule_id(sarif_file):
-    """
-    Extract all the results of a sarif file and organize them by id.
-    """
-    with open(sarif_file, "r", encoding="utf-8") as f:
-        data = json.load(f)
+class SarifLocation(Location):
+    @classmethod
+    def from_sarif(cls, sarif_location) -> Self:
+        artifact_location = sarif_location["physicalLocation"]["artifactLocation"]
+        file = Path(artifact_location["uri"])
+        start = LineInfo(
+            line=sarif_location["physicalLocation"]["region"]["startLine"],
+            column=sarif_location["physicalLocation"]["region"]["startColumn"],
+            snippet=sarif_location["physicalLocation"]["region"]["snippet"]["text"],
+        )
+        end = LineInfo(
+            line=sarif_location["physicalLocation"]["region"]["endLine"],
+            column=sarif_location["physicalLocation"]["region"]["endColumn"],
+            snippet=sarif_location["physicalLocation"]["region"]["snippet"]["text"],
+        )
+        return cls(file=file, start=start, end=end)
 
-    path_and_ruleid_dict = defaultdict(lambda: defaultdict(list))
-    for sarif_run in data["runs"]:
-        results = sarif_run["results"]
 
-        path_dict = defaultdict(list)
-        for r in results:
-            path = r["locations"][0]["physicalLocation"]["artifactLocation"]["uri"]
-            path_dict.setdefault(path, []).append(r)
+class SarifResult(Result):
+    @classmethod
+    def from_sarif(cls, sarif_result, sarif_run) -> Self:
+        rule_id = extract_rule_id(sarif_result, sarif_run)
+        if not rule_id:
+            raise ValueError("Could not extract rule id from sarif result.")
 
-        for path in path_dict.keys():
-            rule_id_dict = defaultdict(list)
-            for r in path_dict.get(path):
-                # semgrep preprends the folders into the rule-id, we want the base name only
-                rule_id = extract_rule_id(r, sarif_run)
-                if rule_id:
-                    rule_id_dict.setdefault(rule_id, []).append(r)
-            path_and_ruleid_dict[path].update(rule_id_dict)
-    return path_and_ruleid_dict
+        locations: list[Location] = []
+        for location in sarif_result["locations"]:
+            artifact_location = SarifLocation.from_sarif(location)
+            locations.append(artifact_location)
+        return cls(rule_id=rule_id, locations=locations)
+
+
+class SarifResultSet(ResultSet):
+    @classmethod
+    def from_sarif(cls, sarif_file: str | Path) -> Self:
+        with open(sarif_file, "r", encoding="utf-8") as f:
+            data = json.load(f)
+
+        result_set = cls()
+        for sarif_run in data["runs"]:
+            for result in sarif_run["results"]:
+                sarif_result = SarifResult.from_sarif(result, sarif_run)
+                result_set.add_result(sarif_result)
+
+        return result_set

--- a/src/codemodder/semgrep.py
+++ b/src/codemodder/semgrep.py
@@ -1,7 +1,7 @@
 import subprocess
 import itertools
 from tempfile import NamedTemporaryFile
-from typing import Iterable
+from typing import Iterable, Optional
 from pathlib import Path
 from codemodder.context import CodemodExecutionContext
 from codemodder.sarifs import SarifResultSet
@@ -11,6 +11,7 @@ from codemodder.logging import logger
 def run(
     execution_context: CodemodExecutionContext,
     yaml_files: Iterable[Path],
+    files_to_analyze: Optional[Iterable[Path]] = None,
 ) -> SarifResultSet:
     """
     Runs Semgrep and outputs a dict with the results organized by rule_id.
@@ -34,7 +35,7 @@ def run(
                 map(lambda f: ["--config", str(f)], yaml_files)
             )
         )
-        command.append(str(execution_context.directory))
+        command.extend(map(str, files_to_analyze or [execution_context.directory]))
         logger.debug("semgrep command: `%s`", " ".join(command))
         subprocess.run(
             command,

--- a/src/codemodder/semgrep.py
+++ b/src/codemodder/semgrep.py
@@ -4,11 +4,14 @@ from tempfile import NamedTemporaryFile
 from typing import Iterable
 from pathlib import Path
 from codemodder.context import CodemodExecutionContext
-from codemodder.sarifs import results_by_path_and_rule_id
+from codemodder.sarifs import SarifResultSet
 from codemodder.logging import logger
 
 
-def run(execution_context: CodemodExecutionContext, yaml_files: Iterable[Path]) -> dict:
+def run(
+    execution_context: CodemodExecutionContext,
+    yaml_files: Iterable[Path],
+) -> SarifResultSet:
     """
     Runs Semgrep and outputs a dict with the results organized by rule_id.
     """
@@ -40,5 +43,5 @@ def run(execution_context: CodemodExecutionContext, yaml_files: Iterable[Path]) 
             stdout=None if execution_context.verbose else subprocess.PIPE,
             stderr=None if execution_context.verbose else subprocess.PIPE,
         )
-        results = results_by_path_and_rule_id(temp_sarif_file.name)
+        results = SarifResultSet.from_sarif(temp_sarif_file.name)
         return results

--- a/src/codemodder/utils/abc_dataclass.py
+++ b/src/codemodder/utils/abc_dataclass.py
@@ -1,0 +1,13 @@
+from abc import ABC
+from dataclasses import dataclass
+
+
+@dataclass
+class ABCDataclass(ABC):
+    """Inspired by https://stackoverflow.com/a/60669138"""
+
+    def __new__(cls, *args, **kwargs):
+        del args, kwargs
+        if cls == ABCDataclass or cls.__bases__[0] == ABCDataclass:
+            raise TypeError("Cannot instantiate abstract class.")
+        return super().__new__(cls)

--- a/src/core_codemods/django_debug_flag_on.py
+++ b/src/core_codemods/django_debug_flag_on.py
@@ -45,7 +45,7 @@ class DjangoDebugFlagOn(SemgrepCodemod, Codemod):
         # checks if the file we looking is a settings.py file from django's default directory structure
         if is_django_settings_file(self.file_context.file_path):
             debug_flag_transformer = DebugFlagTransformer(
-                self.context, self.file_context, self._results
+                self.context, self.file_context, self.file_context.findings
             )
             new_tree = debug_flag_transformer.transform_module(tree)
             if debug_flag_transformer.changes_in_file:

--- a/src/core_codemods/django_session_cookie_secure_off.py
+++ b/src/core_codemods/django_session_cookie_secure_off.py
@@ -44,7 +44,7 @@ class DjangoSessionCookieSecureOff(SemgrepCodemod, Codemod):
     def transform_module_impl(self, tree: cst.Module) -> cst.Module:
         if is_django_settings_file(self.file_context.file_path):
             transformer = SessionCookieSecureTransformer(
-                self.context, self.file_context, self._results
+                self.context, self.file_context, self.file_context.findings
             )
             new_tree = transformer.transform_module(tree)
             if transformer.changes_in_file:

--- a/src/core_codemods/sql_parameterization.py
+++ b/src/core_codemods/sql_parameterization.py
@@ -67,7 +67,7 @@ class SQLQueryParameterization(BaseCodemod, UtilsMixin, Codemod):
             cst.CSTNode, cst.CSTNode | cst.RemovalSentinel | cst.FlattenSentinel
         ] = {}
         BaseCodemod.__init__(self, file_context, *codemod_args)
-        UtilsMixin.__init__(self, context, {})
+        UtilsMixin.__init__(self, [])
         Codemod.__init__(self, context)
 
     def _build_param_element(self, middle, index: int) -> cst.BaseExpression:

--- a/src/core_codemods/url_sandbox.py
+++ b/src/core_codemods/url_sandbox.py
@@ -66,7 +66,9 @@ class UrlSandbox(SemgrepCodemod, Codemod):
     def transform_module_impl(self, tree: cst.Module) -> cst.Module:
         # we first gather all the nodes we want to change together with their replacements
         find_requests_visitor = FindRequestCallsAndImports(
-            self.context, self.file_context, self._results
+            self.context,
+            self.file_context,
+            self.file_context.findings,
         )
         tree.visit(find_requests_visitor)
         if find_requests_visitor.nodes_to_change:

--- a/tests/codemods/base_codemod_test.py
+++ b/tests/codemods/base_codemod_test.py
@@ -1,5 +1,4 @@
 # pylint: disable=no-member,not-callable,attribute-defined-outside-init
-from collections import defaultdict
 import os
 from pathlib import Path
 from textwrap import dedent
@@ -40,7 +39,7 @@ class BaseCodemodTest:
             file_path,
             [],
             [],
-            defaultdict(list),
+            [],
         )
         wrapper = cst.MetadataWrapper(input_tree)
         command_instance = self.codemod(
@@ -85,7 +84,12 @@ class BaseSemgrepCodemodTest(BaseCodemodTest):
         )
         input_tree = cst.parse_module(input_code)
         all_results = self.results_by_id_filepath(input_code, file_path)
-        results = all_results[str(file_path)]
+        results = [
+            result
+            for entry in all_results.values()
+            for result in entry
+            if result.rule_id == self.codemod.name()
+        ]
         self.file_context = FileContext(
             root,
             file_path,

--- a/tests/codemods/base_codemod_test.py
+++ b/tests/codemods/base_codemod_test.py
@@ -84,12 +84,7 @@ class BaseSemgrepCodemodTest(BaseCodemodTest):
         )
         input_tree = cst.parse_module(input_code)
         all_results = self.results_by_id_filepath(input_code, file_path)
-        results = [
-            result
-            for entry in all_results.values()
-            for result in entry
-            if result.rule_id == self.codemod.name()
-        ]
+        results = all_results.results_for_rule_and_file(self.codemod.name(), file_path)
         self.file_context = FileContext(
             root,
             file_path,

--- a/tests/test_codemodder.py
+++ b/tests/test_codemodder.py
@@ -6,6 +6,7 @@ import libcst as cst
 from codemodder.codemodder import create_diff, run, find_semgrep_results
 from codemodder.semgrep import run as semgrep_run
 from codemodder.registry import load_registered_codemods
+from codemodder.result import ResultSet
 
 
 class TestRun:
@@ -190,7 +191,7 @@ class TestExitCode:
             codemod_include=["use-defusedxml"]
         )
         result = find_semgrep_results(mocker.MagicMock(), codemods)
-        assert result == set()
+        assert result == ResultSet()
         assert run_semgrep.call_count == 0
 
     def test_diff_newline_edge_case(self):

--- a/tests/test_sarif_processing.py
+++ b/tests/test_sarif_processing.py
@@ -1,5 +1,5 @@
 from codemodder.sarifs import extract_rule_id
-from codemodder.sarifs import results_by_path_and_rule_id
+from codemodder.sarifs import SarifResultSet
 from pathlib import Path
 import subprocess
 import json
@@ -28,16 +28,15 @@ class TestSarifProcessing:
         rule_id = extract_rule_id(result, sarif_run)
         assert rule_id == "secure-random"
 
-    def test_results_by_path_and_rule_id(self):
+    def test_results_by_rule_id(self):
         sarif_file = Path("tests") / "samples" / "semgrep.sarif"
 
-        results = results_by_path_and_rule_id(sarif_file)
-        expected_path = "tests/samples/insecure_random.py"
-        assert list(results.keys()) == [expected_path]
-
+        results = SarifResultSet.from_sarif(sarif_file)
         expected_rule = "secure-random"
-        rule_in_path = next(iter(results[expected_path].keys()))
-        assert expected_rule == rule_in_path
+        assert list(results.keys()) == [expected_rule]
+
+        expected_path = Path("tests/samples/insecure_random.py")
+        assert expected_path == results[expected_rule][0].locations[0].file
 
     def test_codeql_sarif_input(self, tmpdir):
         completed_process = subprocess.run(

--- a/tests/test_sarif_processing.py
+++ b/tests/test_sarif_processing.py
@@ -36,7 +36,12 @@ class TestSarifProcessing:
         assert list(results.keys()) == [expected_rule]
 
         expected_path = Path("tests/samples/insecure_random.py")
-        assert expected_path == results[expected_rule][0].locations[0].file
+        assert list(results[expected_rule].keys()) == [expected_path]
+
+        assert results[expected_rule][expected_path][0].rule_id == expected_rule
+        assert (
+            results[expected_rule][expected_path][0].locations[0].file == expected_path
+        )
 
     def test_codeql_sarif_input(self, tmpdir):
         completed_process = subprocess.run(


### PR DESCRIPTION
## Overview
*Only run semgrep on files that have findings from initial run*

## Description

* This is an optimization designed to make semgrep faster by limiting the number of files it analyzes
  * This is motivated by the fact that semgrep execution is our long pole in certain environments
* Only files that have findings from the initial "discovery" run will be considered for further analysis
* In order to enable this change I made some changes to the structure of processed sarif results