### PR TITLE
Support for f-strings in SQLQueryParameterization

### DIFF
--- a/src/codemodder/codemods/transformations/remove_empty_string_concatenation.py
+++ b/src/codemodder/codemods/transformations/remove_empty_string_concatenation.py
@@ -1,11 +1,28 @@
+from typing import Union
 import libcst as cst
-from libcst import CSTTransformer
+from libcst import CSTTransformer, RemovalSentinel, SimpleString
 
 
 class RemoveEmptyStringConcatenation(CSTTransformer):
     """
     Removes concatenation with empty strings (e.g. "hello " + "") or "hello" ""
     """
+
+    def leave_FormattedStringExpression(
+        self,
+        original_node: cst.FormattedStringExpression,
+        updated_node: cst.FormattedStringExpression,
+    ) -> Union[
+        cst.BaseFormattedStringContent,
+        cst.FlattenSentinel[cst.BaseFormattedStringContent],
+        RemovalSentinel,
+    ]:
+        expr = original_node.expression
+        match expr:
+            case SimpleString():  # type: ignore
+                if expr.raw_value == "":
+                    return RemovalSentinel.REMOVE
+        return updated_node
 
     def leave_BinaryOperation(
         self, original_node: cst.BinaryOperation, updated_node: cst.BinaryOperation

--- a/src/codemodder/codemods/transformations/remove_empty_string_concatenation.py
+++ b/src/codemodder/codemods/transformations/remove_empty_string_concatenation.py
@@ -19,9 +19,8 @@ class RemoveEmptyStringConcatenation(CSTTransformer):
     ]:
         expr = original_node.expression
         match expr:
-            case SimpleString():  # type: ignore
-                if expr.raw_value == "":
-                    return RemovalSentinel.REMOVE
+            case SimpleString() if expr.raw_value == "":  # type: ignore
+                return RemovalSentinel.REMOVE
         return updated_node
 
     def leave_BinaryOperation(

--- a/src/codemodder/codemods/utils.py
+++ b/src/codemodder/codemods/utils.py
@@ -76,13 +76,7 @@ class ReplaceNodes(cst.CSTTransformer):
         self,
         replacements: dict[
             cst.CSTNode,
-            dict[
-                str,
-                cst.CSTNode
-                | cst.FlattenSentinel
-                | cst.RemovalSentinel
-                | dict[str, Any],
-            ],
+            cst.CSTNode | cst.FlattenSentinel | cst.RemovalSentinel | dict[str, Any],
         ],
     ):
         self.replacements = replacements

--- a/src/codemodder/codemods/utils.py
+++ b/src/codemodder/codemods/utils.py
@@ -1,8 +1,57 @@
+from enum import Enum
 from pathlib import Path
 from typing import Optional, Any
 
 from libcst import matchers
 import libcst as cst
+
+
+class BaseType(Enum):
+    """
+    An enumeration representing the base literal types in Python.
+    """
+
+    NUMBER = 1
+    LIST = 2
+    STRING = 3
+    BYTES = 4
+
+    @classmethod
+    # pylint: disable-next=R0911
+    def infer_expression_type(cls, node: cst.BaseExpression) -> Optional["BaseType"]:
+        """
+        Tries to infer if the type of a given expression is one of the base literal types.
+        """
+        # The current implementation could be enhanced with a few more cases
+        match node:
+            case cst.Integer() | cst.Imaginary() | cst.Float() | cst.Call(
+                func=cst.Name("int")
+            ) | cst.Call(func=cst.Name("float")) | cst.Call(
+                func=cst.Name("abs")
+            ) | cst.Call(
+                func=cst.Name("len")
+            ):
+                return BaseType.NUMBER
+            case cst.Call(name=cst.Name("list")) | cst.List() | cst.ListComp():
+                return BaseType.LIST
+            case cst.Call(func=cst.Name("str")) | cst.FormattedString():
+                return BaseType.STRING
+            case cst.SimpleString():
+                if "b" in node.prefix.lower():
+                    return BaseType.BYTES
+                return BaseType.STRING
+            case cst.ConcatenatedString():
+                return cls.infer_expression_type(node.left)
+            case cst.BinaryOperation(operator=cst.Add()):
+                return cls.infer_expression_type(
+                    node.left
+                ) or cls.infer_expression_type(node.right)
+            case cst.IfExp():
+                if_true = cls.infer_expression_type(node.body)
+                or_else = cls.infer_expression_type(node.orelse)
+                if if_true == or_else:
+                    return if_true
+        return None
 
 
 class SequenceExtension:

--- a/src/core_codemods/sql_parameterization.py
+++ b/src/core_codemods/sql_parameterization.py
@@ -1,5 +1,5 @@
 import re
-from typing import Optional, Tuple
+from typing import Any, Optional, Tuple
 import itertools
 import libcst as cst
 from libcst import FormattedString, SimpleWhitespace, ensure_type, matchers
@@ -38,10 +38,6 @@ from codemodder.file_context import FileContext
 
 parameter_token = "?"
 
-literal_number = matchers.Integer() | matchers.Float() | matchers.Imaginary()
-literal_string = matchers.SimpleString()
-literal = literal_number | literal_string
-
 quote_pattern = re.compile(r"(?<!\\)\\'|(?<!\\)'")
 raw_quote_pattern = re.compile(r"(?<!\\)'")
 
@@ -78,7 +74,8 @@ class SQLQueryParameterization(BaseCodemod, UtilsMixin, Codemod):
         *codemod_args,
     ) -> None:
         self.changed_nodes: dict[
-            cst.CSTNode, cst.CSTNode | cst.RemovalSentinel | cst.FlattenSentinel
+            cst.CSTNode,
+            cst.CSTNode | cst.RemovalSentinel | cst.FlattenSentinel | dict[str, Any],
         ] = {}
         BaseCodemod.__init__(self, file_context, *codemod_args)
         UtilsMixin.__init__(self, [])
@@ -237,7 +234,7 @@ class SQLQueryParameterization(BaseCodemod, UtilsMixin, Codemod):
 
         new_raw_value = raw_value[quote_span.end() :]
         append_raw_value = raw_value[: quote_span.start()]
-        match end:
+        match current_end:
             case cst.SimpleString():
                 # gather string up to quote to parameter
                 if append_raw_value:

--- a/tests/codemods/test_sql_parameterization.py
+++ b/tests/codemods/test_sql_parameterization.py
@@ -51,6 +51,26 @@ class TestSQLQueryParameterization(BaseCodemodTest):
         self.run_and_assert(tmpdir, dedent(input_code), dedent(expected))
         assert len(self.file_context.codemod_changes) == 1
 
+    def test_simple_with_quotes_in_middle(self, tmpdir):
+        input_code = """\
+        import sqlite3
+
+        name = input()
+        connection = sqlite3.connect("my_db.db")
+        cursor = connection.cursor()
+        cursor.execute(r"SELECT * from USERS WHERE name ='user_" + name + r"_system'")
+        """
+        expected = """\
+        import sqlite3
+
+        name = input()
+        connection = sqlite3.connect("my_db.db")
+        cursor = connection.cursor()
+        cursor.execute(r"SELECT * from USERS WHERE name =?", (r"user_" + name + r"_system", ))
+        """
+        self.run_and_assert(tmpdir, dedent(input_code), dedent(expected))
+        assert len(self.file_context.codemod_changes) == 1
+
     def test_can_deal_with_multiple_variables(self, tmpdir):
         input_code = """\
         import sqlite3

--- a/tests/codemods/test_sql_parameterization.py
+++ b/tests/codemods/test_sql_parameterization.py
@@ -158,10 +158,7 @@ class TestSQLQueryParameterization(BaseCodemodTest):
         self.run_and_assert(tmpdir, dedent(input_code), dedent(expected))
         assert len(self.file_context.codemod_changes) == 1
 
-    # negative tests below
-
     def test_formatted_string_simple(self, tmpdir):
-        # TODO change when we add support for it
         input_code = """\
         import sqlite3
 
@@ -170,8 +167,18 @@ class TestSQLQueryParameterization(BaseCodemodTest):
         cursor = connection.cursor()
         cursor.execute(f"SELECT * from USERS WHERE name='{name}'")
         """
-        self.run_and_assert(tmpdir, dedent(input_code), dedent(input_code))
-        assert len(self.file_context.codemod_changes) == 0
+        expected = """\
+        import sqlite3
+
+        name = input()
+        connection = sqlite3.connect("my_db.db")
+        cursor = connection.cursor()
+        cursor.execute("SELECT * from USERS WHERE name=?", (name, ))
+        """
+        self.run_and_assert(tmpdir, dedent(input_code), dedent(expected))
+        assert len(self.file_context.codemod_changes) == 1
+
+    # negative tests below
 
     def test_no_sql_keyword(self, tmpdir):
         input_code = """\

--- a/tests/test_basetype.py
+++ b/tests/test_basetype.py
@@ -1,36 +1,36 @@
 import libcst as cst
-from codemodder.codemods.utils import BaseType
+from codemodder.codemods.utils import BaseType, infer_expression_type
 
 
 class TestBaseType:
     def test_binary_op_number(self):
         e = cst.parse_expression("1 + float(2)")
-        assert BaseType.infer_expression_type(e) == BaseType.NUMBER
+        assert infer_expression_type(e) == BaseType.NUMBER
 
     def test_binary_op_string_mixed(self):
         e = cst.parse_expression('f"a"+foo()')
-        assert BaseType.infer_expression_type(e) == BaseType.STRING
+        assert infer_expression_type(e) == BaseType.STRING
 
     def test_binary_op_list(self):
         e = cst.parse_expression("[1,2] + [x for x in [3]] + list((4,5))")
-        assert BaseType.infer_expression_type(e) == BaseType.LIST
+        assert infer_expression_type(e) == BaseType.LIST
 
     def test_binary_op_none(self):
         e = cst.parse_expression("foo() + bar()")
-        assert BaseType.infer_expression_type(e) == None
+        assert infer_expression_type(e) == None
 
     def test_bytes(self):
         e = cst.parse_expression('b"123"')
-        assert BaseType.infer_expression_type(e) == BaseType.BYTES
+        assert infer_expression_type(e) == BaseType.BYTES
 
     def test_if_mixed(self):
         e = cst.parse_expression('1 if True else "a"')
-        assert BaseType.infer_expression_type(e) == None
+        assert infer_expression_type(e) == None
 
     def test_if_numbers(self):
         e = cst.parse_expression("abs(1) if True else 2")
-        assert BaseType.infer_expression_type(e) == BaseType.NUMBER
+        assert infer_expression_type(e) == BaseType.NUMBER
 
     def test_if_numbers2(self):
         e = cst.parse_expression("float(1) if True else len([1,2])")
-        assert BaseType.infer_expression_type(e) == BaseType.NUMBER
+        assert infer_expression_type(e) == BaseType.NUMBER

--- a/tests/test_basetype.py
+++ b/tests/test_basetype.py
@@ -1,0 +1,36 @@
+import libcst as cst
+from codemodder.codemods.utils import BaseType
+
+
+class TestBaseType:
+    def test_binary_op_number(self):
+        e = cst.parse_expression("1 + float(2)")
+        assert BaseType.infer_expression_type(e) == BaseType.NUMBER
+
+    def test_binary_op_string_mixed(self):
+        e = cst.parse_expression('f"a"+foo()')
+        assert BaseType.infer_expression_type(e) == BaseType.STRING
+
+    def test_binary_op_list(self):
+        e = cst.parse_expression("[1,2] + [x for x in [3]] + list((4,5))")
+        assert BaseType.infer_expression_type(e) == BaseType.LIST
+
+    def test_binary_op_none(self):
+        e = cst.parse_expression("foo() + bar()")
+        assert BaseType.infer_expression_type(e) == None
+
+    def test_bytes(self):
+        e = cst.parse_expression('b"123"')
+        assert BaseType.infer_expression_type(e) == BaseType.BYTES
+
+    def test_if_mixed(self):
+        e = cst.parse_expression('1 if True else "a"')
+        assert BaseType.infer_expression_type(e) == None
+
+    def test_if_numbers(self):
+        e = cst.parse_expression("abs(1) if True else 2")
+        assert BaseType.infer_expression_type(e) == BaseType.NUMBER
+
+    def test_if_numbers2(self):
+        e = cst.parse_expression("float(1) if True else len([1,2])")
+        assert BaseType.infer_expression_type(e) == BaseType.NUMBER


### PR DESCRIPTION
## Overview
Added support for query parameterization contained in f-strings.

## Description

Aside from the main change, the following are of note:
- Added a new utility: `BaseType` to represent literal types in python. It comes along with a method to infer an expression type from a few common cases
- Changed how multiple expressions in a single injection are parameterized. The reason is to avoid problems with type conversions. For example, given the following:
```
cursor.execute("SELECT * FROM users where name ='" + name + '_and_' + lastname + "'")
```
will now produce:
```
cursor.execure("SELECT * FROM users where name =?", ('{0}_and_{1}'.format(name, lastname), ))
```
while before it would result in:
```
cursor.execure("SELECT * FROM users where name =?", (name + '_and_' + lastname, ))
```

The `.format` method was chosen for compatibility. While f-strings would look better, they require python 3.6+.

