### PR TITLE
Flip insecure defined flask session config

### DIFF
--- a/integration_tests/test_secure_flask_session_config.py
+++ b/integration_tests/test_secure_flask_session_config.py
@@ -1,0 +1,16 @@
+from core_codemods.secure_flask_session_config import SecureFlaskSessionConfig
+from integration_tests.base_test import (
+    BaseIntegrationTest,
+    original_and_expected_from_code_path,
+)
+
+
+class TestSecureFlaskSessionConfig(BaseIntegrationTest):
+    codemod = SecureFlaskSessionConfig
+    code_path = "tests/samples/flask_app.py"
+    original_code, expected_new_code = original_and_expected_from_code_path(
+        code_path, [(2, "app.config['SESSION_COOKIE_HTTPONLY'] = True\n")]
+    )
+    expected_diff = "--- \n+++ \n@@ -1,6 +1,6 @@\n from flask import Flask\n app = Flask(__name__)\n-app.config['SESSION_COOKIE_HTTPONLY'] = False\n+app.config['SESSION_COOKIE_HTTPONLY'] = True\n @app.route('/')\n def hello_world():\n     return 'Hello World!'\n"
+    expected_line_change = "3"
+    change_description = SecureFlaskSessionConfig.CHANGE_DESCRIPTION

--- a/src/codemodder/project_analysis/file_parsers/setup_py_file_parser.py
+++ b/src/codemodder/project_analysis/file_parsers/setup_py_file_parser.py
@@ -1,11 +1,11 @@
 from codemodder.project_analysis.file_parsers.package_store import PackageStore
+from codemodder.utils.utils import clean_simplestring
 from pathlib import Path
 import libcst as cst
 from libcst import matchers
 from packaging.requirements import Requirement
 
 from .base_parser import BaseParser
-from .utils import clean_simplestring
 
 
 class SetupPyParser(BaseParser):

--- a/src/codemodder/project_analysis/file_parsers/utils.py
+++ b/src/codemodder/project_analysis/file_parsers/utils.py
@@ -1,7 +1,0 @@
-import libcst as cst
-
-
-def clean_simplestring(node: cst.SimpleString | str) -> str:
-    if isinstance(node, str):
-        return node.strip('"')
-    return node.raw_value

--- a/src/codemodder/scripts/generate_docs.py
+++ b/src/codemodder/scripts/generate_docs.py
@@ -134,6 +134,10 @@ If you want to allow those protocols, change the incoming PR to look more like t
         importance="Low",
         guidance_explained="We believe this replacement is safe and leads to better performance.",
     ),
+    "secure-flask-session-configuration": DocMetadata(
+        importance="Medium",
+        guidance_explained="Our change fixes explicitly insecure session configuration for a Flask application. However, there may be valid cases to use these insecure configurations, such as for testing or backward compatibility.",
+    ),
 }
 
 

--- a/src/codemodder/utils/utils.py
+++ b/src/codemodder/utils/utils.py
@@ -19,3 +19,20 @@ def true_value(node: cst.Name | cst.SimpleString) -> str | int | bool:
                 return False
             return val
     return ""
+
+
+def extract_targets_of_assignment(
+    assignment: cst.AnnAssign | cst.Assign | cst.WithItem | cst.NamedExpr,
+) -> list[cst.BaseExpression]:
+    match assignment:
+        case cst.AnnAssign():
+            if assignment.target:
+                return [assignment.target]
+        case cst.Assign():
+            return [t.target for t in assignment.targets]
+        case cst.NamedExpr():
+            return [assignment.target]
+        case cst.WithItem():
+            if assignment.asname:
+                return [assignment.asname.name]
+    return []

--- a/src/codemodder/utils/utils.py
+++ b/src/codemodder/utils/utils.py
@@ -1,0 +1,21 @@
+import libcst as cst
+
+
+def clean_simplestring(node: cst.SimpleString | str) -> str:
+    if isinstance(node, str):
+        return node.strip('"')
+    return node.raw_value
+
+
+def true_value(node: cst.Name | cst.SimpleString) -> str | int | bool:
+    match node:
+        case cst.SimpleString():
+            return clean_simplestring(node)
+        case cst.Name():
+            val = node.value
+            if val.lower() == "true":
+                return True
+            elif val.lower() == "false":
+                return False
+            return val
+    return ""

--- a/src/core_codemods/__init__.py
+++ b/src/core_codemods/__init__.py
@@ -27,6 +27,7 @@ from .use_defused_xml import UseDefusedXml
 from .use_generator import UseGenerator
 from .use_walrus_if import UseWalrusIf
 from .with_threading_lock import WithThreadingLock
+from .secure_flask_session_config import SecureFlaskSessionConfig
 
 registry = CodemodCollection(
     origin="pixee",
@@ -60,5 +61,6 @@ registry = CodemodCollection(
         UseWalrusIf,
         WithThreadingLock,
         SQLQueryParameterization,
+        SecureFlaskSessionConfig,
     ],
 )

--- a/src/core_codemods/docs/pixee_python_secure-flask-session-configuration.md
+++ b/src/core_codemods/docs/pixee_python_secure-flask-session-configuration.md
@@ -1,0 +1,13 @@
+Flask applications can configure sessions behavior at the application level. 
+This codemod looks for Flask application configuration that set `SESSION_COOKIE_HTTPONLY`, `SESSION_COOKIE_SECURE`, or `SESSION_COOKIE_SAMESITE` to an insecure value and changes it to a secure one.
+
+The changes from this codemod look like this:
+
+```diff
+  from flask import Flask
+  app = Flask(__name__)
+- app.config['SESSION_COOKIE_HTTPONLY'] = False
+- app.config.update(SESSION_COOKIE_SECURE=False)
++ app.config['SESSION_COOKIE_HTTPONLY'] = True
++ app.config.update(SESSION_COOKIE_SECURE=True)
+```

--- a/src/core_codemods/secure_flask_session_config.py
+++ b/src/core_codemods/secure_flask_session_config.py
@@ -1,0 +1,96 @@
+import libcst as cst
+from libcst.codemod import Codemod, CodemodContext, ContextAwareVisitor
+from libcst.metadata import ParentNodeProvider, ScopeProvider
+
+from libcst import matchers
+from codemodder.codemods.base_codemod import ReviewGuidance
+from codemodder.codemods.api import BaseCodemod
+from codemodder.codemods.utils_mixin import NameResolutionMixin
+
+
+class SecureFlaskSessionConfig(BaseCodemod):
+    METADATA_DEPENDENCIES = BaseCodemod.METADATA_DEPENDENCIES + (
+        ParentNodeProvider,
+        ScopeProvider,
+    )
+    NAME = "secure-flask-session-configuration"
+    SUMMARY = "UTODO"
+    REVIEW_GUIDANCE = ReviewGuidance.MERGE_AFTER_REVIEW
+    DESCRIPTION = "TODO"
+    REFERENCES = [
+        {
+            "url": "todo",
+            "description": "",
+        }
+    ]
+
+    def transform_module_impl(self, tree: cst.Module) -> cst.Module:
+        flask_visitor = FindConfigCalls(self.context)
+        tree.visit(flask_visitor)
+        if not flask_visitor.flask_app_name:
+            return tree
+
+        # TODO: iterate through flask_visitor.config_access
+        # TODO: use a list of secure config names, values to only write the needed ones out
+        result = self.insert_config_line_endof_mod(tree, flask_visitor.flask_app_name)
+        return result
+
+    def insert_config_line_endof_mod(
+        self, original_node: cst.Module, app_name: str
+    ) -> cst.Module:
+        # TODO: record change
+        # line_number is the end of the module where we will insert the new flag.
+        # pos_to_match = self.node_position(original_node)
+        # line_number = pos_to_match.end.line
+        # self.changes_in_file.append(
+        #     Change(line_number, DjangoSessionCookieSecureOff.CHANGE_DESCRIPTION)
+        # )
+        # self.file_context.codemod_changes.append(
+        #     Change(line_number, self.CHANGE_DESCRIPTION)
+        # )
+        secure_configs = """SESSION_COOKIE_HTTPONLY=True, SESSION_COOKIE_SECURE=True, SESSION_COOKIE_SAMESITE='Lax'"""
+        final_line = cst.parse_statement(f"{app_name}.config.update({secure_configs})")
+        new_body = original_node.body + (final_line,)
+        return original_node.with_changes(body=new_body)
+
+
+class FindConfigCalls(ContextAwareVisitor, NameResolutionMixin):
+    """
+    Visitor to find calls to flask.Flask and related `.config` accesses.
+    """
+
+    METADATA_DEPENDENCIES = (ParentNodeProvider,)
+
+    def __init__(self, context: CodemodContext) -> None:
+        self.config_access: list = []
+        self.flask_app_name = ""
+        super().__init__(context)
+
+    def _find_config_accesses(self, flask_app_attr: cst.AnnAssign | cst.Assign):
+        assignments = self.find_assignments(flask_app_attr)
+        for assignment in assignments:
+            if assignment.references:
+                # Flask app instance is accessed
+                references_to_app = [x.node for x in assignment.references]
+                for node in references_to_app:
+                    parent = self.get_metadata(ParentNodeProvider, node)
+                    match parent:
+                        case cst.Attribute():
+                            config = cst.Name(value="config")
+                            if matchers.matches(
+                                parent, matchers.Attribute(value=node, attr=config)
+                            ):
+                                gparent = self.get_metadata(ParentNodeProvider, parent)
+                                self.config_access.append(gparent)
+
+    def leave_Call(self, original_node: cst.Call) -> None:
+        true_name = self.find_base_name(original_node.func)
+        if true_name == "flask.Flask":
+            flask_app_parent = self.get_metadata(ParentNodeProvider, original_node)
+            match flask_app_parent:
+                case cst.AnnAssign() | cst.Assign():
+                    flask_app_attr = flask_app_parent.targets[0].target
+                    self.flask_app_name = flask_app_attr.value
+                    self._find_config_accesses(flask_app_attr)
+
+        return original_node

--- a/src/core_codemods/secure_flask_session_config.py
+++ b/src/core_codemods/secure_flask_session_config.py
@@ -24,20 +24,112 @@ class SecureFlaskSessionConfig(BaseCodemod):
         }
     ]
 
+    SECURE_SESSION_CONFIGS = dict(
+        # None value indicates unassigned, using default is safe
+        # values in order of precedence
+        SESSION_COOKIE_HTTPONLY=[None, True],
+        SESSION_COOKIE_SECURE=[True],
+        SESSION_COOKIE_SAMESITE=["Lax", "Strict"],
+    )
+
     def transform_module_impl(self, tree: cst.Module) -> cst.Module:
         flask_visitor = FindConfigCalls(self.context)
         tree.visit(flask_visitor)
         if not flask_visitor.flask_app_name:
             return tree
 
-        # TODO: iterate through flask_visitor.config_access
-        # TODO: use a list of secure config names, values to only write the needed ones out
-        result = self.insert_config_line_endof_mod(tree, flask_visitor.flask_app_name)
+        if len(flask_visitor.config_access) == 0:
+            return self.insert_config_line_endof_mod(
+                tree, flask_visitor.flask_app_name, self.SECURE_SESSION_CONFIGS
+            )
+
+        # Handle single config.update line, reuse it
+        if len(flask_visitor.config_access) == 1 and isinstance(
+            single_config := flask_visitor.config_access[0], cst.Call
+        ):
+            defined_configs = self._get_configs(single_config)
+
+            configs_to_write = {**self.SECURE_SESSION_CONFIGS.copy(), **defined_configs}
+
+            for key, val in configs_to_write.items():
+                if (
+                    key in self.SECURE_SESSION_CONFIGS
+                    and val in self.SECURE_SESSION_CONFIGS[key]
+                ):
+                    del configs_to_write[key]
+
+            return self.reuse_config_line(
+                tree, flask_visitor.flask_app_name, configs_to_write
+            )
+
+        # Handle single config['access'] line, add update line excluding configs already set
+        if len(flask_visitor.config_access) == 1 and isinstance(
+            single_config := flask_visitor.config_access[0], cst.Assign
+        ):
+            defined_config = self._get_config_from_slice(single_config)
+            defined_key = list(defined_config.keys())[0]
+            configs_to_write = self.SECURE_SESSION_CONFIGS.copy()
+
+            for key, val in configs_to_write.items():
+                if key in defined_config and val in self.SECURE_SESSION_CONFIGS[key]:
+                    del configs_to_write[key]
+
+            # any of the secure sesh in defined config, we want to reuse the line
+            # but flip it if necessary
+            if defined_key in self.SECURE_SESSION_CONFIGS:
+                del configs_to_write[defined_key]
+                return self.reuse_config_subscript_line(
+                    tree, flask_visitor.flask_app_name, configs_to_write, defined_key
+                )
+            return self.insert_config_line_endof_mod(
+                tree, flask_visitor.flask_app_name, configs_to_write
+            )
+
+
+        defined_configs = self.get_defined_configs(flask_visitor.config_access)
+        breakpoint()
+        configs_to_write = self.SECURE_SESSION_CONFIGS.copy()
+        for key, vals in defined_configs.items():
+            defined_val = vals[-1]
+            if key in self.SECURE_SESSION_CONFIGS and defined_val in self.SECURE_SESSION_CONFIGS[key]:
+                del configs_to_write[key]
+
+        result = self.insert_config_line_endof_mod(
+            tree, flask_visitor.flask_app_name, configs_to_write
+        )
         return result
 
-    def insert_config_line_endof_mod(
-        self, original_node: cst.Module, app_name: str
+    def get_defined_configs(self, config_access):
+        all_defined_configs = {}
+        for config_line in config_access:
+            match config_line:
+                case cst.Call():
+                    # app.config.update(...)
+                    defined_configs = self._get_configs(config_line)
+                    all_defined_configs.update(defined_configs)
+                case cst.Assign():
+                    # app.config['...']
+                    defined_configs = self._get_config_from_slice(config_line)
+                    all_defined_configs.update(defined_configs)
+
+        return all_defined_configs
+    def _get_configs(self, config_line: cst.Call):
+        defined_configs = {}
+        for arg in config_line.args:
+            defined_configs[arg.keyword.value] = [true_value(arg.value)]
+        return defined_configs
+
+    def _get_config_from_slice(self, config_line: cst.Assign):
+        defined_configs = {}
+        key = true_value(config_line.targets[0].target.slice[0].slice.value)
+        defined_configs[key] = [true_value(config_line.value)]
+        return defined_configs
+
+    def reuse_config_line(
+        self, original_node: cst.Module, app_name: str, configs: dict
     ) -> cst.Module:
+        if not configs:
+            return original_node
         # TODO: record change
         # line_number is the end of the module where we will insert the new flag.
         # pos_to_match = self.node_position(original_node)
@@ -48,8 +140,74 @@ class SecureFlaskSessionConfig(BaseCodemod):
         # self.file_context.codemod_changes.append(
         #     Change(line_number, self.CHANGE_DESCRIPTION)
         # )
-        secure_configs = """SESSION_COOKIE_HTTPONLY=True, SESSION_COOKIE_SECURE=True, SESSION_COOKIE_SAMESITE='Lax'"""
-        final_line = cst.parse_statement(f"{app_name}.config.update({secure_configs})")
+        config_string = ", ".join(
+            f"{key}='{value[0]}'" if isinstance(value[0], str) else f"{key}={value[0]}"
+            for key, value in configs.items()
+            if value and value[0] is not None
+        )
+        # secure_configs = """SESSION_COOKIE_HTTPONLY=True, SESSION_COOKIE_SECURE=True, SESSION_COOKIE_SAMESITE='Lax'"""
+        final_line = cst.parse_statement(f"{app_name}.config.update({config_string})")
+        new_body = original_node.body[:-1] + (final_line,)
+        return original_node.with_changes(body=new_body)
+
+    def reuse_config_subscript_line(
+        self, original_node: cst.Module, app_name: str, configs: dict, defined_key: str
+    ) -> cst.Module:
+        if not configs:
+            return original_node
+        # TODO: record change
+        # line_number is the end of the module where we will insert the new flag.
+        # pos_to_match = self.node_position(original_node)
+        # line_number = pos_to_match.end.line
+        # self.changes_in_file.append(
+        #     Change(line_number, DjangoSessionCookieSecureOff.CHANGE_DESCRIPTION)
+        # )
+        # self.file_context.codemod_changes.append(
+        #     Change(line_number, self.CHANGE_DESCRIPTION)
+        # )
+        config_string = ", ".join(
+            f"{key}='{value[0]}'" if isinstance(value[0], str) else f"{key}={value[0]}"
+            for key, value in configs.items()
+            if value and value[0] is not None
+        )
+
+        final_line = cst.parse_statement(f"{app_name}.config.update({config_string})")
+        secure_val = (
+            self.SECURE_SESSION_CONFIGS[defined_key][0]
+            or self.SECURE_SESSION_CONFIGS[defined_key][1]
+        )
+        final_config_subscript_line = cst.parse_statement(
+            f"{app_name}.config['{defined_key}'] = {secure_val}"
+        )
+        new_body = original_node.body[:-1] + (
+            final_config_subscript_line,
+            final_line,
+        )
+        return original_node.with_changes(body=new_body)
+
+    def insert_config_line_endof_mod(
+        self, original_node: cst.Module, app_name: str, configs: dict
+    ) -> cst.Module:
+        if not configs:
+            return original_node
+        # TODO: record change
+        # line_number is the end of the module where we will insert the new flag.
+        # pos_to_match = self.node_position(original_node)
+        # line_number = pos_to_match.end.line
+        # self.changes_in_file.append(
+        #     Change(line_number, DjangoSessionCookieSecureOff.CHANGE_DESCRIPTION)
+        # )
+        # self.file_context.codemod_changes.append(
+        #     Change(line_number, self.CHANGE_DESCRIPTION)
+        # )
+        config_string = ", ".join(
+            f"{key}='{value[0]}'" if isinstance(value[0], str) else f"{key}={value[0]}"
+            for key, value in configs.items()
+            if value and value[0] is not None
+        )
+        if not config_string:
+            return original_node
+        final_line = cst.parse_statement(f"{app_name}.config.update({config_string})")
         new_body = original_node.body + (final_line,)
         return original_node.with_changes(body=new_body)
 
@@ -81,7 +239,16 @@ class FindConfigCalls(ContextAwareVisitor, NameResolutionMixin):
                                 parent, matchers.Attribute(value=node, attr=config)
                             ):
                                 gparent = self.get_metadata(ParentNodeProvider, parent)
-                                self.config_access.append(gparent)
+                                ggparent = self.get_metadata(
+                                    ParentNodeProvider, gparent
+                                )
+                                if matchers.matches(gparent, matchers.Subscript()):
+                                    gggparent = self.get_metadata(
+                                        ParentNodeProvider, ggparent
+                                    )
+                                    self.config_access.append(gggparent)
+                                else:
+                                    self.config_access.append(ggparent)
 
     def leave_Call(self, original_node: cst.Call) -> None:
         true_name = self.find_base_name(original_node.func)
@@ -94,3 +261,30 @@ class FindConfigCalls(ContextAwareVisitor, NameResolutionMixin):
                     self._find_config_accesses(flask_app_attr)
 
         return original_node
+
+
+def true_value(node: cst.Name | cst.SimpleString):
+    # todo: move to a more general util
+    from codemodder.project_analysis.file_parsers.utils import clean_simplestring
+
+    # convert 'True' to True, etc
+    # '123'  to 123
+    # leave strs as they are
+    # Try to convert the string to a boolean, integer, or float
+    match node:
+        case cst.SimpleString():
+            return clean_simplestring(node)
+        case cst.Name():
+            val = node.value
+            if val.lower() == "true":
+                return True
+            elif val.lower() == "false":
+                return False
+            try:
+                return int(val)
+            except ValueError:
+                try:
+                    return float(val)
+                except ValueError:
+                    # If no conversion worked, return the original string
+                    return val

--- a/tests/codemods/test_secure_flask_session_config.py
+++ b/tests/codemods/test_secure_flask_session_config.py
@@ -1,0 +1,267 @@
+import pytest
+from core_codemods.secure_flask_session_config import SecureFlaskSessionConfig
+from tests.codemods.base_codemod_test import BaseCodemodTest
+from textwrap import dedent
+
+
+class TestSecureFlaskSessionConfig(BaseCodemodTest):
+    codemod = SecureFlaskSessionConfig
+
+    def test_name(self):
+        assert self.codemod.name() == "secure-flask-session-configuration"
+
+    def test_no_flask_app(self, tmpdir):
+        input_code = """\
+        import flask
+
+        response = flask.Response()
+        var = "hello"
+        response.set_cookie("name", "value")
+        """
+        self.run_and_assert(tmpdir, dedent(input_code), dedent(input_code))
+
+    def test_app_not_accessed(self, tmpdir):
+        input_code = """\
+        import flask
+
+        app = flask.Flask(__name__)
+        # more code
+        print(1)
+        """
+        expexted_output = """\
+        import flask
+
+        app = flask.Flask(__name__)
+        # more code
+        print(1)
+        app.config.update(SESSION_COOKIE_HTTPONLY=True, SESSION_COOKIE_SECURE=True, SESSION_COOKIE_SAMESITE='Lax')
+        """
+        self.run_and_assert(tmpdir, dedent(input_code), dedent(expexted_output))
+        # assert len(self.file_context.codemod_changes) == 1
+
+    def test_app_defined_separate_module(self, tmpdir):
+        # TODO: test this as an integration test with two real modules
+        input_code = """\
+        from my_app_module import app
+
+        app.config["SESSION_COOKIE_SECURE"] = False
+        """
+        self.run_and_assert(tmpdir, dedent(input_code), dedent(input_code))
+        assert len(self.file_context.codemod_changes) == 0
+
+    def test_app_not_assigned(self, tmpdir):
+        input_code = """\
+        import flask
+
+        flask.Flask(__name__)
+        print(1)
+        """
+        self.run_and_assert(tmpdir, dedent(input_code), dedent(input_code))
+
+    def test_app_accessed_config_not_called(self, tmpdir):
+        input_code = """\
+        import flask
+
+        app = flask.Flask(__name__)
+        app.secret_key = "dev"
+        # more code
+        """
+        expexted_output = """\
+        import flask
+
+        app = flask.Flask(__name__)
+        app.secret_key = "dev"
+        app.config.update(SESSION_COOKIE_HTTPONLY=True, SESSION_COOKIE_SECURE=True, SESSION_COOKIE_SAMESITE='Lax')
+        # more code
+        """
+        self.run_and_assert(tmpdir, dedent(input_code), dedent(expexted_output))
+        # assert len(self.file_context.codemod_changes) == 1
+
+    def test_from_import(self, tmpdir):
+        input_code = """\
+        from flask import Flask
+
+        app = flask.Flask(__name__)
+        app.secret_key = "dev"
+        # more code
+        """
+        expexted_output = """\
+        from flask import Flask
+
+        app = flask.Flask(__name__)
+        app.secret_key = "dev"
+        app.config.update(SESSION_COOKIE_HTTPONLY=True, SESSION_COOKIE_SECURE=True, SESSION_COOKIE_SAMESITE='Lax')
+        # more code
+        """
+        self.run_and_assert(tmpdir, dedent(input_code), dedent(expexted_output))
+        # assert len(self.file_context.codemod_changes) == 1
+
+    def test_import_alias(self, tmpdir):
+        input_code = f"""\
+        from flask import Flask as flask_app
+        app = flask_app(__name__)
+        app.secret_key = "dev"
+        # more code
+        """
+        expexted_output = f"""\
+        from flask import Flask as flask_app
+        app = flask_app(__name__)
+        app.secret_key = "dev"
+        app.config.update(SESSION_COOKIE_HTTPONLY=True, SESSION_COOKIE_SECURE=True, SESSION_COOKIE_SAMESITE='Lax')
+        # more code
+        """
+        self.run_and_assert(tmpdir, dedent(input_code), dedent(expexted_output))
+        # assert len(self.file_context.codemod_changes) == 1
+
+    @pytest.mark.parametrize(
+        "input_code,expected_output",
+        [
+            (
+                """\
+            import flask
+
+            app = flask.Flask(__name__)
+            app.secret_key = "dev"
+            app.config
+            """,
+                """\
+            import flask
+
+            app = flask.Flask(__name__)
+            app.secret_key = "dev"
+            app.config
+            app.config.update(SESSION_COOKIE_HTTPONLY=True, SESSION_COOKIE_SECURE=True, SESSION_COOKIE_SAMESITE='Lax')
+            """,
+            ),
+            (
+                """\
+                import flask
+
+                app = flask.Flask(__name__)
+                app.secret_key = "dev"
+                app.config["TESTING"] = True
+                """,
+                """\
+                import flask
+
+                app = flask.Flask(__name__)
+                app.secret_key = "dev"
+                app.config["TESTING"] = True
+                app.config.update(SESSION_COOKIE_HTTPONLY=True, SESSION_COOKIE_SECURE=True, SESSION_COOKIE_SAMESITE='Lax')
+                """,
+            ),
+            (
+                """\
+                import flask
+
+                app = flask.Flask(__name__)
+                app.secret_key = "dev"
+                app.config.testing = True
+                """,
+                """\
+                    import flask
+
+                    app = flask.Flask(__name__)
+                    app.secret_key = "dev"
+                    app.config.testing = True
+                    app.config.update(SESSION_COOKIE_HTTPONLY=True, SESSION_COOKIE_SECURE=True, SESSION_COOKIE_SAMESITE='Lax')
+                    """,
+            ),
+            (
+                """\
+                    import flask
+
+                    app = flask.Flask(__name__)
+                    app.secret_key = "dev"
+                    app.config["SESSION_COOKIE_SECURE"] = False
+                    """,
+                """\
+                    import flask
+
+                    app = flask.Flask(__name__)
+                    app.secret_key = "dev"
+                    app.config["SESSION_COOKIE_SECURE"] = False
+                    app.config.update(SESSION_COOKIE_HTTPONLY=True, SESSION_COOKIE_SECURE=True, SESSION_COOKIE_SAMESITE='Lax')
+                    """,
+            ),
+            (
+                """\
+                    import flask
+
+                    app = flask.Flask(__name__)
+                    app.secret_key = "dev"
+                    app.config["SESSION_COOKIE_HTTPONLY"] = False
+                    """,
+                """\
+                    import flask
+
+                    app = flask.Flask(__name__)
+                    app.secret_key = "dev"
+                    app.config["SESSION_COOKIE_HTTPONLY"] = False
+                    app.config.update(SESSION_COOKIE_HTTPONLY=True, SESSION_COOKIE_SECURE=True, SESSION_COOKIE_SAMESITE='Lax')
+                    """,
+            ),
+            (
+                """\
+                    import flask
+
+                    app = flask.Flask(__name__)
+                    app.secret_key = "dev"
+                    app.config.update(SESSION_COOKIE_HTTPONLY=True, SESSION_COOKIE_SECURE=True, SESSION_COOKIE_SAMESITE='Strict')
+                    """,
+                """\
+                    import flask
+
+                    app = flask.Flask(__name__)
+                    app.secret_key = "dev"
+                    app.config.update(SESSION_COOKIE_HTTPONLY=True, SESSION_COOKIE_SECURE=True, SESSION_COOKIE_SAMESITE='Strict')
+                    app.config.update(SESSION_COOKIE_HTTPONLY=True, SESSION_COOKIE_SECURE=True, SESSION_COOKIE_SAMESITE='Lax')
+                    """,
+            ),
+            (
+                """\
+                    import flask
+
+                    app = flask.Flask(__name__)
+                    app.secret_key = "dev"
+                    app.config["SESSION_COOKIE_SECURE"] = False
+                    app.config["SESSION_COOKIE_SECURE"] = True
+                    """,
+                """\
+                    import flask
+
+                    app = flask.Flask(__name__)
+                    app.secret_key = "dev"
+                    app.config["SESSION_COOKIE_SECURE"] = False
+                    app.config["SESSION_COOKIE_SECURE"] = True
+                    app.config.update(SESSION_COOKIE_HTTPONLY=True, SESSION_COOKIE_SECURE=True, SESSION_COOKIE_SAMESITE='Lax')
+                    """,
+            ),
+        ],
+    )
+    def test_config_accessed(self, tmpdir, input_code, expected_output):
+        self.run_and_assert(tmpdir, input_code, expected_output)
+
+    @pytest.mark.skip()
+    def test_func_scope(self, tmpdir):
+        input_code = """\
+        from flask import Flask
+        app = Flask(__name__)
+
+        @app.route('/')
+        def hello_world():
+            return 'Hello World!'
+
+        def configure():
+            app.config['TESTING'] = True
+
+        if __name__ == '__main__':
+            configure()
+            app.run()
+        """
+        expexted_output = """\
+        # TODO correct fix could be multiple options,
+        # either within configure() call or after it's called
+        """
+        self.run_and_assert(tmpdir, dedent(input_code), dedent(expexted_output))
+        # assert len(self.file_context.codemod_changes) == 1

--- a/tests/codemods/test_secure_flask_session_config.py
+++ b/tests/codemods/test_secure_flask_session_config.py
@@ -34,7 +34,7 @@ class TestSecureFlaskSessionConfig(BaseCodemodTest):
         app = flask.Flask(__name__)
         # more code
         print(1)
-        app.config.update(SESSION_COOKIE_HTTPONLY=True, SESSION_COOKIE_SECURE=True, SESSION_COOKIE_SAMESITE='Lax')
+        app.config.update(SESSION_COOKIE_SECURE=True, SESSION_COOKIE_SAMESITE='Lax')
         """
         self.run_and_assert(tmpdir, dedent(input_code), dedent(expexted_output))
         # assert len(self.file_context.codemod_changes) == 1
@@ -71,7 +71,7 @@ class TestSecureFlaskSessionConfig(BaseCodemodTest):
 
         app = flask.Flask(__name__)
         app.secret_key = "dev"
-        app.config.update(SESSION_COOKIE_HTTPONLY=True, SESSION_COOKIE_SECURE=True, SESSION_COOKIE_SAMESITE='Lax')
+        app.config.update(SESSION_COOKIE_SECURE=True, SESSION_COOKIE_SAMESITE='Lax')
         # more code
         """
         self.run_and_assert(tmpdir, dedent(input_code), dedent(expexted_output))
@@ -90,7 +90,7 @@ class TestSecureFlaskSessionConfig(BaseCodemodTest):
 
         app = flask.Flask(__name__)
         app.secret_key = "dev"
-        app.config.update(SESSION_COOKIE_HTTPONLY=True, SESSION_COOKIE_SECURE=True, SESSION_COOKIE_SAMESITE='Lax')
+        app.config.update(SESSION_COOKIE_SECURE=True, SESSION_COOKIE_SAMESITE='Lax')
         # more code
         """
         self.run_and_assert(tmpdir, dedent(input_code), dedent(expexted_output))
@@ -107,140 +107,107 @@ class TestSecureFlaskSessionConfig(BaseCodemodTest):
         from flask import Flask as flask_app
         app = flask_app(__name__)
         app.secret_key = "dev"
-        app.config.update(SESSION_COOKIE_HTTPONLY=True, SESSION_COOKIE_SECURE=True, SESSION_COOKIE_SAMESITE='Lax')
+        app.config.update(SESSION_COOKIE_SECURE=True, SESSION_COOKIE_SAMESITE='Lax')
         # more code
         """
         self.run_and_assert(tmpdir, dedent(input_code), dedent(expexted_output))
         # assert len(self.file_context.codemod_changes) == 1
 
     @pytest.mark.parametrize(
-        "input_code,expected_output",
+        "config_lines,expected_config_lines",
         [
             (
-                """\
-            import flask
-
-            app = flask.Flask(__name__)
-            app.secret_key = "dev"
-            app.config
-            """,
-                """\
-            import flask
-
-            app = flask.Flask(__name__)
-            app.secret_key = "dev"
-            app.config
-            app.config.update(SESSION_COOKIE_HTTPONLY=True, SESSION_COOKIE_SECURE=True, SESSION_COOKIE_SAMESITE='Lax')
-            """,
+                """app.config""",
+                """app.config
+app.config.update(SESSION_COOKIE_SECURE=True, SESSION_COOKIE_SAMESITE='Lax')""",
             ),
             (
-                """\
-                import flask
-
-                app = flask.Flask(__name__)
-                app.secret_key = "dev"
-                app.config["TESTING"] = True
-                """,
-                """\
-                import flask
-
-                app = flask.Flask(__name__)
-                app.secret_key = "dev"
-                app.config["TESTING"] = True
-                app.config.update(SESSION_COOKIE_HTTPONLY=True, SESSION_COOKIE_SECURE=True, SESSION_COOKIE_SAMESITE='Lax')
-                """,
+                """app.config["TESTING"] = True""",
+                """app.config["TESTING"] = True
+app.config.update(SESSION_COOKIE_SECURE=True, SESSION_COOKIE_SAMESITE='Lax')""",
             ),
             (
-                """\
-                import flask
-
-                app = flask.Flask(__name__)
-                app.secret_key = "dev"
-                app.config.testing = True
-                """,
-                """\
-                    import flask
-
-                    app = flask.Flask(__name__)
-                    app.secret_key = "dev"
-                    app.config.testing = True
-                    app.config.update(SESSION_COOKIE_HTTPONLY=True, SESSION_COOKIE_SECURE=True, SESSION_COOKIE_SAMESITE='Lax')
-                    """,
+                """app.config.testing = True""",
+                """app.config.testing = True
+app.config.update(SESSION_COOKIE_SECURE=True, SESSION_COOKIE_SAMESITE='Lax')""",
             ),
             (
-                """\
-                    import flask
-
-                    app = flask.Flask(__name__)
-                    app.secret_key = "dev"
-                    app.config["SESSION_COOKIE_SECURE"] = False
-                    """,
-                """\
-                    import flask
-
-                    app = flask.Flask(__name__)
-                    app.secret_key = "dev"
-                    app.config["SESSION_COOKIE_SECURE"] = False
-                    app.config.update(SESSION_COOKIE_HTTPONLY=True, SESSION_COOKIE_SECURE=True, SESSION_COOKIE_SAMESITE='Lax')
-                    """,
+                """app.config.update(SESSION_COOKIE_SECURE=True, SESSION_COOKIE_SAMESITE='Lax')""",
+                """app.config.update(SESSION_COOKIE_SECURE=True, SESSION_COOKIE_SAMESITE='Lax')""",
             ),
             (
-                """\
-                    import flask
-
-                    app = flask.Flask(__name__)
-                    app.secret_key = "dev"
-                    app.config["SESSION_COOKIE_HTTPONLY"] = False
-                    """,
-                """\
-                    import flask
-
-                    app = flask.Flask(__name__)
-                    app.secret_key = "dev"
-                    app.config["SESSION_COOKIE_HTTPONLY"] = False
-                    app.config.update(SESSION_COOKIE_HTTPONLY=True, SESSION_COOKIE_SECURE=True, SESSION_COOKIE_SAMESITE='Lax')
-                    """,
+                """app.config.update(SECRET_KEY='123SOMEKEY')""",
+                """app.config.update(SESSION_COOKIE_SECURE=True, SESSION_COOKIE_SAMESITE='Lax', SECRET_KEY='123SOMEKEY')""",
             ),
             (
-                """\
-                    import flask
-
-                    app = flask.Flask(__name__)
-                    app.secret_key = "dev"
-                    app.config.update(SESSION_COOKIE_HTTPONLY=True, SESSION_COOKIE_SECURE=True, SESSION_COOKIE_SAMESITE='Strict')
-                    """,
-                """\
-                    import flask
-
-                    app = flask.Flask(__name__)
-                    app.secret_key = "dev"
-                    app.config.update(SESSION_COOKIE_HTTPONLY=True, SESSION_COOKIE_SECURE=True, SESSION_COOKIE_SAMESITE='Strict')
-                    app.config.update(SESSION_COOKIE_HTTPONLY=True, SESSION_COOKIE_SECURE=True, SESSION_COOKIE_SAMESITE='Lax')
-                    """,
+                """app.config.update(SESSION_COOKIE_SECURE=True)""",
+                """app.config.update(SESSION_COOKIE_SECURE=True, SESSION_COOKIE_SAMESITE='Lax')""",
             ),
             (
-                """\
-                    import flask
-
-                    app = flask.Flask(__name__)
-                    app.secret_key = "dev"
-                    app.config["SESSION_COOKIE_SECURE"] = False
-                    app.config["SESSION_COOKIE_SECURE"] = True
-                    """,
-                """\
-                    import flask
-
-                    app = flask.Flask(__name__)
-                    app.secret_key = "dev"
-                    app.config["SESSION_COOKIE_SECURE"] = False
-                    app.config["SESSION_COOKIE_SECURE"] = True
-                    app.config.update(SESSION_COOKIE_HTTPONLY=True, SESSION_COOKIE_SECURE=True, SESSION_COOKIE_SAMESITE='Lax')
-                    """,
+                """app.config.update(SESSION_COOKIE_HTTPONLY=True)""",
+                """app.config.update(SESSION_COOKIE_HTTPONLY=True, SESSION_COOKIE_SECURE=True, SESSION_COOKIE_SAMESITE='Lax')""",
             ),
+            (
+                """app.config['SESSION_COOKIE_SECURE'] = False""",
+                """app.config['SESSION_COOKIE_SECURE'] = True
+app.config.update(SESSION_COOKIE_SAMESITE='Lax')""",
+            ),
+            (
+                """app.config['SESSION_COOKIE_HTTPONLY'] = False""",
+                """app.config['SESSION_COOKIE_HTTPONLY'] = True
+app.config.update(SESSION_COOKIE_SECURE=True, SESSION_COOKIE_SAMESITE='Lax')""",
+            ),
+            (
+                    '''app.config["SESSION_COOKIE_SECURE"] = True
+app.config["SESSION_COOKIE_SAMESITE"] = "Lax"
+''',
+                    '''app.config["SESSION_COOKIE_SECURE"] = True
+app.config["SESSION_COOKIE_SAMESITE"] = "Lax"
+''',
+            ),
+            (
+                    '''app.config["SESSION_COOKIE_SECURE"] = False
+app.config["SESSION_COOKIE_SAMESITE"] = None
+''',
+                    '''app.config["SESSION_COOKIE_SECURE"] = True
+app.config["SESSION_COOKIE_SAMESITE"] = "Lax"
+''',
+            ),
+#             (
+#                     '''app.config["SESSION_COOKIE_SECURE"] = False
+# app.config["SESSION_COOKIE_HTTPONLY"] = False
+# app.config["SESSION_COOKIE_SAMESITE"] = "Strict"
+# ''',
+#                     '''app.config["SESSION_COOKIE_SECURE"] = True
+# app.config["SESSION_COOKIE_HTTPONLY"] = True
+# app.config["SESSION_COOKIE_SAMESITE"] = "Strict"
+# ''',
+#             ),
+            #         (
+            #                 """app.config["SESSION_COOKIE_SECURE"] = False
+            # app.config["SESSION_COOKIE_SECURE"] = True
+            # """,
+            #                 """app.config["SESSION_COOKIE_SECURE"] = False
+            # app.config["SESSION_COOKIE_SECURE"] = True
+            # app.config.update(SESSION_COOKIE_SAMESITE='Lax')
+            # """,
+            #         ),
         ],
     )
-    def test_config_accessed(self, tmpdir, input_code, expected_output):
-        self.run_and_assert(tmpdir, input_code, expected_output)
+    def test_config_accessed_variations(
+        self, tmpdir, config_lines, expected_config_lines
+    ):
+        input_code = f"""import flask
+app = flask.Flask(__name__)
+app.secret_key = "dev"
+{config_lines}
+"""
+        expected_output = f"""import flask
+app = flask.Flask(__name__)
+app.secret_key = "dev"
+{expected_config_lines}
+"""
+        self.run_and_assert(tmpdir, dedent(input_code), dedent(expected_output))
 
     @pytest.mark.skip()
     def test_func_scope(self, tmpdir):

--- a/tests/samples/flask_app.py
+++ b/tests/samples/flask_app.py
@@ -1,0 +1,6 @@
+from flask import Flask
+app = Flask(__name__)
+app.config['SESSION_COOKIE_HTTPONLY'] = False
+@app.route('/')
+def hello_world():
+    return 'Hello World!'


### PR DESCRIPTION
## Overview
*A codemod that will check if `SESSION_COOKIE_HTTPONLY`, `SESSION_COOKIE_SECURE` or `SESSION_COOKIE_SAMESITE` are set to an insecure value on a flask app config object.*

## Description

* This codemod checks any instances of a Flask app for any calls to its configuration. If any of those calls leads to setting any of the 3 flags to their unsafe value, this codemod will change the value.
* Note that after quite a bit of back and forth, we've decided this codemod will not at this time add set the secure values for any of these configs. We will only handle the case when the user specifically set to an unsafe value. We're aware that some default values are unsafe. 
* I've left some commented out code which did handle ^ above by adding a line at the very end of the module any of the config values which were not set. We decided there is some risk to adding this line at the end of the module so we won't do so right now.

