### PR TITLE
Work around bug in difflib

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -9,7 +9,8 @@ repos:
         exclude: |
           (?x)^(
               src/core_codemods/docs/.*|
-              integration_tests/.*
+              integration_tests/.*|
+              tests/test_codemodder.py
           )$
     -   id: check-added-large-files
 -   repo: https://github.com/psf/black

--- a/src/codemodder/codemodder.py
+++ b/src/codemodder/codemodder.py
@@ -48,6 +48,21 @@ def find_semgrep_results(
     return {rule_id for file_changes in results.values() for rule_id in file_changes}
 
 
+def create_diff(original_tree: cst.Module, new_tree: cst.Module) -> str:
+    diff_lines = list(
+        difflib.unified_diff(
+            original_tree.code.splitlines(keepends=True),
+            new_tree.code.splitlines(keepends=True),
+        )
+    )
+    # All but the last diff line should end with a newline
+    # The last diff line should be preserved as-is (with or without a newline)
+    diff_lines = [
+        line if line.endswith("\n") else line + "\n" for line in diff_lines[:-1]
+    ] + [diff_lines[-1]]
+    return "".join(diff_lines)
+
+
 def apply_codemod_to_file(
     base_directory: Path,
     file_context,
@@ -68,12 +83,7 @@ def apply_codemod_to_file(
     if output_tree.deep_equals(source_tree):
         return False
 
-    diff = "".join(
-        difflib.unified_diff(
-            source_tree.code.splitlines(1), output_tree.code.splitlines(1)
-        )
-    )
-
+    diff = create_diff(source_tree, output_tree)
     change_set = ChangeSet(
         str(file_context.file_path.relative_to(base_directory)),
         diff,


### PR DESCRIPTION
## Overview
*Works around an edge case in `difflib` that produces incorrect diffs*

## Description

* `difflib` has a bug that causes it to produce incorrect unified diffs in certain cases: **https://github.com/python/cpython/issues/46395**
* Specifically, it causes an issue when the original input does not have a terminating newline and the new result appends a new line to the end