### PR TITLE
Make `--output` CLI flag optional

### DIFF
--- a/src/codemodder/cli.py
+++ b/src/codemodder/cli.py
@@ -116,8 +116,6 @@ def parse_args(argv, codemod_registry: CodemodRegistry):
         "--output",
         type=str,
         help="name of output file to produce",
-        default="stdout",
-        required=True,
     )
 
     codemod_validator = build_codemod_validator(codemod_registry)

--- a/src/codemodder/codemodder.py
+++ b/src/codemodder/codemodder.py
@@ -287,7 +287,9 @@ def run(original_args) -> int:
 
     elapsed = datetime.datetime.now() - start
     elapsed_ms = int(elapsed.total_seconds() * 1000)
-    report_default(elapsed_ms, argv, original_args, results)
+
+    if argv.output:
+        report_default(elapsed_ms, argv, original_args, results)
 
     log_report(context, argv, elapsed_ms, files_to_analyze)
     return 0

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -21,7 +21,7 @@ class TestParseArgs:
         error_logger.assert_called()
         assert error_logger.call_args_list[0][0] == (
             "CLI error: %s",
-            "the following arguments are required: directory, --output",
+            "the following arguments are required: directory",
         )
 
     @pytest.mark.parametrize(


### PR DESCRIPTION
## Overview
*Make `--output` CLI flag optional*

## Description

* Sometimes it's useful just to run codemodder to see the produced diffs and/or log output
* The spec now supports `--output` as optional: https://github.com/pixee/codemodder-specs/pull/14