### PR TITLE
Specify position in split diff for contextual comment

### DIFF
--- a/src/codemodder/dependency_manager.py
+++ b/src/codemodder/dependency_manager.py
@@ -51,7 +51,11 @@ class DependencyManager:
             Change(
                 lineNumber=len(original_lines) + i + 1,
                 description=dep.build_description(),
-                properties={"contextual_description": True},
+                # Contextual comments should be added to the right side of split diffs
+                properties={
+                    "contextual_description": True,
+                    "contextual_description_position": "right",
+                },
                 packageActions=[
                     PackageAction(Action.ADD, Result.COMPLETED, str(dep.requirement))
                 ],

--- a/tests/test_dependency_manager.py
+++ b/tests/test_dependency_manager.py
@@ -49,7 +49,10 @@ class TestDependencyManager:
         assert len(changeset.changes) == 1
         assert changeset.changes[0].lineNumber == 4
         assert changeset.changes[0].description == DefusedXML.build_description()
-        assert changeset.changes[0].properties == {"contextual_description": True}
+        assert changeset.changes[0].properties == {
+            "contextual_description": True,
+            "contextual_description_position": "right",
+        }
 
     def test_add_multiple_dependencies(self, tmpdir):
         dependency_file = Path(tmpdir) / "requirements.txt"


### PR DESCRIPTION
## Overview
*Provide additional information about position of contextual comment in split diffs*

## Description

* Currently the only contextual comments we add belong to new dependencies, so they belong on the right side of a split diff
* Eventually we may add contextual comments for removed code, in which case we would specify the left side