### PR TITLE
New codemod: fix-deprecated-abstractproperty

### DIFF
--- a/integration_tests/test_fix_deprecated_abstractproperty.py
+++ b/integration_tests/test_fix_deprecated_abstractproperty.py
@@ -1,0 +1,52 @@
+from textwrap import dedent
+
+from core_codemods.fix_deprecated_abstractproperty import FixDeprecatedAbstractproperty
+from integration_tests.base_test import (
+    BaseIntegrationTest,
+    original_and_expected_from_code_path,
+)
+
+
+class TestFixDeprecatedAbstractproperty(BaseIntegrationTest):
+    codemod = FixDeprecatedAbstractproperty
+    code_path = "tests/samples/deprecated_abstractproperty.py"
+
+    original_code, _ = original_and_expected_from_code_path(code_path, [])
+    expected_new_code = dedent(
+        """\
+    from abc import abstractmethod
+    import abc
+
+
+    class A:
+        @property
+        @abc.abstractmethod
+        def foo(self):
+            pass
+
+        @abstractmethod
+        def bar(self):
+            pass
+    """
+    )
+
+    expected_diff = """\
+--- 
++++ 
+@@ -1,8 +1,10 @@
+-from abc import abstractproperty as ap, abstractmethod
++from abc import abstractmethod
++import abc
+ 
+ 
+ class A:
+-    @ap
++    @property
++    @abc.abstractmethod
+     def foo(self):
+         pass
+ 
+"""
+
+    expected_line_change = "5"
+    change_description = FixDeprecatedAbstractproperty.DESCRIPTION

--- a/src/codemodder/scripts/generate_docs.py
+++ b/src/codemodder/scripts/generate_docs.py
@@ -154,6 +154,10 @@ If you want to allow those protocols, change the incoming PR to look more like t
         importance="Medium",
         guidance_explained="This change will only restrict the response type and will not alter the response data itself. Thus we deem it safe.",
     ),
+    "fix-deprecated-abstractproperty": DocMetadata(
+        importance="Low",
+        guidance_explained="This change fixes deprecated uses and is safe.",
+    ),
 }
 
 

--- a/src/core_codemods/__init__.py
+++ b/src/core_codemods/__init__.py
@@ -5,6 +5,7 @@ from core_codemods.sql_parameterization import SQLQueryParameterization
 from .django_debug_flag_on import DjangoDebugFlagOn
 from .django_session_cookie_secure_off import DjangoSessionCookieSecureOff
 from .enable_jinja2_autoescape import EnableJinja2Autoescape
+from .fix_deprecated_abstractproperty import FixDeprecatedAbstractproperty
 from .fix_mutable_params import FixMutableParams
 from .harden_pyyaml import HardenPyyaml
 from .harden_ruamel import HardenRuamel
@@ -41,6 +42,7 @@ registry = CodemodCollection(
         DjangoDebugFlagOn,
         DjangoSessionCookieSecureOff,
         EnableJinja2Autoescape,
+        FixDeprecatedAbstractproperty,
         FixMutableParams,
         HardenPyyaml,
         HardenRuamel,

--- a/src/core_codemods/docs/pixee_python_fix-deprecated-abstractproperty.md
+++ b/src/core_codemods/docs/pixee_python_fix-deprecated-abstractproperty.md
@@ -1,0 +1,13 @@
+The `@abstractproperty` decorator from `abc` has been [deprecated](https://docs.python.org/3/library/abc.html#abc.abstractproperty) since Python 3.3. This is because it's possible to use `@property` in combination with `@abstractmethod`. 
+
+Our changes look like the following:
+```diff
+ import abc
+
+ class Foo:
+-   @abc.abstractproperty
++   @property
++   @abc.abstractmethod
+    def bar():
+        ...
+```

--- a/src/core_codemods/fix_deprecated_abstractproperty.py
+++ b/src/core_codemods/fix_deprecated_abstractproperty.py
@@ -1,0 +1,43 @@
+import libcst as cst
+
+from codemodder.codemods.api import BaseCodemod, ReviewGuidance
+from codemodder.codemods.utils_mixin import NameResolutionMixin
+
+
+class FixDeprecatedAbstractproperty(BaseCodemod, NameResolutionMixin):
+    NAME = "fix-deprecated-abstractproperty"
+    SUMMARY = "Replace deprecated abstractproperty"
+    REVIEW_GUIDANCE = ReviewGuidance.MERGE_WITHOUT_REVIEW
+    DESCRIPTION = "Replace deprecated abstractproperty with property and abstractmethod"
+    REFERENCES = [
+        {
+            "url": "https://docs.python.org/3/library/abc.html#abc.abstractproperty",
+            "description": "",
+        },
+    ]
+
+    def leave_Decorator(
+        self, original_node: cst.Decorator, updated_node: cst.Decorator
+    ):
+        if (
+            base_name := self.find_base_name(original_node.decorator)
+        ) and base_name == "abc.abstractproperty":
+            self.add_needed_import("abc")
+            self.remove_unused_import(original_node)
+            self.add_change(original_node, self.DESCRIPTION)
+            return cst.FlattenSentinel(
+                [
+                    cst.Decorator(
+                        decorator=cst.Name(value="property"),
+                        trailing_whitespace=updated_node.trailing_whitespace,
+                    ),
+                    cst.Decorator(
+                        decorator=cst.Attribute(
+                            value=cst.Name(value="abc"),
+                            attr=cst.Name(value="abstractmethod"),
+                        )
+                    ),
+                ]
+            )
+
+        return original_node

--- a/src/core_codemods/numpy_nan_equality.py
+++ b/src/core_codemods/numpy_nan_equality.py
@@ -97,11 +97,11 @@ class NumpyNanEquality(BaseCodemod, NameResolutionMixin):
         return triples
 
     def _build_nan_comparison(self, nan_node, node):
-        maybe_numpy_alias = self.find_alias_for_import_in_node("numpy", nan_node)
-        if maybe_numpy_alias:
+        if maybe_numpy_alias := self.find_alias_for_import_in_node("numpy", nan_node):
             call = cst.parse_expression(f"{maybe_numpy_alias}.isnan()")
         else:
             self.add_needed_import("numpy")
+            self.remove_unused_import(nan_node)
             call = cst.parse_expression("numpy.isnan()")
         return call.with_changes(args=[cst.Arg(value=node)])
 

--- a/tests/codemods/test_fix_deprecated_abstractproperty.py
+++ b/tests/codemods/test_fix_deprecated_abstractproperty.py
@@ -1,0 +1,123 @@
+from core_codemods.fix_deprecated_abstractproperty import FixDeprecatedAbstractproperty
+from tests.codemods.base_codemod_test import BaseCodemodTest
+
+
+class TestFixDeprecatedAbstractproperty(BaseCodemodTest):
+    codemod = FixDeprecatedAbstractproperty
+
+    def test_import(self, tmpdir):
+        original_code = """
+        import abc
+
+        class A:
+            @abc.abstractproperty
+            def foo(self):
+                pass
+        """
+        new_code = """
+        import abc
+
+        class A:
+            @property
+            @abc.abstractmethod
+            def foo(self):
+                pass
+        """
+        self.run_and_assert(tmpdir, original_code, new_code)
+
+    def test_import_from(self, tmpdir):
+        original_code = """
+        from abc import abstractproperty
+
+        class A:
+            @abstractproperty
+            def foo(self):
+                pass
+        """
+        new_code = """
+        import abc
+
+        class A:
+            @property
+            @abc.abstractmethod
+            def foo(self):
+                pass
+        """
+        self.run_and_assert(tmpdir, original_code, new_code)
+
+    def test_import_alias(self, tmpdir):
+        original_code = """
+        from abc import abstractproperty as ap
+
+        class A:
+            @ap
+            def foo(self):
+                pass
+        """
+        new_code = """
+        import abc
+
+        class A:
+            @property
+            @abc.abstractmethod
+            def foo(self):
+                pass
+        """
+        self.run_and_assert(tmpdir, original_code, new_code)
+
+    def test_different_abstractproperty(self, tmpdir):
+        new_code = original_code = """
+        from xyz import abstractproperty
+
+        class A:
+            @abstractproperty
+            def foo(self):
+                pass
+
+            @property
+            def bar(self):
+                pass
+        """
+        self.run_and_assert(tmpdir, original_code, new_code)
+
+    def test_preserve_decorator_order(self, tmpdir):
+        original_code = """
+        import abc
+
+        class A:
+            @whatever
+            @abc.abstractproperty
+            def foo(self):
+                pass
+        """
+        new_code = """
+        import abc
+
+        class A:
+            @whatever
+            @property
+            @abc.abstractmethod
+            def foo(self):
+                pass
+        """
+        self.run_and_assert(tmpdir, original_code, new_code)
+
+    def test_preserve_comments(self, tmpdir):
+        original_code = """
+        import abc
+
+        class A:
+            @abc.abstractproperty # comment
+            def foo(self):
+                pass
+        """
+        new_code = """
+        import abc
+
+        class A:
+            @property # comment
+            @abc.abstractmethod
+            def foo(self):
+                pass
+        """
+        self.run_and_assert(tmpdir, original_code, new_code)

--- a/tests/codemods/test_numpy_nan_equality.py
+++ b/tests/codemods/test_numpy_nan_equality.py
@@ -23,6 +23,21 @@ class TestNumpyNanEquality(BaseCodemodTest):
         self.run_and_assert(tmpdir, dedent(input_code), dedent(expected))
         assert len(self.file_context.codemod_changes) == 1
 
+    def test_from_numpy(self, tmpdir):
+        input_code = """\
+        from numpy import nan
+        if a == nan:
+            pass
+        """
+        expected = """\
+        import numpy
+
+        if numpy.isnan(a):
+            pass
+        """
+        self.run_and_assert(tmpdir, dedent(input_code), dedent(expected))
+        assert len(self.file_context.codemod_changes) == 1
+
     def test_simple_left(self, tmpdir):
         input_code = """\
         import numpy

--- a/tests/samples/deprecated_abstractproperty.py
+++ b/tests/samples/deprecated_abstractproperty.py
@@ -1,0 +1,11 @@
+from abc import abstractproperty as ap, abstractmethod
+
+
+class A:
+    @ap
+    def foo(self):
+        pass
+
+    @abstractmethod
+    def bar(self):
+        pass


### PR DESCRIPTION
## Overview
*Add new codemod for `fix-deprecated-abstractproperty`*

## Description

* This replaces deprecated `@abstractproperty` with `@property` and `@abstractmethod`
* Also made a minor fix to `numpy-nan-equality`