### PR TITLE
Set content-type for Django Json Response Type Codemod

### DIFF
--- a/integration_tests/test_django_json_response_type.py
+++ b/integration_tests/test_django_json_response_type.py
@@ -1,0 +1,36 @@
+from core_codemods.django_json_response_type import DjangoJsonResponseType
+from integration_tests.base_test import (
+    BaseIntegrationTest,
+    original_and_expected_from_code_path,
+)
+
+
+class TestDjangoJsonResponseType(BaseIntegrationTest):
+    codemod = DjangoJsonResponseType
+    code_path = "tests/samples/django_json_response_type.py"
+    original_code, expected_new_code = original_and_expected_from_code_path(
+        code_path,
+        [
+            (
+                5,
+                """    return HttpResponse(json_response, content_type = "application/json")\n""",
+            ),
+        ],
+    )
+
+    # fmt: off
+    expected_diff =(
+    """--- \n"""
+    """+++ \n"""
+    """@@ -3,4 +3,4 @@\n"""
+    """ \n"""
+    """ def foo(request):\n"""
+    """     json_response = json.dumps({ "user_input": request.GET.get("input") })\n"""
+    """-    return HttpResponse(json_response)\n"""
+    """+    return HttpResponse(json_response, content_type = "application/json")\n"""
+    )
+    # fmt: on
+
+    expected_line_change = "6"
+    change_description = DjangoJsonResponseType.CHANGE_DESCRIPTION
+    num_changed_files = 1

--- a/integration_tests/test_django_json_response_type.py
+++ b/integration_tests/test_django_json_response_type.py
@@ -13,7 +13,7 @@ class TestDjangoJsonResponseType(BaseIntegrationTest):
         [
             (
                 5,
-                """    return HttpResponse(json_response, content_type = "application/json")\n""",
+                """    return HttpResponse(json_response, content_type="application/json")\n""",
             ),
         ],
     )
@@ -27,7 +27,7 @@ class TestDjangoJsonResponseType(BaseIntegrationTest):
     """ def foo(request):\n"""
     """     json_response = json.dumps({ "user_input": request.GET.get("input") })\n"""
     """-    return HttpResponse(json_response)\n"""
-    """+    return HttpResponse(json_response, content_type = "application/json")\n"""
+    """+    return HttpResponse(json_response, content_type="application/json")\n"""
     )
     # fmt: on
 

--- a/src/codemodder/scripts/generate_docs.py
+++ b/src/codemodder/scripts/generate_docs.py
@@ -150,6 +150,10 @@ If you want to allow those protocols, change the incoming PR to look more like t
         importance="Medium",
         guidance_explained="We believe any use of `==` to compare with `numpy.nan` is unintended given that it is always `False`. Thus we consider this change safe.",
     ),
+    "django-json-response-type": DocMetadata(
+        importance="Medium",
+        guidance_explained="This change will only restrict the response type and will not alter the response data itself. Thus we deem it safe.",
+    ),
 }
 
 

--- a/src/core_codemods/__init__.py
+++ b/src/core_codemods/__init__.py
@@ -31,6 +31,7 @@ from .with_threading_lock import WithThreadingLock
 from .secure_flask_session_config import SecureFlaskSessionConfig
 from .file_resource_leak import FileResourceLeak
 from .django_receiver_on_top import DjangoReceiverOnTop
+from .django_json_response_type import DjangoJsonResponseType
 
 registry = CodemodCollection(
     origin="pixee",
@@ -68,5 +69,6 @@ registry = CodemodCollection(
         FileResourceLeak,
         DjangoReceiverOnTop,
         NumpyNanEquality,
+        DjangoJsonResponseType,
     ],
 )

--- a/src/core_codemods/django_json_response_type.py
+++ b/src/core_codemods/django_json_response_type.py
@@ -6,7 +6,7 @@ from codemodder.codemods.api import SemgrepCodemod
 
 class DjangoJsonResponseType(SemgrepCodemod):
     NAME = "django-json-response-type"
-    SUMMARY = "Restricts the type to `json/application` for django.http.HttpResponse with json objects as argument."
+    SUMMARY = "Set content type to `json/application` for `django.http.HttpResponse` with JSON data"
     REVIEW_GUIDANCE = ReviewGuidance.MERGE_WITHOUT_REVIEW
     DESCRIPTION = "Sets `content_type` to `json/application`."
     REFERENCES = [
@@ -42,6 +42,10 @@ class DjangoJsonResponseType(SemgrepCodemod):
                 cst.Arg(
                     value=cst.parse_expression('"application/json"'),
                     keyword=cst.Name("content_type"),
+                    equal=cst.AssignEqual(
+                        whitespace_before=cst.SimpleWhitespace(""),
+                        whitespace_after=cst.SimpleWhitespace(""),
+                    ),
                 ),
             ],
         )

--- a/src/core_codemods/django_json_response_type.py
+++ b/src/core_codemods/django_json_response_type.py
@@ -1,0 +1,47 @@
+import libcst as cst
+
+from codemodder.codemods.base_codemod import ReviewGuidance
+from codemodder.codemods.api import SemgrepCodemod
+
+
+class DjangoJsonResponseType(SemgrepCodemod):
+    NAME = "django-json-response-type"
+    SUMMARY = "Restricts the type to `json/application` for django.http.HttpResponse with json objects as argument."
+    REVIEW_GUIDANCE = ReviewGuidance.MERGE_WITHOUT_REVIEW
+    DESCRIPTION = "Sets `content_type` to `json/application`."
+    REFERENCES = [
+        {
+            "url": "https://docs.djangoproject.com/en/4.0/ref/request-response/#django.http.HttpResponse.__init__",
+            "description": "",
+        },
+        {
+            "url": "https://cheatsheetseries.owasp.org/cheatsheets/Cross_Site_Scripting_Prevention_Cheat_Sheet.html#output-encoding-for-javascript-contexts",
+            "description": "",
+        },
+    ]
+
+    @classmethod
+    def rule(cls):
+        return """
+        rules:
+          - id: django-json-response-type
+            mode: taint
+            pattern-sources:
+              - pattern: json.dumps(...)
+            pattern-sinks:
+              - patterns:
+                - pattern: django.http.HttpResponse(...)
+                - pattern-not: django.http.HttpResponse(...,content_type=...,...)
+        """
+
+    def on_result_found(self, _, updated_node):
+        return self.update_arg_target(
+            updated_node,
+            [
+                *updated_node.args,
+                cst.Arg(
+                    value=cst.parse_expression('"application/json"'),
+                    keyword=cst.Name("content_type"),
+                ),
+            ],
+        )

--- a/src/core_codemods/docs/pixee_python_django-json-response-type.md
+++ b/src/core_codemods/docs/pixee_python_django-json-response-type.md
@@ -1,4 +1,6 @@
-For a `HttpReponse` in Django, if the `content_type` is not set, it default to `text/html`. If the JSON contains user supplied input without being sanitized first, a malicious user may supply HTTP code which leaves the application vulnerable to cross-site scripting (XSS). This transformation restricts the response type to `application/json` to avoid this vulnerability. Our changes look something like this:
+The default `content_type` for `HttpResponse` in Django is `'text/html'`. This is true even when the response contains JSON data.
+If the JSON contains (unsanitized) user-supplied input, a malicious user may supply HTML code which leaves the application vulnerable to cross-site scripting (XSS). 
+This fix explicitly sets the response type to `application/json` when the response body is JSON data to avoid this vulnerability. Our changes look something like this:
 
 ```diff
 from django.http import HttpResponse

--- a/src/core_codemods/docs/pixee_python_django-json-response-type.md
+++ b/src/core_codemods/docs/pixee_python_django-json-response-type.md
@@ -1,0 +1,11 @@
+For a `HttpReponse` in Django, if the `content_type` is not set, it default to `text/html`. If the JSON contains user supplied input without being sanitized first, a malicious user may supply HTTP code which leaves the application vulnerable to cross-site scripting (XSS). This transformation restricts the response type to `application/json` to avoid this vulnerability. Our changes look something like this:
+
+```diff
+from django.http import HttpResponse
+import json
+
+def foo(request):
+    json_response = json.dumps({ "user_input": request.GET.get("input") })
+-    return HttpResponse(json_response)
++    return HttpResponse(json_response, content_type="application/json")
+```

--- a/tests/codemods/test_django_json_response_type.py
+++ b/tests/codemods/test_django_json_response_type.py
@@ -1,0 +1,92 @@
+from core_codemods.django_json_response_type import DjangoJsonResponseType
+from tests.codemods.base_codemod_test import BaseSemgrepCodemodTest
+from textwrap import dedent
+
+
+class TestDjangoJsonResponseType(BaseSemgrepCodemodTest):
+    codemod = DjangoJsonResponseType
+
+    def test_name(self):
+        assert self.codemod.name() == "django-json-response-type"
+
+    def test_simple(self, tmpdir):
+        input_code = """\
+        from django.http import HttpResponse
+        import json
+
+        def foo(request):
+            json_response = json.dumps({ "user_input": request.GET.get("input") })
+            return HttpResponse(json_response)
+        """
+        expected = """\
+        from django.http import HttpResponse
+        import json
+
+        def foo(request):
+            json_response = json.dumps({ "user_input": request.GET.get("input") })
+            return HttpResponse(json_response, content_type = "application/json")
+        """
+        self.run_and_assert(tmpdir, dedent(input_code), dedent(expected))
+        assert len(self.file_context.codemod_changes) == 1
+
+    def test_alias(self, tmpdir):
+        input_code = """\
+        from django.http import HttpResponse as response
+        import json as jsan
+
+        def foo(request):
+            json_response = jsan.dumps({ "user_input": request.GET.get("input") })
+            return response(json_response)
+        """
+        expected = """\
+        from django.http import HttpResponse as response
+        import json as jsan
+
+        def foo(request):
+            json_response = jsan.dumps({ "user_input": request.GET.get("input") })
+            return response(json_response, content_type = "application/json")
+        """
+        self.run_and_assert(tmpdir, dedent(input_code), dedent(expected))
+        assert len(self.file_context.codemod_changes) == 1
+
+    def test_direct(self, tmpdir):
+        input_code = """\
+        from django.http import HttpResponse
+        import json
+
+        def foo(request):
+            return HttpResponse(json.dumps({ "user_input": request.GET.get("input") }))
+        """
+        expected = """\
+        from django.http import HttpResponse
+        import json
+
+        def foo(request):
+            return HttpResponse(json.dumps({ "user_input": request.GET.get("input") }), content_type = "application/json")
+        """
+        self.run_and_assert(tmpdir, dedent(input_code), dedent(expected))
+        assert len(self.file_context.codemod_changes) == 1
+
+    def test_content_type_set(self, tmpdir):
+        input_code = """\
+        from django.http import HttpResponse
+        import json
+
+        def foo(request):
+            json_response = json.dumps({ "user_input": request.GET.get("input") })
+            return HttpResponse(json_response, content_type='application/json')
+        """
+        self.run_and_assert(tmpdir, dedent(input_code), dedent(input_code))
+        assert len(self.file_context.codemod_changes) == 0
+
+    def test_no_json_input(self, tmpdir):
+        input_code = """\
+        from django.http import HttpResponse
+        import json
+
+        def foo(request):
+            dict_reponse = { "user_input": request.GET.get("input") }
+            return HttpResponse(dict_response)
+        """
+        self.run_and_assert(tmpdir, dedent(input_code), dedent(input_code))
+        assert len(self.file_context.codemod_changes) == 0

--- a/tests/codemods/test_django_json_response_type.py
+++ b/tests/codemods/test_django_json_response_type.py
@@ -24,7 +24,7 @@ class TestDjangoJsonResponseType(BaseSemgrepCodemodTest):
 
         def foo(request):
             json_response = json.dumps({ "user_input": request.GET.get("input") })
-            return HttpResponse(json_response, content_type = "application/json")
+            return HttpResponse(json_response, content_type="application/json")
         """
         self.run_and_assert(tmpdir, dedent(input_code), dedent(expected))
         assert len(self.file_context.codemod_changes) == 1
@@ -44,7 +44,7 @@ class TestDjangoJsonResponseType(BaseSemgrepCodemodTest):
 
         def foo(request):
             json_response = jsan.dumps({ "user_input": request.GET.get("input") })
-            return response(json_response, content_type = "application/json")
+            return response(json_response, content_type="application/json")
         """
         self.run_and_assert(tmpdir, dedent(input_code), dedent(expected))
         assert len(self.file_context.codemod_changes) == 1
@@ -62,7 +62,7 @@ class TestDjangoJsonResponseType(BaseSemgrepCodemodTest):
         import json
 
         def foo(request):
-            return HttpResponse(json.dumps({ "user_input": request.GET.get("input") }), content_type = "application/json")
+            return HttpResponse(json.dumps({ "user_input": request.GET.get("input") }), content_type="application/json")
         """
         self.run_and_assert(tmpdir, dedent(input_code), dedent(expected))
         assert len(self.file_context.codemod_changes) == 1

--- a/tests/samples/django_json_response_type.py
+++ b/tests/samples/django_json_response_type.py
@@ -1,0 +1,6 @@
+from django.http import HttpResponse
+import json
+
+def foo(request):
+    json_response = json.dumps({ "user_input": request.GET.get("input") })
+    return HttpResponse(json_response)


### PR DESCRIPTION
## Overview
Sets `content-type` to `application-json` for `HttpResponse()` calls in Django if the argument is a json string.
