### PR TITLE
Do not duplicate existing dependency with different version

### DIFF
--- a/src/codemodder/dependency_management/base_dependency_writer.py
+++ b/src/codemodder/dependency_management/base_dependency_writer.py
@@ -33,9 +33,10 @@ class DependencyWriter(metaclass=ABCMeta):
     def add(self, dependencies: list[Dependency]) -> list[Dependency]:
         """add any number of dependencies to the end of list of dependencies."""
         new = []
+
         for new_dep in dependencies:
             requirement: Requirement = new_dep.requirement
-            if requirement not in self.dependency_store.dependencies:
+            if not self.dependency_store.has_requirement(requirement):
                 self.dependency_store.dependencies.add(requirement)
                 new.append(new_dep)
         return new

--- a/src/codemodder/dependency_management/requirements_txt_writer.py
+++ b/src/codemodder/dependency_management/requirements_txt_writer.py
@@ -13,9 +13,9 @@ class RequirementsTxtWriter(DependencyWriter):
     def add_to_file(
         self, dependencies: list[Dependency], dry_run: bool = False
     ) -> Optional[ChangeSet]:
-        lines = self._parse_file()
-        if lines is None:
+        if (lines := self._parse_file()) is None:
             return None
+
         original_lines = lines.copy()
         if not original_lines[-1].endswith("\n"):
             original_lines[-1] += "\n"

--- a/src/codemodder/project_analysis/file_parsers/package_store.py
+++ b/src/codemodder/project_analysis/file_parsers/package_store.py
@@ -33,3 +33,6 @@ class PackageStore:
             for dep in dependencies
         }
         self.py_versions = py_versions
+
+    def has_requirement(self, requirement: Requirement) -> bool:
+        return requirement.name in {dep.name for dep in self.dependencies}

--- a/tests/dependency_management/test_base_dependency_writer.py
+++ b/tests/dependency_management/test_base_dependency_writer.py
@@ -1,0 +1,83 @@
+from codemodder.change import ChangeSet
+from codemodder.dependency import Dependency, Requirement
+from codemodder.dependency_management.base_dependency_writer import DependencyWriter
+from codemodder.project_analysis.file_parsers.package_store import PackageStore
+
+
+class FakeDependencyWriter(DependencyWriter):
+    def add_to_file(  # pylint: disable=useless-return
+        self, dependencies: list[Dependency], dry_run: bool = False
+    ) -> ChangeSet | None:
+        del dependencies, dry_run
+        return None
+
+
+def test_add_dependency(mocker):
+    mocker.patch("codemodder.dependency_management.base_dependency_writer.Path")
+
+    dependency_store = PackageStore(mocker.Mock(), mocker.Mock(), set(), [])
+    dep = FakeDependencyWriter(
+        dependency_store=dependency_store,
+        parent_directory=mocker.Mock(),
+    )
+
+    requirement = Requirement("foo==1.0.0")
+    dependency = Dependency(
+        requirement,
+        mocker.Mock(),
+        mocker.Mock(),
+        mocker.Mock(),
+        mocker.Mock(),
+    )
+
+    dep.add([dependency])
+    assert dependency_store.dependencies == {dependency.requirement}
+
+
+def test_add_dependency_already_exists(mocker):
+    mocker.patch("codemodder.dependency_management.base_dependency_writer.Path")
+
+    dependency_store = PackageStore(
+        mocker.Mock(), mocker.Mock(), {Requirement("foo==1.0.0")}, []
+    )
+    dep = FakeDependencyWriter(
+        dependency_store=dependency_store,
+        parent_directory=mocker.Mock(),
+    )
+
+    requirement = Requirement("foo==1.0.0")
+    dependency = Dependency(
+        requirement,
+        mocker.Mock(),
+        mocker.Mock(),
+        mocker.Mock(),
+        mocker.Mock(),
+    )
+
+    dep.add([dependency])
+    assert dependency_store.dependencies == {dependency.requirement}
+
+
+def test_add_dependency_already_exists_different_version(mocker):
+    mocker.patch("codemodder.dependency_management.base_dependency_writer.Path")
+
+    original_requirement = Requirement("foo==1.0.0")
+    dependency_store = PackageStore(
+        mocker.Mock(), mocker.Mock(), {original_requirement}, []
+    )
+    dep = FakeDependencyWriter(
+        dependency_store=dependency_store,
+        parent_directory=mocker.Mock(),
+    )
+
+    requirement = Requirement("foo==2.0.0")
+    dependency = Dependency(
+        requirement,
+        mocker.Mock(),
+        mocker.Mock(),
+        mocker.Mock(),
+        mocker.Mock(),
+    )
+
+    dep.add([dependency])
+    assert dependency_store.dependencies == {original_requirement}


### PR DESCRIPTION
## Overview
*Do not duplicate existing dependency with different version*

## Description

* This fixes a regression in the dependency manager
* We should never update dependency versions or add versions that conflict with existing dependencies