### PR TITLE
New codemod: add-requests-timeout

### DIFF
--- a/ci_tests/test_pygoat_findings.py
+++ b/ci_tests/test_pygoat_findings.py
@@ -4,6 +4,7 @@ import pytest
 
 
 EXPECTED_FINDINGS = [
+    "pixee:python/add-requests-timeouts",
     "pixee:python/secure-random",
     "pixee:python/sandbox-process-creation",
     "pixee:python/django-session-cookie-secure-off",

--- a/integration_tests/test_add_requests_timeout.py
+++ b/integration_tests/test_add_requests_timeout.py
@@ -1,0 +1,36 @@
+from core_codemods.add_requests_timeouts import AddRequestsTimeouts
+from integration_tests.base_test import (
+    BaseIntegrationTest,
+    original_and_expected_from_code_path,
+)
+
+
+class TestAddRequestsTimeouts(BaseIntegrationTest):
+    codemod = AddRequestsTimeouts
+    code_path = "tests/samples/requests_timeout.py"
+
+    original_code, expected_new_code = original_and_expected_from_code_path(
+        code_path,
+        [
+            (2, 'requests.get("https://example.com", timeout=60)\n'),
+            (5, 'requests.post("https://example.com", verify=False, timeout=60)\n'),
+        ],
+    )
+
+    expected_diff = """\
+--- 
++++ 
+@@ -1,6 +1,6 @@
+ import requests
+ 
+-requests.get("https://example.com")
++requests.get("https://example.com", timeout=60)
+ requests.get("https://example.com", timeout=1)
+ requests.get("https://example.com", timeout=(1, 10), verify=False)
+-requests.post("https://example.com", verify=False)
++requests.post("https://example.com", verify=False, timeout=60)
+"""
+
+    num_changes = 2
+    expected_line_change = "3"
+    change_description = AddRequestsTimeouts.CHANGE_DESCRIPTION

--- a/src/codemodder/codemods/api/helpers.py
+++ b/src/codemodder/codemods/api/helpers.py
@@ -97,10 +97,26 @@ class Helpers:
             )
         )
         return cst.Arg(
-            keyword=cst.parse_expression(name),
+            keyword=cst.Name(value=name),
             value=cst.parse_expression(value),
             equal=equal,
         )
+
+    def add_arg_to_call(self, node: cst.Call, name: str, value):
+        """
+        Add a new arg to the end of the args list.
+        """
+        new_args = list(node.args) + [
+            cst.Arg(
+                keyword=cst.Name(value=name),
+                value=cst.parse_expression(str(value)),
+                equal=cst.AssignEqual(
+                    whitespace_before=cst.SimpleWhitespace(""),
+                    whitespace_after=cst.SimpleWhitespace(""),
+                ),
+            )
+        ]
+        return node.with_changes(args=new_args)
 
 
 def _match_with_existing_arg(arg, args_info):

--- a/src/codemodder/scripts/generate_docs.py
+++ b/src/codemodder/scripts/generate_docs.py
@@ -15,6 +15,10 @@ class DocMetadata:
 
 # codemod-specific metadata that's used only for docs, not for codemod API
 METADATA = {
+    "add-requests-timeouts": DocMetadata(
+        importance="Medium",
+        guidance_explained="This change makes your code safer but in some cases it may be necessary to adjust the timeout value for your particular application.",
+    ),
     "django-debug-flag-on": DocMetadata(
         importance="Medium",
         guidance_explained="Django's `DEBUG` flag may be overridden somewhere else or the runtime settings file may be set with the `DJANGO_SETTINGS_MODULE` environment variable. This means that the `DEBUG` flag may intentionally be left on as a development aid.",

--- a/src/core_codemods/__init__.py
+++ b/src/core_codemods/__init__.py
@@ -1,5 +1,6 @@
 from codemodder.registry import CodemodCollection
 
+from .add_requests_timeouts import AddRequestsTimeouts
 from .django_debug_flag_on import DjangoDebugFlagOn
 from .django_session_cookie_secure_off import DjangoSessionCookieSecureOff
 from .enable_jinja2_autoescape import EnableJinja2Autoescape
@@ -41,6 +42,7 @@ registry = CodemodCollection(
     docs_module="core_codemods.docs",
     semgrep_config_module="core_codemods.semgrep",
     codemods=[
+        AddRequestsTimeouts,
         DjangoDebugFlagOn,
         DjangoSessionCookieSecureOff,
         EnableJinja2Autoescape,

--- a/src/core_codemods/add_requests_timeouts.py
+++ b/src/core_codemods/add_requests_timeouts.py
@@ -1,0 +1,45 @@
+from codemodder.codemods.api import SemgrepCodemod, ReviewGuidance
+
+
+class AddRequestsTimeouts(SemgrepCodemod):
+    NAME = "add-requests-timeouts"
+    SUMMARY = "Add timeout to `requests` calls"
+    REVIEW_GUIDANCE = ReviewGuidance.MERGE_AFTER_CURSORY_REVIEW
+    DESCRIPTION = "Add timeout to `requests` call"
+    REFERENCES = [
+        {
+            "url": "https://docs.python-requests.org/en/master/user/quickstart/#timeouts",
+            "description": "",
+        },
+    ]
+
+    @classmethod
+    def rule(cls):
+        return """
+        rules:
+            - patterns:
+                - pattern-inside: |
+                    import requests
+                    ...
+                - pattern: $CALL(...)
+                - pattern-not: $CALL(..., timeout=$TIMEOUT, ...)
+                - metavariable-pattern:
+                    metavariable: $CALL
+                    patterns:
+                      - pattern-either:
+                        - pattern: requests.get
+                        - pattern: requests.post
+                        - pattern: requests.put
+                        - pattern: requests.delete
+                        - pattern: requests.head
+                        - pattern: requests.options
+                        - pattern: requests.patch
+                        - pattern: requests.request
+        """
+
+    # Sets an arbitrary default timeout for all requests
+    DEFAULT_TIMEOUT = 60
+
+    def on_result_found(self, original_node, updated_node):
+        del original_node
+        return self.add_arg_to_call(updated_node, "timeout", self.DEFAULT_TIMEOUT)

--- a/src/core_codemods/docs/pixee_python_add-requests-timeouts.md
+++ b/src/core_codemods/docs/pixee_python_add-requests-timeouts.md
@@ -1,0 +1,13 @@
+Many developers will be surprised to learn that `requests` library calls do not include timeouts by default. This means that an attempted request could hang indefinitely if no connection is established or if no data is received from the server. 
+
+The [requests documentation](https://requests.readthedocs.io/en/latest/user/advanced/#timeouts) suggests that most calls should explicitly include a `timeout` parameter. This codemod adds a default timeout value in order to set an upper bound on connection times and ensure that requests connect or fail in a timely manner. This value also ensures the connection will timeout if the server does not respond with data within a reasonable amount of time. 
+
+While timeout values will be application dependent, we believe that this codemod adds a reasonable default that serves as an appropriate ceiling for most situations. 
+
+Our changes look like the following:
+```diff
+ import requests
+ 
+- requests.get("http://example.com")
++ requests.get("http://example.com", timeout=60)
+```

--- a/tests/codemods/test_add_requests_timeouts.py
+++ b/tests/codemods/test_add_requests_timeouts.py
@@ -1,0 +1,83 @@
+import pytest
+
+from core_codemods.add_requests_timeouts import AddRequestsTimeouts
+from tests.codemods.base_codemod_test import BaseSemgrepCodemodTest
+
+METHODS = ["get", "post", "put", "delete", "head", "options", "patch"]
+TIMEOUT = AddRequestsTimeouts.DEFAULT_TIMEOUT
+
+
+class TestAddRequestsTimeouts(BaseSemgrepCodemodTest):
+    codemod = AddRequestsTimeouts
+
+    @pytest.mark.parametrize("method", METHODS)
+    def test_import(self, tmpdir, method):
+        original = f"""
+            import requests
+            requests.{method}("https://example.com")
+        """
+        expected = f"""
+            import requests
+            requests.{method}("https://example.com", timeout={TIMEOUT})
+        """
+        self.run_and_assert(tmpdir, original, expected)
+
+    def test_import_use_request(self, tmpdir):
+        original = """
+            import requests
+            requests.request("GET", "https://example.com")
+        """
+        expected = f"""
+            import requests
+            requests.request("GET", "https://example.com", timeout={TIMEOUT})
+        """
+        self.run_and_assert(tmpdir, original, expected)
+
+    @pytest.mark.parametrize("method", METHODS)
+    def test_import_from(self, tmpdir, method):
+        original = f"""
+            from requests import {method}
+            {method}("https://example.com")
+        """
+        expected = f"""
+            from requests import {method}
+            {method}("https://example.com", timeout={TIMEOUT})
+        """
+        self.run_and_assert(tmpdir, original, expected)
+
+    @pytest.mark.parametrize("method", METHODS)
+    def test_import_alias(self, tmpdir, method):
+        original = f"""
+            from requests import {method} as my_method
+            my_method("https://example.com")
+        """
+        expected = f"""
+            from requests import {method} as my_method
+            my_method("https://example.com", timeout={TIMEOUT})
+        """
+        self.run_and_assert(tmpdir, original, expected)
+
+    def test_preserve_other_args(self, tmpdir):
+        original = """
+            import requests
+            requests.get("https://example.com", headers={"foo": "bar"})
+        """
+        expected = f"""
+            import requests
+            requests.get("https://example.com", headers={{"foo": "bar"}}, timeout={TIMEOUT})
+        """
+        self.run_and_assert(tmpdir, original, expected)
+
+    def test_has_timeout(self, tmpdir):
+        original = """
+            import requests
+            requests.get("https://example.com", timeout=10)
+        """
+        self.run_and_assert(tmpdir, original, original)
+
+    def test_not_requests(self, tmpdir):
+        original = """
+            import demands
+            demands.get("https://example.com")
+        """
+        self.run_and_assert(tmpdir, original, original)

--- a/tests/samples/requests_timeout.py
+++ b/tests/samples/requests_timeout.py
@@ -1,0 +1,6 @@
+import requests
+
+requests.get("https://example.com")
+requests.get("https://example.com", timeout=1)
+requests.get("https://example.com", timeout=(1, 10), verify=False)
+requests.post("https://example.com", verify=False)


### PR DESCRIPTION
## Overview
*Add new codemod `add-requests-timeouts`*

## Description

* By default the `requests` API calls do not include timeouts
* We add a fairly arbitrary timeout value to enforce a ceiling for connections and data received
  * We could potentially change this value based on user feedback
  * Also we could set `timeout=(x, y)` to use different values for connection and data received
  * This would also be a good use case for parametrized codemods if/when that becomes a thing
