### PR TITLE
Implement --describe flag for codemodder

### DIFF
--- a/src/codemodder/executor.py
+++ b/src/codemodder/executor.py
@@ -78,6 +78,14 @@ class CodemodExecutorWrapper(CallableObjectProxy):
             for yaml_file in getattr(self, "YAML_FILES", [])
         ]
 
+    def describe(self):
+        return {
+            "codemod": self.id,
+            "summary": self.summary,
+            "description": self.description,
+            "references": self.references,
+        }
+
     def __repr__(self):
         return "<{} at 0x{:x} for {}.{}>".format(
             type(self).__name__,

--- a/src/codemodder/registry.py
+++ b/src/codemodder/registry.py
@@ -99,6 +99,14 @@ class CodemodRegistry:
             for name in codemod_include
         ]
 
+    def describe_codemods(
+        self,
+        codemod_include: Optional[list] = None,
+        codemod_exclude: Optional[list] = None,
+    ) -> list[dict]:
+        codemods = self.match_codemods(codemod_include, codemod_exclude)
+        return [codemod.describe() for codemod in codemods]
+
 
 def load_registered_codemods() -> CodemodRegistry:
     registry = CodemodRegistry()

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,3 +1,5 @@
+import json
+
 import mock
 import pytest
 
@@ -87,6 +89,20 @@ class TestParseArgs:
         assert sorted(self.registry.ids) == sorted(printed_names)
 
         assert err.value.args[0] == 0
+
+    @mock.patch("builtins.print")
+    def test_describe_prints_codemod_metadata(self, mock_print):
+        with pytest.raises(SystemExit) as err:
+            parse_args(
+                ["--describe"],
+                self.registry,
+            )
+
+        assert err.value.args[0] == 0
+        assert mock_print.call_count == 1
+
+        results = json.loads(mock_print.call_args_list[0][0][0])
+        assert len(results["results"]) == len(self.registry.codemods)
 
     @mock.patch("codemodder.cli.logger.error")
     def test_bad_output_format(self, error_logger):


### PR DESCRIPTION
## Overview
*Implement `--describe` flag for codemodder*

## Details
* This is a new part of the codemodder spec
* The purpose is to allow upstream tools to query codemodder for detailed metadata about supported codemods
* I had a hard time getting this to honor `--codemod-include` and `--codemod-exclude` due to the way argument handling is currently implemented. Maybe we can revisit this if/when we switch over to `click` 
