### PR TITLE
Handle requirements.txt files without trailing newlines

### DIFF
--- a/src/codemodder/codemodder.py
+++ b/src/codemodder/codemodder.py
@@ -1,6 +1,5 @@
 from concurrent.futures import ThreadPoolExecutor
 import datetime
-import difflib
 import itertools
 import logging
 import os
@@ -17,6 +16,7 @@ from codemodder.cli import parse_args
 from codemodder.change import ChangeSet
 from codemodder.code_directory import file_line_patterns, match_files
 from codemodder.context import CodemodExecutionContext
+from codemodder.diff import create_diff as create_diff_from_lines
 from codemodder.executor import CodemodExecutorWrapper
 from codemodder.project_analysis.python_repo_manager import PythonRepoManager
 from codemodder.report.codetf_reporter import report_default
@@ -49,18 +49,13 @@ def find_semgrep_results(
 
 
 def create_diff(original_tree: cst.Module, new_tree: cst.Module) -> str:
-    diff_lines = list(
-        difflib.unified_diff(
-            original_tree.code.splitlines(keepends=True),
-            new_tree.code.splitlines(keepends=True),
-        )
+    """
+    Create a diff between the original and output trees.
+    """
+    return create_diff_from_lines(
+        original_tree.code.splitlines(keepends=True),
+        new_tree.code.splitlines(keepends=True),
     )
-    # All but the last diff line should end with a newline
-    # The last diff line should be preserved as-is (with or without a newline)
-    diff_lines = [
-        line if line.endswith("\n") else line + "\n" for line in diff_lines[:-1]
-    ] + [diff_lines[-1]]
-    return "".join(diff_lines)
 
 
 def apply_codemod_to_file(

--- a/src/codemodder/diff.py
+++ b/src/codemodder/diff.py
@@ -1,0 +1,12 @@
+import difflib
+
+
+def create_diff(original_lines: list[str], new_lines: list[str]) -> str:
+    diff_lines = list(difflib.unified_diff(original_lines, new_lines))
+
+    # All but the last diff line should end with a newline
+    # The last diff line should be preserved as-is (with or without a newline)
+    diff_lines = [
+        line if line.endswith("\n") else line + "\n" for line in diff_lines[:-1]
+    ] + [diff_lines[-1]]
+    return "".join(diff_lines)

--- a/tests/test_dependency_manager.py
+++ b/tests/test_dependency_manager.py
@@ -40,11 +40,11 @@ class TestDependencyManager:
         assert changeset.diff == (
             "--- \n"
             "+++ \n"
-            "@@ -1,3 +1,5 @@\n"
+            "@@ -1,3 +1,4 @@\n"
             " # comment\n"
             " \n"
             " requests\n"
-            "+defusedxml~=0.7.1+\n"
+            "+defusedxml~=0.7.1\n"
         )
         assert len(changeset.changes) == 1
         assert changeset.changes[0].lineNumber == 4
@@ -96,7 +96,18 @@ class TestDependencyManager:
 
         dm = DependencyManager(Path(tmpdir))
         dm.add([Security])
-        dm.write()
+        changeset = dm.write()
+
+        assert changeset is not None
+        assert changeset.diff == (
+            "--- \n"
+            "+++ \n"
+            "@@ -1,2 +1,3 @@\n"
+            " requests\n"
+            "-whatever\n"
+            "+whatever\n"
+            "+security~=1.2.0\n"
+        )
 
         assert dependency_file.read_text(encoding="utf-8") == (
             "requests\nwhatever\nsecurity~=1.2.0\n"


### PR DESCRIPTION
## Overview
*Correctly generate diffs when adding dependencies to `requirements.txt` files without trailing newlines*

## Description

* This was fixed for libcst codemods in general but `requirements.txt` is a special case
