### PR TITLE
Codemod for numpy NaN equality bug

### DIFF
--- a/integration_tests/test_numpy_nan_equality.py
+++ b/integration_tests/test_numpy_nan_equality.py
@@ -1,0 +1,34 @@
+from core_codemods.numpy_nan_equality import NumpyNanEquality
+from integration_tests.base_test import (
+    BaseIntegrationTest,
+    original_and_expected_from_code_path,
+)
+
+
+class TestNumpyNanEquality(BaseIntegrationTest):
+    codemod = NumpyNanEquality
+    code_path = "tests/samples/numpy_nan_equality.py"
+    original_code, expected_new_code = original_and_expected_from_code_path(
+        code_path,
+        [
+            (3, """if np.isnan(a):\n"""),
+        ],
+    )
+
+    # fmt: off
+    expected_diff =(
+    """--- \n"""
+    """+++ \n"""
+    """@@ -1,5 +1,5 @@\n"""
+    """ import numpy as np\n"""
+    """ \n"""
+    """ a = np.nan\n"""
+    """-if a == np.nan:\n"""
+    """+if np.isnan(a):\n"""
+    """     pass\n"""
+    )
+    # fmt: on
+
+    expected_line_change = "4"
+    change_description = NumpyNanEquality.CHANGE_DESCRIPTION
+    num_changed_files = 1

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -60,6 +60,7 @@ test = [
     "security~=1.2.0",
     "types-mock==5.1.*",
     "django==4.*",
+    "numpy~=1.26.0",
 ]
 complexity = [
     "radon==6.0.*",

--- a/src/codemodder/scripts/generate_docs.py
+++ b/src/codemodder/scripts/generate_docs.py
@@ -144,7 +144,8 @@ If you want to allow those protocols, change the incoming PR to look more like t
     ),
     "django-receiver-on-top": DocMetadata(
         importance="Medium",
-        guidance_explained="We believe this change leads to the intended behavior the application and is thus safe."),
+        guidance_explained="We believe this change leads to the intended behavior the application and is thus safe.",
+    ),
     "numpy-nan-equality": DocMetadata(
         importance="Medium",
         guidance_explained="We believe any use of `==` to compare with `numpy.nan` is unintended given that it is always `False`. Thus we consider this change safe.",

--- a/src/codemodder/scripts/generate_docs.py
+++ b/src/codemodder/scripts/generate_docs.py
@@ -144,7 +144,10 @@ If you want to allow those protocols, change the incoming PR to look more like t
     ),
     "django-receiver-on-top": DocMetadata(
         importance="Medium",
-        guidance_explained="We believe this change leads to the intended behavior the application and is thus safe.",
+        guidance_explained="We believe this change leads to the intended behavior the application and is thus safe."),
+    "numpy-nan-equality": DocMetadata(
+        importance="Medium",
+        guidance_explained="We believe any use of `==` to compare with `numpy.nan` is unintended given that it is always `False`. Thus we consider this change safe.",
     ),
 }
 

--- a/src/core_codemods/__init__.py
+++ b/src/core_codemods/__init__.py
@@ -1,4 +1,5 @@
 from codemodder.registry import CodemodCollection
+from core_codemods.numpy_nan_equality import NumpyNanEquality
 from core_codemods.sql_parameterization import SQLQueryParameterization
 
 from .django_debug_flag_on import DjangoDebugFlagOn
@@ -66,5 +67,6 @@ registry = CodemodCollection(
         SecureFlaskSessionConfig,
         FileResourceLeak,
         DjangoReceiverOnTop,
+        NumpyNanEquality,
     ],
 )

--- a/src/core_codemods/docs/pixee_python_numpy-nan-equality.md
+++ b/src/core_codemods/docs/pixee_python_numpy-nan-equality.md
@@ -1,4 +1,4 @@
-Comparisons against `numpy.nan` always results in `False`. Thus comparing an expression directly against `numpy.nan` is always unintended. The correct way to compare a value for `NaN` is to use the `numpy.isnan` function.
+Comparisons against `numpy.nan` always result in `False`. Thus comparing an expression directly against `numpy.nan` is always unintended. The correct way to compare a value for `NaN` is to use the `numpy.isnan` function.
 
 Our changes look something like this:
 

--- a/src/core_codemods/docs/pixee_python_numpy-nan-equality.md
+++ b/src/core_codemods/docs/pixee_python_numpy-nan-equality.md
@@ -1,0 +1,12 @@
+Comparisons against `numpy.nan` always results in `False`. Thus comparing an expression directly against `numpy.nan` is always unintended. The correct way to compare a value for `NaN` is to use the `numpy.isnan` function.
+
+Our changes look something like this:
+
+```diff
+import numpy as np
+
+a = np.nan
+-if a == np.nan:
++if np.isnan(a):
+    pass
+```

--- a/src/core_codemods/numpy_nan_equality.py
+++ b/src/core_codemods/numpy_nan_equality.py
@@ -1,0 +1,120 @@
+from collections import namedtuple
+from typing import Optional
+import libcst as cst
+from libcst import matchers
+from codemodder.codemods.api import BaseCodemod
+from codemodder.codemods.base_codemod import ReviewGuidance
+
+from codemodder.codemods.utils_mixin import NameResolutionMixin
+
+NodeWithTrueName = namedtuple("NodeWithTrueName", ["node", "name"])
+
+
+class NumpyNanEquality(BaseCodemod, NameResolutionMixin):
+    NAME = "numpy-nan-equality"
+    SUMMARY = "Uses numpy.isnan() instead of ==."
+    REVIEW_GUIDANCE = ReviewGuidance.MERGE_WITHOUT_REVIEW
+    DESCRIPTION = SUMMARY
+    REFERENCES = [
+        {
+            "url": "https://numpy.org/doc/stable/reference/constants.html#numpy.nan",
+            "description": "",
+        },
+    ]
+    CHANGE_DESCRIPTION = "Replaces == check with numpy.isnan()."
+
+    np_nan = "numpy.nan"
+
+    def _is_np_nan(
+        self, left: NodeWithTrueName, right: NodeWithTrueName
+    ) -> Optional[tuple[cst.CSTNode, cst.CSTNode]]:
+        if self.np_nan == left.name:
+            return left.node, right.node
+        if self.np_nan == right.name:
+            return right.node, left.node
+        return None
+
+    def _build_conjunction(
+        self, expressions: list[cst.BaseExpression], index: int
+    ) -> cst.BaseExpression:
+        if index == 0:
+            return expressions[0]
+        return cst.BooleanOperation(
+            left=self._build_conjunction(expressions, index - 1),
+            right=expressions[index],
+            operator=cst.And(),
+        )
+
+    def _build_new_comparison(self, expression_triples) -> cst.BaseExpression:
+        conjunction_expression = []
+        before: Optional[cst.Comparison] = None
+        for left, right, operator in expression_triples:
+            maybe_has_nan = self._is_np_nan(left, right)
+            if maybe_has_nan:
+                nan_node, node = maybe_has_nan
+                if before:
+                    conjunction_expression.append(before)
+                    before = None
+                conjunction_expression.append(
+                    self._build_nan_comparison(nan_node, node)
+                )
+            else:
+                if before:
+                    before.comparisons.append(
+                        cst.ComparisonTarget(operator=operator, comparator=right.node)
+                    )
+                else:
+                    before = cst.Comparison(
+                        left=left.node,
+                        comparisons=[
+                            cst.ComparisonTarget(
+                                operator=operator, comparator=right.node
+                            )
+                        ],
+                    )
+        if before:
+            conjunction_expression.append(before)
+        return self._build_conjunction(
+            conjunction_expression, len(conjunction_expression) - 1
+        )
+
+    def _break_into_triples(self, comparison: cst.Comparison):
+        """
+        Breaks a comparison expression into triples.
+        For example, the expression a == b == c is equivalent to a == b and b == c. This method will break it into [(a,b,==), (b,c,==)].
+        """
+        left = NodeWithTrueName(
+            node=comparison.left, name=self.find_base_name(comparison.left)
+        )
+        # the first always exists
+        ct = comparison.comparisons[0]
+        right = NodeWithTrueName(ct.comparator, self.find_base_name(ct.comparator))
+        triples = [(left, right, ct.operator)]
+        for ct in comparison.comparisons[1:]:
+            left = right
+            right = NodeWithTrueName(ct.comparator, self.find_base_name(ct.comparator))
+            triples.append((left, right, ct.operator))
+        return triples
+
+    def _build_nan_comparison(self, nan_node, node):
+        maybe_numpy_alias = self.find_alias_for_import_in_node("numpy", nan_node)
+        if maybe_numpy_alias:
+            call = cst.parse_expression(f"{maybe_numpy_alias}.isnan()")
+        else:
+            self.add_needed_import("numpy")
+            call = cst.parse_expression("numpy.isnan()")
+        return call.with_changes(args=[cst.Arg(value=node)])
+
+    def leave_Comparison(
+        self, original_node: cst.Comparison, updated_node: cst.Comparison
+    ) -> cst.BaseExpression:
+        if self.filter_by_path_includes_or_excludes(self.node_position(original_node)):
+            comparison_triples = self._break_into_triples(original_node)
+            for left, right, operator in comparison_triples:
+                if matchers.matches(operator, matchers.Equal()) and self.np_nan in (
+                    left.name,
+                    right.name,
+                ):
+                    self.report_change(original_node)
+                    return self._build_new_comparison(comparison_triples)
+        return updated_node

--- a/src/core_codemods/numpy_nan_equality.py
+++ b/src/core_codemods/numpy_nan_equality.py
@@ -12,7 +12,7 @@ NodeWithTrueName = namedtuple("NodeWithTrueName", ["node", "name"])
 
 class NumpyNanEquality(BaseCodemod, NameResolutionMixin):
     NAME = "numpy-nan-equality"
-    SUMMARY = "Uses numpy.isnan() instead of ==."
+    SUMMARY = "Replace == comparison with numpy.isnan()"
     REVIEW_GUIDANCE = ReviewGuidance.MERGE_WITHOUT_REVIEW
     DESCRIPTION = SUMMARY
     REFERENCES = [

--- a/tests/codemods/test_numpy_nan_equality.py
+++ b/tests/codemods/test_numpy_nan_equality.py
@@ -1,0 +1,75 @@
+from core_codemods.numpy_nan_equality import NumpyNanEquality
+from tests.codemods.base_codemod_test import BaseCodemodTest
+from textwrap import dedent
+
+
+class TestNumpyNanEquality(BaseCodemodTest):
+    codemod = NumpyNanEquality
+
+    def test_name(self):
+        assert self.codemod.name() == "numpy-nan-equality"
+
+    def test_simple(self, tmpdir):
+        input_code = """\
+        import numpy
+        if a == numpy.nan:
+            pass
+        """
+        expected = """\
+        import numpy
+        if numpy.isnan(a):
+            pass
+        """
+        self.run_and_assert(tmpdir, dedent(input_code), dedent(expected))
+        assert len(self.file_context.codemod_changes) == 1
+
+    def test_alias(self, tmpdir):
+        input_code = """\
+        import numpy as np
+        if a == np.nan:
+            pass
+        """
+        expected = """\
+        import numpy as np
+        if np.isnan(a):
+            pass
+        """
+        self.run_and_assert(tmpdir, dedent(input_code), dedent(expected))
+        assert len(self.file_context.codemod_changes) == 1
+
+    def test_multiple_comparisons(self, tmpdir):
+        input_code = """\
+        import numpy as np
+        if a == np.nan == b:
+            pass
+        """
+        expected = """\
+        import numpy as np
+        if np.isnan(a) and np.isnan(b):
+            pass
+        """
+        self.run_and_assert(tmpdir, dedent(input_code), dedent(expected))
+        assert len(self.file_context.codemod_changes) == 1
+
+    def test_multiple_comparisons_preserve_longest(self, tmpdir):
+        input_code = """\
+        import numpy as np
+        if a == np.nan == b == c == d <= e:
+            pass
+        """
+        expected = """\
+        import numpy as np
+        if np.isnan(a) and np.isnan(b) and b == c == d <= e:
+            pass
+        """
+        self.run_and_assert(tmpdir, dedent(input_code), dedent(expected))
+        assert len(self.file_context.codemod_changes) == 1
+
+    def test_not_numpy(self, tmpdir):
+        input_code = """\
+        import not_numpy as np
+        if a == np.nan:
+            pass
+        """
+        self.run_and_assert(tmpdir, dedent(input_code), dedent(input_code))
+        assert len(self.file_context.codemod_changes) == 0

--- a/tests/codemods/test_numpy_nan_equality.py
+++ b/tests/codemods/test_numpy_nan_equality.py
@@ -23,6 +23,20 @@ class TestNumpyNanEquality(BaseCodemodTest):
         self.run_and_assert(tmpdir, dedent(input_code), dedent(expected))
         assert len(self.file_context.codemod_changes) == 1
 
+    def test_simple_left(self, tmpdir):
+        input_code = """\
+        import numpy
+        if numpy.nan == a:
+            pass
+        """
+        expected = """\
+        import numpy
+        if numpy.isnan(a):
+            pass
+        """
+        self.run_and_assert(tmpdir, dedent(input_code), dedent(expected))
+        assert len(self.file_context.codemod_changes) == 1
+
     def test_alias(self, tmpdir):
         input_code = """\
         import numpy as np

--- a/tests/samples/numpy_nan_equality.py
+++ b/tests/samples/numpy_nan_equality.py
@@ -1,0 +1,5 @@
+import numpy as np
+
+a = np.nan
+if a == np.nan:
+    pass


### PR DESCRIPTION
## Overview
This codemod will change any equality to `numpy.nan` using `==` to use `numpy.isnan()` instead.