### PR TITLE
pyproject.toml writer

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,6 +19,7 @@ dependencies = [
     "PyYAML~=6.0.0",
     "semgrep~=1.50.0",
     "toml~=0.10.2",
+    "tomlkit~=0.12.0",
     "wrapt~=1.16.0",
 ]
 keywords = ["codemod", "codemods", "security", "fix", "fixes"]

--- a/src/codemodder/dependency_management/base_dependency_writer.py
+++ b/src/codemodder/dependency_management/base_dependency_writer.py
@@ -16,10 +16,18 @@ class DependencyWriter(metaclass=ABCMeta):
         self.parent_directory = parent_directory
 
     @abstractmethod
-    def write(
+    def add_to_file(
         self, dependencies: list[Dependency], dry_run: bool = False
     ) -> Optional[ChangeSet]:
         pass
+
+    def write(
+        self, dependencies: list[Dependency], dry_run: bool = False
+    ) -> Optional[ChangeSet]:
+        new_dependencies = self.add(dependencies)
+        if new_dependencies:
+            return self.add_to_file(new_dependencies, dry_run)
+        return None
 
     def add(self, dependencies: list[Dependency]) -> list[Dependency]:
         """add any number of dependencies to the end of list of dependencies."""

--- a/src/codemodder/dependency_management/dependency_manager.py
+++ b/src/codemodder/dependency_management/dependency_manager.py
@@ -4,6 +4,7 @@ from codemodder.dependency import Dependency
 from codemodder.dependency_management.requirements_txt_writer import (
     RequirementsTxtWriter,
 )
+from codemodder.dependency_management.pyproject_writer import PyprojectWriter
 from codemodder.project_analysis.file_parsers.package_store import PackageStore
 from pathlib import Path
 
@@ -25,6 +26,10 @@ class DependencyManager:
         match self.dependencies_store.type:
             case "requirements.txt":
                 return RequirementsTxtWriter(
+                    self.dependencies_store, self.parent_directory
+                ).write(dependencies, dry_run)
+            case "pyproject.toml":
+                return PyprojectWriter(
                     self.dependencies_store, self.parent_directory
                 ).write(dependencies, dry_run)
             case "setup.py":

--- a/src/codemodder/dependency_management/pyproject_writer.py
+++ b/src/codemodder/dependency_management/pyproject_writer.py
@@ -4,7 +4,7 @@ from copy import deepcopy
 from codemodder.dependency import Dependency
 from codemodder.change import Action, Change, ChangeSet, PackageAction, Result
 from codemodder.dependency_management.base_dependency_writer import DependencyWriter
-from codemodder.diff import create_diff
+from codemodder.diff import create_diff_and_linenums
 
 
 class PyprojectWriter(DependencyWriter):
@@ -17,21 +17,17 @@ class PyprojectWriter(DependencyWriter):
             [f"{dep.requirement}" for dep in dependencies]
         )
 
-        diff = create_diff(
+        diff, added_line_nums = create_diff_and_linenums(
             tomlkit.dumps(original).split("\n"), tomlkit.dumps(pyproject).split("\n")
         )
-
-        added_lines = self.calc_new_line_nums(original, pyproject)
 
         if not dry_run:
             with open(self.path, "w") as f:
                 tomlkit.dump(pyproject, f)
 
-        # TODO: compute the correct line num, maybe use the diff?
-        last_dep_line = ""
         changes = [
             Change(
-                lineNumber=added_lines[i],
+                lineNumber=added_line_nums[i],
                 description=dep.build_description(),
                 # Contextual comments should be added to the right side of split diffs
                 properties={
@@ -53,36 +49,3 @@ class PyprojectWriter(DependencyWriter):
     def _parse_file(self):
         with open(self.path) as f:
             return tomlkit.load(f)
-
-    def calc_new_line_nums(self, original, updated):
-        added_lines = []
-        current_line_number = 0
-        import difflib
-
-        diff_lines = list(
-            difflib.unified_diff(
-                tomlkit.dumps(original).split("\n"),
-                tomlkit.dumps(updated).split("\n"),
-                lineterm="",
-            )
-        )
-        for line in diff_lines:
-            if line.startswith("@@"):
-                # Extract the starting line number for the updated file from the diff metadata.
-                # The format is @@ -x,y +a,b @@, where a is the starting line number in the updated file.
-                start_line = line.split(" ")[2]
-                current_line_number = (
-                    int(start_line.split(",")[0][1:]) - 1
-                )  # Subtract 1 because line numbers are 1-indexed
-
-            elif line.startswith("+"):
-                # Increment line number for each line in the updated file
-                current_line_number += 1
-                if not line.startswith("++"):  # Ignore the diff metadata lines
-                    added_lines.append(current_line_number)
-
-            elif not line.startswith("-"):
-                # Increment line number for unchanged/context lines
-                current_line_number += 1
-
-        return added_lines

--- a/src/codemodder/dependency_management/pyproject_writer.py
+++ b/src/codemodder/dependency_management/pyproject_writer.py
@@ -21,14 +21,17 @@ class PyprojectWriter(DependencyWriter):
             tomlkit.dumps(original).split("\n"), tomlkit.dumps(pyproject).split("\n")
         )
 
+        added_lines = self.calc_new_line_nums(original, pyproject)
+
         if not dry_run:
             with open(self.path, "w") as f:
                 tomlkit.dump(pyproject, f)
 
         # TODO: compute the correct line num, maybe use the diff?
+        last_dep_line = ""
         changes = [
             Change(
-                lineNumber=len(original) + i + 1,
+                lineNumber=added_lines[i],
                 description=dep.build_description(),
                 # Contextual comments should be added to the right side of split diffs
                 properties={
@@ -50,3 +53,36 @@ class PyprojectWriter(DependencyWriter):
     def _parse_file(self):
         with open(self.path) as f:
             return tomlkit.load(f)
+
+    def calc_new_line_nums(self, original, updated):
+        added_lines = []
+        current_line_number = 0
+        import difflib
+
+        diff_lines = list(
+            difflib.unified_diff(
+                tomlkit.dumps(original).split("\n"),
+                tomlkit.dumps(updated).split("\n"),
+                lineterm="",
+            )
+        )
+        for line in diff_lines:
+            if line.startswith("@@"):
+                # Extract the starting line number for the updated file from the diff metadata.
+                # The format is @@ -x,y +a,b @@, where a is the starting line number in the updated file.
+                start_line = line.split(" ")[2]
+                current_line_number = (
+                    int(start_line.split(",")[0][1:]) - 1
+                )  # Subtract 1 because line numbers are 1-indexed
+
+            elif line.startswith("+"):
+                # Increment line number for each line in the updated file
+                current_line_number += 1
+                if not line.startswith("++"):  # Ignore the diff metadata lines
+                    added_lines.append(current_line_number)
+
+            elif not line.startswith("-"):
+                # Increment line number for unchanged/context lines
+                current_line_number += 1
+
+        return added_lines

--- a/src/codemodder/dependency_management/pyproject_writer.py
+++ b/src/codemodder/dependency_management/pyproject_writer.py
@@ -1,23 +1,52 @@
-from typing import Optional
-
 import tomlkit
-
+from typing import Optional
+from copy import deepcopy
 from codemodder.dependency import Dependency
-from codemodder.change import ChangeSet
+from codemodder.change import Action, Change, ChangeSet, PackageAction, Result
 from codemodder.dependency_management.base_dependency_writer import DependencyWriter
+from codemodder.diff import create_diff
 
 
 class PyprojectWriter(DependencyWriter):
-    def write(
+    def add_to_file(
         self, dependencies: list[Dependency], dry_run: bool = False
     ) -> Optional[ChangeSet]:
-        with open(self.path) as f:
-            pyproject = tomlkit.load(f)
-        # todo, convert dependencies to requirements
-        pyproject["project"]["dependencies"].extend(map(str, dependencies))
+        pyproject = self._parse_file()
+        original = deepcopy(pyproject)
+        pyproject["project"]["dependencies"].extend(
+            [f"{dep.requirement}" for dep in dependencies]
+        )
+
+        diff = create_diff(
+            tomlkit.dumps(original).split("\n"), tomlkit.dumps(pyproject).split("\n")
+        )
 
         if not dry_run:
             with open(self.path, "w") as f:
                 tomlkit.dump(pyproject, f)
 
-        return None
+        # TODO: compute the correct line num, maybe use the diff?
+        changes = [
+            Change(
+                lineNumber=len(original) + i + 1,
+                description=dep.build_description(),
+                # Contextual comments should be added to the right side of split diffs
+                properties={
+                    "contextual_description": True,
+                    "contextual_description_position": "right",
+                },
+                packageActions=[
+                    PackageAction(Action.ADD, Result.COMPLETED, str(dep.requirement))
+                ],
+            )
+            for i, dep in enumerate(dependencies)
+        ]
+        return ChangeSet(
+            str(self.path.relative_to(self.parent_directory)),
+            diff,
+            changes=changes,
+        )
+
+    def _parse_file(self):
+        with open(self.path) as f:
+            return tomlkit.load(f)

--- a/src/codemodder/dependency_management/pyproject_writer.py
+++ b/src/codemodder/dependency_management/pyproject_writer.py
@@ -1,0 +1,23 @@
+from typing import Optional
+
+import tomlkit
+
+from codemodder.dependency import Dependency
+from codemodder.change import ChangeSet
+from codemodder.dependency_management.base_dependency_writer import DependencyWriter
+
+
+class PyprojectWriter(DependencyWriter):
+    def write(
+        self, dependencies: list[Dependency], dry_run: bool = False
+    ) -> Optional[ChangeSet]:
+        with open(self.path) as f:
+            pyproject = tomlkit.load(f)
+        # todo, convert dependencies to requirements
+        pyproject["project"]["dependencies"].extend(map(str, dependencies))
+
+        if not dry_run:
+            with open(self.path, "w") as f:
+                tomlkit.dump(pyproject, f)
+
+        return None

--- a/src/codemodder/diff.py
+++ b/src/codemodder/diff.py
@@ -3,7 +3,8 @@ import difflib
 
 def create_diff(original_lines: list[str], new_lines: list[str]) -> str:
     diff_lines = list(difflib.unified_diff(original_lines, new_lines))
-
+    if not diff_lines:
+        return ""
     # All but the last diff line should end with a newline
     # The last diff line should be preserved as-is (with or without a newline)
     diff_lines = [

--- a/tests/dependency_management/test_pyproject_writer.py
+++ b/tests/dependency_management/test_pyproject_writer.py
@@ -65,25 +65,21 @@ def test_update_pyproject_dependencies(tmpdir, dry_run):
 
     assert changeset is not None
     assert changeset.path == pyproject_toml.basename
-
-    res = dedent(
-        """\
-            ---
-            +++
-            @@ -11,5 +11,7 @@
-                 "libcst~=1.1.0",
-                 "pylint~=3.0.0",
-                 "PyYAML~=6.0.0",
-            +    "defusedxml~=0.7.1",
-            +    "security~=1.2.0",
-             ]
-          """
+    res = (
+        "--- \n"
+        "+++ \n"
+        "@@ -11,5 +11,7 @@\n"
+        """     "libcst~=1.1.0",\n"""
+        """     "pylint~=3.0.0",\n"""
+        """     "PyYAML~=6.0.0",\n"""
+        """+    "defusedxml~=0.7.1",\n"""
+        """+    "security~=1.2.0",\n"""
+        " ]\n "
     )
-    # TODO
-    # assert changeset.diff == res
+    assert changeset.diff == res
     assert len(changeset.changes) == 2
     change_one = changeset.changes[0]
-    # todo line num
+
     assert change_one.lineNumber == 14
     assert change_one.description == DefusedXML.build_description()
     assert change_one.properties == {

--- a/tests/dependency_management/test_pyproject_writer.py
+++ b/tests/dependency_management/test_pyproject_writer.py
@@ -1,0 +1,50 @@
+from textwrap import dedent
+
+from packaging.requirements import Requirement
+from codemodder.dependency_management.pyproject_writer import PyprojectWriter
+
+
+def test_update_pyproject_dependencies(tmpdir):
+    orig_pyproject = """\
+        [build-system]
+        requires = ["setuptools", "setuptools_scm>=8"]
+        build-backend = "setuptools.build_meta"
+
+        [project]
+        dynamic = ["version"]
+        name = "codemodder"
+        requires-python = ">=3.10.0"
+        readme = "README.md"
+        dependencies = [
+            "libcst~=1.1.0",
+            "pylint~=3.0.0",
+            "PyYAML~=6.0.0",
+        ]
+    """
+
+    pyproject_toml = tmpdir.join("pyproject.toml")
+    pyproject_toml.write(dedent(orig_pyproject))
+
+    writer = PyprojectWriter(pyproject_toml)
+    writer.write([Requirement("defusedxml~=0.7.1"), Requirement("security~=1.2.0")])
+
+    updated_pyproject = """\
+        [build-system]
+        requires = ["setuptools", "setuptools_scm>=8"]
+        build-backend = "setuptools.build_meta"
+
+        [project]
+        dynamic = ["version"]
+        name = "codemodder"
+        requires-python = ">=3.10.0"
+        readme = "README.md"
+        dependencies = [
+            "libcst~=1.1.0",
+            "pylint~=3.0.0",
+            "PyYAML~=6.0.0",
+            "defusedxml~=0.7.1",
+            "security~=1.2.0",
+        ]
+    """
+
+    assert pyproject_toml.read() == dedent(updated_pyproject)

--- a/tests/dependency_management/test_pyproject_writer.py
+++ b/tests/dependency_management/test_pyproject_writer.py
@@ -1,10 +1,14 @@
 from textwrap import dedent
+import pytest
 
 from packaging.requirements import Requirement
 from codemodder.dependency_management.pyproject_writer import PyprojectWriter
+from codemodder.dependency import DefusedXML, Security
+from codemodder.project_analysis.file_parsers.package_store import PackageStore
 
 
-def test_update_pyproject_dependencies(tmpdir):
+@pytest.mark.parametrize("dry_run", [True, False])
+def test_update_pyproject_dependencies(tmpdir, dry_run):
     orig_pyproject = """\
         [build-system]
         requires = ["setuptools", "setuptools_scm>=8"]
@@ -25,8 +29,16 @@ def test_update_pyproject_dependencies(tmpdir):
     pyproject_toml = tmpdir.join("pyproject.toml")
     pyproject_toml.write(dedent(orig_pyproject))
 
-    writer = PyprojectWriter(pyproject_toml)
-    writer.write([Requirement("defusedxml~=0.7.1"), Requirement("security~=1.2.0")])
+    store = PackageStore(
+        type="requirements.txt",
+        file=str(pyproject_toml),
+        dependencies=set(),
+        py_versions=[">=3.10.0"],
+    )
+
+    writer = PyprojectWriter(store, tmpdir)
+    dependencies = [DefusedXML, Security]
+    changeset = writer.write(dependencies, dry_run=dry_run)
 
     updated_pyproject = """\
         [build-system]
@@ -47,4 +59,129 @@ def test_update_pyproject_dependencies(tmpdir):
         ]
     """
 
+    assert pyproject_toml.read() == (
+        dedent(orig_pyproject) if dry_run else dedent(updated_pyproject)
+    )
+
+    assert changeset is not None
+    assert changeset.path == pyproject_toml.basename
+
+    res = dedent(
+        """\
+            ---
+            +++
+            @@ -11,5 +11,7 @@
+                 "libcst~=1.1.0",
+                 "pylint~=3.0.0",
+                 "PyYAML~=6.0.0",
+            +    "defusedxml~=0.7.1",
+            +    "security~=1.2.0",
+             ]
+          """
+    )
+    # TODO
+    # assert changeset.diff == res
+    assert len(changeset.changes) == 2
+    change_one = changeset.changes[0]
+    # todo line num
+    assert change_one.lineNumber == 14
+    assert change_one.description == DefusedXML.build_description()
+    assert change_one.properties == {
+        "contextual_description": True,
+        "contextual_description_position": "right",
+    }
+    change_two = changeset.changes[1]
+    assert change_two.lineNumber == 15
+    assert change_two.description == Security.build_description()
+    assert change_two.properties == {
+        "contextual_description": True,
+        "contextual_description_position": "right",
+    }
+
+
+def test_add_same_dependency_only_once(tmpdir):
+    orig_pyproject = """\
+        [build-system]
+        requires = ["setuptools", "setuptools_scm>=8"]
+        build-backend = "setuptools.build_meta"
+
+        [project]
+        dynamic = ["version"]
+        name = "codemodder"
+        requires-python = ">=3.10.0"
+        readme = "README.md"
+        dependencies = [
+            "libcst~=1.1.0",
+            "pylint~=3.0.0",
+            "PyYAML~=6.0.0",
+        ]
+    """
+
+    pyproject_toml = tmpdir.join("pyproject.toml")
+    pyproject_toml.write(dedent(orig_pyproject))
+
+    store = PackageStore(
+        type="requirements.txt",
+        file=str(pyproject_toml),
+        dependencies=set(),
+        py_versions=[">=3.10.0"],
+    )
+
+    writer = PyprojectWriter(store, tmpdir)
+    dependencies = [Security, Security]
+    changeset = writer.write(dependencies)
+
+    updated_pyproject = """\
+        [build-system]
+        requires = ["setuptools", "setuptools_scm>=8"]
+        build-backend = "setuptools.build_meta"
+
+        [project]
+        dynamic = ["version"]
+        name = "codemodder"
+        requires-python = ">=3.10.0"
+        readme = "README.md"
+        dependencies = [
+            "libcst~=1.1.0",
+            "pylint~=3.0.0",
+            "PyYAML~=6.0.0",
+            "security~=1.2.0",
+        ]
+    """
+
     assert pyproject_toml.read() == dedent(updated_pyproject)
+
+
+def test_dont_add_existing_dependency(tmpdir):
+    orig_pyproject = """\
+        [build-system]
+        requires = ["setuptools", "setuptools_scm>=8"]
+        build-backend = "setuptools.build_meta"
+
+        [project]
+        dynamic = ["version"]
+        name = "codemodder"
+        requires-python = ">=3.10.0"
+        readme = "README.md"
+        dependencies = [
+            "libcst~=1.1.0",
+            "pylint~=3.0.0",
+            "PyYAML~=6.0.0",
+        ]
+    """
+
+    pyproject_toml = tmpdir.join("pyproject.toml")
+    pyproject_toml.write(dedent(orig_pyproject))
+
+    store = PackageStore(
+        type="requirements.txt",
+        file=str(pyproject_toml),
+        dependencies=set([Security.requirement]),
+        py_versions=[">=3.10.0"],
+    )
+
+    writer = PyprojectWriter(store, tmpdir)
+    dependencies = [Security]
+    changeset = writer.write(dependencies)
+
+    assert pyproject_toml.read() == dedent(orig_pyproject)

--- a/tests/dependency_management/test_requirements_txt_writer.py
+++ b/tests/dependency_management/test_requirements_txt_writer.py
@@ -7,11 +7,6 @@ from codemodder.project_analysis.file_parsers.package_store import PackageStore
 from codemodder.dependency import DefusedXML, Security
 
 
-@pytest.fixture(autouse=True, scope="module")
-def disable_write_dependencies():
-    """Override fixture from conftest.py in order to allow testing"""
-
-
 class TestRequirementsTxtWriter:
     @pytest.mark.parametrize("dry_run", [True, False])
     def test_add_dependencies_preserve_comments(self, tmpdir, dry_run):


### PR DESCRIPTION
## Overview
*Add a pyproject.toml dependency writer*

## Description

* Following the example of the requirements.txt writer, add one for pyproject.toml, IFF it has a [project] dependencies section in the file
* the one interesting difference for this writer is that since we're using `tomlkit` to parse and update the toml file, we didn't have a way to get the line numbers that changed. For that, I created a custom function that uses the output of `difflib.unified_diff` and parses out the `@@ -x,y +a,b @@` and any `+ ...` lines.
