### PR TITLE
Integrate Repo Manager

### DIFF
--- a/src/codemodder/codemodder.py
+++ b/src/codemodder/codemodder.py
@@ -93,6 +93,7 @@ def apply_codemod_to_file(
     return True
 
 
+# pylint: disable-next=too-many-arguments
 def process_file(
     idx: int,
     file_path: Path,
@@ -100,7 +101,7 @@ def process_file(
     codemod,
     results: ResultSet,
     cli_args,
-):  # pylint: disable=too-many-arguments
+) -> FileContext:
     logger.debug("scanning file %s", file_path)
     if idx and idx % 100 == 0:
         logger.info("scanned %s files...", idx)  # pragma: no cover
@@ -262,8 +263,8 @@ def run(original_args) -> int:
         codemod_registry,
         repo_manager,
     )
-    # todo: enable when ready
-    # repo_manager.package_stores
+
+    repo_manager.parse_project()
 
     # TODO: this should be a method of CodemodExecutionContext
     codemods_to_run = codemod_registry.match_codemods(

--- a/src/codemodder/context.py
+++ b/src/codemodder/context.py
@@ -87,20 +87,23 @@ class CodemodExecutionContext:  # pylint: disable=too-many-instance-attributes
         )
 
     def process_dependencies(self, codemod_id: str):
+        """Write the dependencies a codemod added to the appropriate dependency
+        file in the project.
+        """
         dependencies = self.dependencies.get(codemod_id)
         if not dependencies:
             return
 
-        dm = DependencyManager(self.directory)
-        if not dm.found_dependency_file:
+        dependencies_store = self.repo_manager.dependencies_store
+        if dependencies_store is None:
             logger.info(
                 "unable to write dependencies for %s: no dependency file found",
                 codemod_id,
             )
             return
 
-        dm.add(list(dependencies))
-        if (changeset := dm.write(self.dry_run)) is not None:
+        dm = DependencyManager(dependencies_store, self.directory)
+        if (changeset := dm.write(list(dependencies), self.dry_run)) is not None:
             self.add_results(codemod_id, [changeset])
 
     def add_description(self, codemod: CodemodExecutorWrapper):

--- a/src/codemodder/dependency_management/__init__.py
+++ b/src/codemodder/dependency_management/__init__.py
@@ -1,1 +1,1 @@
-from .dependency_manager import DependencyManager, Requirement
+from .dependency_manager import DependencyManager

--- a/src/codemodder/dependency_management/base_dependency_writer.py
+++ b/src/codemodder/dependency_management/base_dependency_writer.py
@@ -21,12 +21,12 @@ class DependencyWriter(metaclass=ABCMeta):
     ) -> Optional[ChangeSet]:
         pass
 
-    def add(self, dependencies: list[Dependency]) -> Optional[list[Dependency]]:
+    def add(self, dependencies: list[Dependency]) -> list[Dependency]:
         """add any number of dependencies to the end of list of dependencies."""
         new = []
         for new_dep in dependencies:
             requirement: Requirement = new_dep.requirement
             if requirement not in self.dependency_store.dependencies:
-                self.dependency_store.dependencies.append(requirement)
+                self.dependency_store.dependencies.add(requirement)
                 new.append(new_dep)
         return new

--- a/src/codemodder/dependency_management/base_dependency_writer.py
+++ b/src/codemodder/dependency_management/base_dependency_writer.py
@@ -1,0 +1,19 @@
+from abc import ABCMeta, abstractmethod
+from pathlib import Path
+from typing import Optional
+
+from codemodder.change import ChangeSet
+from codemodder.dependency import Requirement
+
+
+class DependencyWriter(metaclass=ABCMeta):
+    path: Path
+
+    def __init__(self, path: str | Path):
+        self.path = Path(path)
+
+    @abstractmethod
+    def write(
+        self, dependencies: list[Requirement], dry_run: bool = False
+    ) -> Optional[ChangeSet]:
+        pass

--- a/src/codemodder/dependency_management/base_dependency_writer.py
+++ b/src/codemodder/dependency_management/base_dependency_writer.py
@@ -1,19 +1,32 @@
 from abc import ABCMeta, abstractmethod
 from pathlib import Path
 from typing import Optional
-
+from codemodder.project_analysis.file_parsers.package_store import PackageStore
 from codemodder.change import ChangeSet
-from codemodder.dependency import Requirement
+from codemodder.dependency import Dependency
+from packaging.requirements import Requirement
 
 
 class DependencyWriter(metaclass=ABCMeta):
-    path: Path
+    dependency_store: PackageStore
 
-    def __init__(self, path: str | Path):
-        self.path = Path(path)
+    def __init__(self, dependency_store: PackageStore, parent_directory: Path):
+        self.dependency_store = dependency_store
+        self.path = Path(dependency_store.file)
+        self.parent_directory = parent_directory
 
     @abstractmethod
     def write(
         self, dependencies: list[Requirement], dry_run: bool = False
     ) -> Optional[ChangeSet]:
         pass
+
+    def add(self, dependencies: list[Dependency]) -> Optional[list[Dependency]]:
+        """add any number of dependencies to the end of list of dependencies."""
+        new = []
+        for new_dep in dependencies:
+            requirement: Requirement = new_dep.requirement
+            if requirement not in self.dependency_store.dependencies:
+                self.dependency_store.dependencies.append(requirement)
+                new.append(new_dep)
+        return new

--- a/src/codemodder/dependency_management/base_dependency_writer.py
+++ b/src/codemodder/dependency_management/base_dependency_writer.py
@@ -17,7 +17,7 @@ class DependencyWriter(metaclass=ABCMeta):
 
     @abstractmethod
     def write(
-        self, dependencies: list[Requirement], dry_run: bool = False
+        self, dependencies: list[Dependency], dry_run: bool = False
     ) -> Optional[ChangeSet]:
         pass
 

--- a/src/codemodder/dependency_management/dependency_manager.py
+++ b/src/codemodder/dependency_management/dependency_manager.py
@@ -1,110 +1,32 @@
-from functools import cached_property
-from pathlib import Path
 from typing import Optional
-
-from packaging.requirements import Requirement
-
-from codemodder.change import Action, Change, ChangeSet, PackageAction, Result
-from codemodder.diff import create_diff
+from codemodder.change import ChangeSet
 from codemodder.dependency import Dependency
+from codemodder.dependency_management.requirements_txt_writer import (
+    RequirementsTxtWriter,
+)
+from codemodder.project_analysis.file_parsers.package_store import PackageStore
+from pathlib import Path
 
 
 class DependencyManager:
+    dependencies_store: PackageStore
     parent_directory: Path
-    _lines: list[str]
-    _new_requirements: list[Dependency]
 
-    def __init__(self, parent_directory: Path):
+    def __init__(self, dependencies_store: PackageStore, parent_directory: Path):
+        self.dependencies_store = dependencies_store
         self.parent_directory = parent_directory
-        self.dependency_file_changed = False
-        self._lines = []
-        self._new_requirements = []
 
-    @property
-    def new_requirements(self) -> list[str]:
-        return [str(x.requirement) for x in self._new_requirements]
-
-    def add(self, dependencies: list[Dependency]):
-        """add any number of dependencies to the end of list of dependencies."""
-        for dep in dependencies:
-            if dep.requirement.name not in self.dependencies:
-                self.dependencies.update({dep.requirement.name: dep.requirement})
-                self._new_requirements.append(dep)
-
-    def write(self, dry_run: bool = False) -> Optional[ChangeSet]:
+    def write(
+        self, dependencies: list[Dependency], dry_run: bool = False
+    ) -> Optional[ChangeSet]:
         """
-        Write the updated dependency files if any changes were made.
+        Write `dependencies` to the appropriate location in the project.
         """
-        if not (self.dependency_file and self._new_requirements):
-            return None
-
-        original_lines = self._lines.copy()
-        if not original_lines[-1].endswith("\n"):
-            original_lines[-1] += "\n"
-
-        requirement_lines = [f"{req}\n" for req in self.new_requirements]
-
-        updated = original_lines + requirement_lines
-        diff = create_diff(self._lines, updated)
-
-        changes = [
-            Change(
-                lineNumber=len(original_lines) + i + 1,
-                description=dep.build_description(),
-                # Contextual comments should be added to the right side of split diffs
-                properties={
-                    "contextual_description": True,
-                    "contextual_description_position": "right",
-                },
-                packageActions=[
-                    PackageAction(Action.ADD, Result.COMPLETED, str(dep.requirement))
-                ],
-            )
-            for i, dep in enumerate(self._new_requirements)
-        ]
-
-        if not dry_run:
-            with open(self.dependency_file, "w", encoding="utf-8") as f:
-                f.writelines(original_lines)
-                f.writelines(requirement_lines)
-
-        self.dependency_file_changed = True
-        return ChangeSet(
-            str(self.dependency_file.relative_to(self.parent_directory)),
-            diff,
-            changes=changes,
-        )
-
-    @property
-    def found_dependency_file(self) -> bool:
-        return self.dependency_file is not None
-
-    @cached_property
-    def dependency_file(self) -> Optional[Path]:
-        try:
-            # For now for simplicity only return the first file
-            return next(Path(self.parent_directory).rglob("requirements.txt"))
-        except StopIteration:
-            pass
+        match self.dependencies_store.type:
+            case "requirements.txt":
+                return RequirementsTxtWriter(
+                    self.dependencies_store, self.parent_directory
+                ).write(dependencies, dry_run)
+            case "setup.py":
+                pass
         return None
-
-    @cached_property
-    def dependencies(self) -> dict[str, Requirement]:
-        """
-        Extract list of dependencies from requirements.txt file.
-        Same order of requirements is maintained, no alphabetical sorting is done.
-        """
-        if not self.dependency_file:
-            return {}
-
-        with open(self.dependency_file, "r", encoding="utf-8") as f:
-            self._lines = f.readlines()
-
-        return {
-            requirement.name: requirement
-            for x in self._lines
-            # Skip empty lines and comments
-            if (line := x.strip())
-            and not line.startswith("#")
-            and (requirement := Requirement(line))
-        }

--- a/src/codemodder/dependency_management/requirements_txt_writer.py
+++ b/src/codemodder/dependency_management/requirements_txt_writer.py
@@ -1,8 +1,57 @@
+from typing import Optional
 from codemodder.dependency_management.base_dependency_writer import DependencyWriter
+from codemodder.change import Action, Change, ChangeSet, PackageAction, Result
+from packaging.requirements import Requirement
+from codemodder.diff import create_diff
 
 
 class RequirementsTxtWriter(DependencyWriter):
     def write(
         self, dependencies: list[Requirement], dry_run: bool = False
     ) -> Optional[ChangeSet]:
-        pass
+        new_dependencies = self.add(dependencies)
+        if new_dependencies:
+            return self.add_to_file(new_dependencies, dry_run)
+        return None
+
+    def add_to_file(self, dependencies: list[Requirement], dry_run: bool):
+        original_lines = self._parse_file()
+        updated_lines = original_lines.copy()
+        if not original_lines[-1].endswith("\n"):
+            updated_lines[-1] += "\n"
+
+        requirement_lines = [f"{dep.requirement}\n" for dep in dependencies]
+        updated_lines += requirement_lines
+
+        diff = create_diff(original_lines, updated_lines)
+
+        changes = [
+            Change(
+                lineNumber=len(original_lines) + i + 1,
+                description=dep.build_description(),
+                # Contextual comments should be added to the right side of split diffs
+                properties={
+                    "contextual_description": True,
+                    "contextual_description_position": "right",
+                },
+                packageActions=[
+                    PackageAction(Action.ADD, Result.COMPLETED, str(dep.requirement))
+                ],
+            )
+            for i, dep in enumerate(dependencies)
+        ]
+
+        if not dry_run:
+            with open(self.path, "w", encoding="utf-8") as f:
+                f.writelines(original_lines)
+                f.writelines(requirement_lines)
+
+        return ChangeSet(
+            str(self.path.relative_to(self.parent_directory)),
+            diff,
+            changes=changes,
+        )
+
+    def _parse_file(self):
+        with open(self.path, "r", encoding="utf-8") as f:
+            return f.readlines()

--- a/src/codemodder/dependency_management/requirements_txt_writer.py
+++ b/src/codemodder/dependency_management/requirements_txt_writer.py
@@ -1,0 +1,8 @@
+from codemodder.dependency_management.base_dependency_writer import DependencyWriter
+
+
+class RequirementsTxtWriter(DependencyWriter):
+    def write(
+        self, dependencies: list[Requirement], dry_run: bool = False
+    ) -> Optional[ChangeSet]:
+        pass

--- a/src/codemodder/dependency_management/requirements_txt_writer.py
+++ b/src/codemodder/dependency_management/requirements_txt_writer.py
@@ -1,13 +1,14 @@
 from typing import Optional
 from codemodder.dependency_management.base_dependency_writer import DependencyWriter
 from codemodder.change import Action, Change, ChangeSet, PackageAction, Result
-from packaging.requirements import Requirement
 from codemodder.diff import create_diff
+from codemodder.dependency import Dependency
+from packaging.requirements import Requirement
 
 
 class RequirementsTxtWriter(DependencyWriter):
     def write(
-        self, dependencies: list[Requirement], dry_run: bool = False
+        self, dependencies: list[Dependency], dry_run: bool = False
     ) -> Optional[ChangeSet]:
         new_dependencies = self.add(dependencies)
         if new_dependencies:
@@ -15,13 +16,13 @@ class RequirementsTxtWriter(DependencyWriter):
         return None
 
     def add_to_file(self, dependencies: list[Requirement], dry_run: bool):
-        original_lines = self._parse_file()
-        updated_lines = original_lines.copy()
+        lines = self._parse_file()
+        original_lines = lines.copy()
         if not original_lines[-1].endswith("\n"):
-            updated_lines[-1] += "\n"
+            original_lines[-1] += "\n"
 
         requirement_lines = [f"{dep.requirement}\n" for dep in dependencies]
-        updated_lines += requirement_lines
+        updated_lines = original_lines + requirement_lines
 
         diff = create_diff(original_lines, updated_lines)
 
@@ -43,8 +44,7 @@ class RequirementsTxtWriter(DependencyWriter):
 
         if not dry_run:
             with open(self.path, "w", encoding="utf-8") as f:
-                f.writelines(original_lines)
-                f.writelines(requirement_lines)
+                f.writelines(updated_lines)
 
         return ChangeSet(
             str(self.path.relative_to(self.parent_directory)),

--- a/src/codemodder/project_analysis/file_parsers/package_store.py
+++ b/src/codemodder/project_analysis/file_parsers/package_store.py
@@ -6,5 +6,5 @@ from packaging.requirements import Requirement
 class PackageStore:
     type: str
     file: str
-    dependencies: list[Requirement]
+    dependencies: set[Requirement]
     py_versions: list[str]

--- a/src/codemodder/project_analysis/file_parsers/pyproject_toml_file_parser.py
+++ b/src/codemodder/project_analysis/file_parsers/pyproject_toml_file_parser.py
@@ -28,6 +28,6 @@ class PyprojectTomlParser(BaseParser):
         return PackageStore(
             type=self.file_name,
             file=str(file),
-            dependencies=self._parse_dependencies_from_toml(data),
+            dependencies=set(self._parse_dependencies_from_toml(data)),
             py_versions=self._parse_py_versions(data),
         )

--- a/src/codemodder/project_analysis/file_parsers/requirements_txt_file_parser.py
+++ b/src/codemodder/project_analysis/file_parsers/requirements_txt_file_parser.py
@@ -15,7 +15,7 @@ class RequirementsTxtParser(BaseParser):
         return PackageStore(
             type=self.file_name,
             file=str(file),
-            dependencies=self._parse_dependencies(lines),
+            dependencies=set(self._parse_dependencies(lines)),
             # requirements.txt files do not declare py versions explicitly
             # though we could create a heuristic by analyzing each dependency
             # and extracting py versions from them.

--- a/src/codemodder/project_analysis/file_parsers/setup_cfg_file_parser.py
+++ b/src/codemodder/project_analysis/file_parsers/setup_cfg_file_parser.py
@@ -32,6 +32,6 @@ class SetupCfgParser(BaseParser):
         return PackageStore(
             type=self.file_name,
             file=str(file),
-            dependencies=self._parse_dependencies_from_cfg(config),
+            dependencies=set(self._parse_dependencies_from_cfg(config)),
             py_versions=self._parse_py_versions(config),
         )

--- a/src/codemodder/project_analysis/file_parsers/setup_py_file_parser.py
+++ b/src/codemodder/project_analysis/file_parsers/setup_py_file_parser.py
@@ -41,7 +41,9 @@ class SetupPyParser(BaseParser):
         return PackageStore(
             type=self.file_name,
             file=str(file),
-            dependencies=self._parse_dependencies_from_cst(visitor.install_requires),
+            dependencies=set(
+                self._parse_dependencies_from_cst(visitor.install_requires)
+            ),
             py_versions=self._parse_py_versions(visitor.python_requires),
         )
 

--- a/src/codemodder/project_analysis/python_repo_manager.py
+++ b/src/codemodder/project_analysis/python_repo_manager.py
@@ -1,5 +1,6 @@
 from functools import cached_property
 from pathlib import Path
+from typing import Optional
 from codemodder.project_analysis.file_parsers import (
     RequirementsTxtParser,
     PyprojectTomlParser,
@@ -20,8 +21,21 @@ class PythonRepoManager:
         ]
 
     @cached_property
+    def dependencies_store(self) -> Optional[PackageStore]:
+        """The location where to write new dependencies for project.
+        For now just pick the first store found with order given by _potential_stores.
+        """
+        if self.package_stores:
+            return self.package_stores[0]
+        return None
+
+    @cached_property
     def package_stores(self) -> list[PackageStore]:
         return self._parse_all_stores()
+
+    def parse_project(self) -> list[PackageStore]:
+        """Wrapper around cached-property for clarity when calling it the first time."""
+        return self.package_stores
 
     def _parse_all_stores(self) -> list[PackageStore]:
         discovered_pkg_stores: list[PackageStore] = []

--- a/tests/dependency_management/test_dependency_manager.py
+++ b/tests/dependency_management/test_dependency_manager.py
@@ -15,7 +15,7 @@ def disable_write_dependencies():
 class TestDependencyManager:
     def test_cant_write_unknown_store(self, tmpdir):
         store = PackageStore(
-            type="unknown", file="idk.txt", dependencies=[], py_versions=[]
+            type="unknown", file="idk.txt", dependencies=set(), py_versions=[]
         )
 
         dm = DependencyManager(store, tmpdir)

--- a/tests/dependency_management/test_requirements_txt_writer.py
+++ b/tests/dependency_management/test_requirements_txt_writer.py
@@ -21,7 +21,7 @@ class TestRequirementsTxtWriter:
         store = PackageStore(
             type="requirements.txt",
             file=str(dependency_file),
-            dependencies=[],
+            dependencies=set(),
             py_versions=[],
         )
         writer = RequirementsTxtWriter(store, Path(tmpdir))
@@ -69,7 +69,7 @@ class TestRequirementsTxtWriter:
         store = PackageStore(
             type="requirements.txt",
             file=str(dependency_file),
-            dependencies=[],
+            dependencies=set(),
             py_versions=[],
         )
         writer = RequirementsTxtWriter(store, Path(tmpdir))
@@ -89,7 +89,7 @@ class TestRequirementsTxtWriter:
         store = PackageStore(
             type="requirements.txt",
             file=str(dependency_file),
-            dependencies=[Security.requirement],
+            dependencies=set([Security.requirement]),
             py_versions=[],
         )
         writer = RequirementsTxtWriter(store, Path(tmpdir))
@@ -106,7 +106,7 @@ class TestRequirementsTxtWriter:
         store = PackageStore(
             type="requirements.txt",
             file=str(dependency_file),
-            dependencies=[],
+            dependencies=set(),
             py_versions=[],
         )
         writer = RequirementsTxtWriter(store, Path(tmpdir))

--- a/tests/dependency_management/test_requirements_txt_writer.py
+++ b/tests/dependency_management/test_requirements_txt_writer.py
@@ -1,0 +1,132 @@
+import pytest
+from pathlib import Path
+from codemodder.dependency_management.requirements_txt_writer import (
+    RequirementsTxtWriter,
+)
+from codemodder.project_analysis.file_parsers.package_store import PackageStore
+from codemodder.dependency import DefusedXML, Security
+
+
+@pytest.fixture(autouse=True, scope="module")
+def disable_write_dependencies():
+    """Override fixture from conftest.py in order to allow testing"""
+
+
+class TestRequirementsTxtWriter:
+    @pytest.mark.parametrize("dry_run", [True, False])
+    def test_add_dependencies_preserve_comments(self, tmpdir, dry_run):
+        contents = "# comment\n\nrequests\n"
+        dependency_file = Path(tmpdir) / "requirements.txt"
+        dependency_file.write_text(contents, encoding="utf-8")
+        store = PackageStore(
+            type="requirements.txt",
+            file=str(dependency_file),
+            dependencies=[],
+            py_versions=[],
+        )
+        writer = RequirementsTxtWriter(store, Path(tmpdir))
+        dependencies = [DefusedXML, Security]
+        changeset = writer.write(dependencies, dry_run=dry_run)
+
+        assert dependency_file.read_text(encoding="utf-8") == (
+            contents
+            if dry_run
+            else "# comment\n\nrequests\ndefusedxml~=0.7.1\nsecurity~=1.2.0\n"
+        )
+
+        assert changeset is not None
+        assert changeset.path == dependency_file.name
+        assert changeset.diff == (
+            "--- \n"
+            "+++ \n"
+            "@@ -1,3 +1,5 @@\n"
+            " # comment\n"
+            " \n"
+            " requests\n"
+            "+defusedxml~=0.7.1\n"
+            "+security~=1.2.0\n"
+        )
+        assert len(changeset.changes) == 2
+        change_one = changeset.changes[0]
+        assert change_one.lineNumber == 4
+        assert change_one.description == DefusedXML.build_description()
+        assert change_one.properties == {
+            "contextual_description": True,
+            "contextual_description_position": "right",
+        }
+        change_two = changeset.changes[1]
+        assert change_two.lineNumber == 5
+        assert change_two.description == Security.build_description()
+        assert change_two.properties == {
+            "contextual_description": True,
+            "contextual_description_position": "right",
+        }
+
+    def test_add_same_dependency_only_once(self, tmpdir):
+        dependency_file = Path(tmpdir) / "requirements.txt"
+        dependency_file.write_text("requests\n", encoding="utf-8")
+
+        store = PackageStore(
+            type="requirements.txt",
+            file=str(dependency_file),
+            dependencies=[],
+            py_versions=[],
+        )
+        writer = RequirementsTxtWriter(store, Path(tmpdir))
+        dependencies = [Security, Security]
+        changeset = writer.write(dependencies)
+        assert len(changeset.changes) == 1
+
+        assert dependency_file.read_text(encoding="utf-8") == (
+            "requests\nsecurity~=1.2.0\n"
+        )
+
+    def test_dont_add_existing_dependency(self, tmpdir):
+        dependency_file = Path(tmpdir) / "requirements.txt"
+        contents = "requests\nsecurity~=1.2.0\n"
+        dependency_file.write_text(contents, encoding="utf-8")
+
+        store = PackageStore(
+            type="requirements.txt",
+            file=str(dependency_file),
+            dependencies=[Security.requirement],
+            py_versions=[],
+        )
+        writer = RequirementsTxtWriter(store, Path(tmpdir))
+        dependencies = [Security]
+        changeset = writer.write(dependencies)
+        assert changeset is None
+        assert dependency_file.read_text(encoding="utf-8") == contents
+
+    def test_dependency_file_no_terminating_newline(self, tmpdir):
+        contents = "# comment\n\nrequests"
+        dependency_file = Path(tmpdir) / "requirements.txt"
+        dependency_file.write_text(contents, encoding="utf-8")
+
+        store = PackageStore(
+            type="requirements.txt",
+            file=str(dependency_file),
+            dependencies=[],
+            py_versions=[],
+        )
+        writer = RequirementsTxtWriter(store, Path(tmpdir))
+        dependencies = [DefusedXML, Security]
+        changeset = writer.write(dependencies)
+
+        assert (
+            dependency_file.read_text(encoding="utf-8")
+            == "# comment\n\nrequests\ndefusedxml~=0.7.1\nsecurity~=1.2.0\n"
+        )
+
+        assert changeset is not None
+        assert changeset.path == dependency_file.name
+        assert changeset.diff == (
+            "--- \n"
+            "+++ \n"
+            "@@ -1,3 +1,5 @@\n"
+            " # comment\n"
+            " \n"
+            " requests\n"
+            "+defusedxml~=0.7.1\n"
+            "+security~=1.2.0\n"
+        )


### PR DESCRIPTION
## Overview
*Turn on python repo manager initial analysis and refactor dependency manager to handle more than just requirements.txt parsing*

## Description

* This PR turns on PRM to run before any codemod runs. When `repo_manager.parse_project()` is run, codemodder will run all available file parsers and determine which is the appropriate location to add dependencies for this project.
* Then, when a codemod needs to add a dependency, it adds the dependency to the file context. At the end of a codemod analyzing all files, the execution context will call on the dependency manager.
* The dependency manager is now responsible for determining where to write the new dependencies. It relies on the fact that PRM already has determined the `dependencies_store`. It then picks the appropriate writer.
* The only enabled writer right now is `RequirementsTxtWriter`, which contains much of what dependency manager used to do (it used to just work with requirements.txt).
* One important thing to note is that at this each codemod that needs to add a dependency is re-parsing the dependency file. Later on we can optimize, such as decide not to parse the dependencies at all at startup.

## Future work
* Add more writers. Need to enable the setup.py writer (which is a codemod) and there is a separate PR for pyproject.toml.
* More complex heuristics for picking where to write dependencies. Many projects can have setup.py and requirements.txt, among other files. We need to update `PythonRepoManager.dependencies_store` to not just pick the first store found.
