### PR TITLE
Run mypy in CI

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -16,7 +16,7 @@ concurrency:
 
 jobs:
   linting:
-    name: Pylint & Black Checks
+    name: Pylint Checks
     runs-on: ubuntu-20.04
     timeout-minutes: 5
     steps:
@@ -29,9 +29,7 @@ jobs:
       - name: Install Codemodder Package
         run: pip install .
       - name: Install Dependencies
-        run: pip install -r requirements/lint.txt
-      - name: Black Format Check
-        run: black --check .
+        run: pip install -r requirements/test.txt
       - name: Run pylint
         run: make lint
 

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -55,3 +55,10 @@ jobs:
         # threshold for pipeline to fail if we go below average, module, or block complexity
         # https://github.com/rubik/xenon
         run: make xenon
+
+  pre-commit:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+    - uses: actions/setup-python@v3
+    - uses: pre-commit/action@v3.0.0

--- a/requirements/lint.txt
+++ b/requirements/lint.txt
@@ -1,3 +1,0 @@
-black==23.11.*
-mypy==1.7.*
--r test.txt


### PR DESCRIPTION
## Overview
*Enable running mypy thru pre-commit in CI*

## Description

* We want to run type checks to avoid regression. Since we already had mypy through pre-commit, I decided to go ahead and enable running pre-commit directly. **The run only runs pre-commit, it does NOT commit anything**. If any pre-commit step fails, CI will fail
* This also meant I removed black from our manual linting step since it's already in pre-commit. 
