### PR TITLE
Exclude some codemods by default

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @drdavella @clavedeluna @andrecsilva
+* @drdavella @andrecsilva

--- a/ci_tests/test_pygoat_findings.py
+++ b/ci_tests/test_pygoat_findings.py
@@ -4,10 +4,8 @@ import pytest
 
 
 EXPECTED_FINDINGS = [
-    "pixee:python/order-imports",
     "pixee:python/secure-random",
     "pixee:python/sandbox-process-creation",
-    "pixee:python/unused-imports",
     "pixee:python/django-session-cookie-secure-off",
     "pixee:python/harden-pyyaml",
     "pixee:python/django-debug-flag-on",

--- a/src/codemodder/registry.py
+++ b/src/codemodder/registry.py
@@ -7,6 +7,13 @@ from codemodder.executor import CodemodExecutorWrapper
 from codemodder.logging import logger
 
 
+# These are generally not intended to be applied directly so they are excluded by default.
+DEFAULT_EXCLUDED_CODEMODS = [
+    "pixee:python/order-imports",
+    "pixee:python/unused-imports",
+]
+
+
 @dataclass
 class CodemodCollection:
     """A collection of codemods that all share the same origin and documentation."""
@@ -77,16 +84,10 @@ class CodemodRegistry:
         codemod_include: Optional[list] = None,
         codemod_exclude: Optional[list] = None,
     ) -> list[CodemodExecutorWrapper]:
-        if not codemod_include and not codemod_exclude:
-            return self.codemods
-
         codemod_include = codemod_include or []
-        codemod_exclude = codemod_exclude or []
+        codemod_exclude = codemod_exclude or DEFAULT_EXCLUDED_CODEMODS
 
-        # cli should've already prevented both include/exclude from being set.
-        assert codemod_include or codemod_exclude
-
-        if codemod_exclude:
+        if codemod_exclude and not codemod_include:
             return [
                 codemod
                 for codemod in self.codemods

--- a/tests/codemods/test_include_exclude.py
+++ b/tests/codemods/test_include_exclude.py
@@ -1,5 +1,5 @@
 import pytest
-from codemodder.registry import load_registered_codemods
+from codemodder.registry import DEFAULT_EXCLUDED_CODEMODS, load_registered_codemods
 
 
 class TestMatchCodemods:
@@ -11,7 +11,10 @@ class TestMatchCodemods:
         )
 
     def test_no_include_exclude(self):
-        assert self.registry.match_codemods(None, None) == self.registry.codemods
+        defaults = set(
+            x for x in self.registry.codemods if x.id not in DEFAULT_EXCLUDED_CODEMODS
+        )
+        assert set(self.registry.match_codemods(None, None)) == defaults
 
     @pytest.mark.parametrize(
         "input_str", ["secure-random", "secure-random,url-sandbox"]

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -5,7 +5,7 @@ import pytest
 
 from codemodder.cli import parse_args
 from codemodder import __version__
-from codemodder.registry import load_registered_codemods
+from codemodder.registry import DEFAULT_EXCLUDED_CODEMODS, load_registered_codemods
 
 
 class TestParseArgs:
@@ -102,7 +102,9 @@ class TestParseArgs:
         assert mock_print.call_count == 1
 
         results = json.loads(mock_print.call_args_list[0][0][0])
-        assert len(results["results"]) == len(self.registry.codemods)
+        assert len(results["results"]) == len(self.registry.codemods) - len(
+            DEFAULT_EXCLUDED_CODEMODS
+        )
 
     @mock.patch("codemodder.cli.logger.error")
     def test_bad_output_format(self, error_logger):

--- a/tests/test_codemodder.py
+++ b/tests/test_codemodder.py
@@ -6,7 +6,7 @@ import libcst as cst
 from codemodder.codemodder import run, find_semgrep_results
 from codemodder.diff import create_diff_from_tree
 from codemodder.semgrep import run as semgrep_run
-from codemodder.registry import DEFAULT_EXCLUDED_CODEMODS, load_registered_codemods
+from codemodder.registry import load_registered_codemods
 from codemodder.result import ResultSet
 
 
@@ -76,6 +76,8 @@ class TestRun:
             "--output",
             str(codetf),
             "--dry-run",
+            # Make this test faster by restricting the number of codemods
+            "--codemod-include=url-sandbox",
         ]
 
         assert not codetf.exists()
@@ -93,6 +95,8 @@ class TestRun:
             "tests/samples/",
             "--output",
             "here.txt",
+            # Make this test faster by restricting the number of codemods
+            "--codemod-include=use-generator,use-defusedxml,use-walrus-if",
         ]
         if dry_run:
             args += ["--dry-run"]
@@ -105,8 +109,7 @@ class TestRun:
         assert len(args_to_reporting) == 4
         _, _, _, results_by_codemod = args_to_reporting
 
-        registry = load_registered_codemods()
-        assert len(results_by_codemod) == len(registry.codemods)
+        assert len(results_by_codemod) == 3
 
     @mock.patch("codemodder.codemods.base_codemod.semgrep_run")
     def test_no_codemods_to_run(self, mock_semgrep_run, tmpdir):

--- a/tests/test_codemodder.py
+++ b/tests/test_codemodder.py
@@ -6,7 +6,7 @@ import libcst as cst
 from codemodder.codemodder import run, find_semgrep_results
 from codemodder.diff import create_diff_from_tree
 from codemodder.semgrep import run as semgrep_run
-from codemodder.registry import load_registered_codemods
+from codemodder.registry import DEFAULT_EXCLUDED_CODEMODS, load_registered_codemods
 from codemodder.result import ResultSet
 
 


### PR DESCRIPTION
## Overview
*Exclude some codemods unless explicitly opted-in*

## Description

* Some codemods aren't necessarily intended to be used on their own
* These remain opt-in with `--codemod-include` but are now excluded by default
* Also updated `CODEOWNERS` so that @clavedeluna doesn't get too much noise for now