### PR TITLE
Remove breakpoints codemod

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -11,7 +11,7 @@ repos:
               src/core_codemods/docs/.*|
               src/codemodder/dependency.py |
               integration_tests/.*|
-              tests/codemods/test_remove_debug_breakpoint.py
+              tests/codemods/test_remove_debug_breakpoint.py |
               tests/test_codemodder.py
           )$
     -   id: check-added-large-files

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -11,6 +11,7 @@ repos:
               src/core_codemods/docs/.*|
               src/codemodder/dependency.py |
               integration_tests/.*|
+              tests/codemods/test_remove_debug_breakpoint.py
               tests/test_codemodder.py
           )$
     -   id: check-added-large-files

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -11,8 +11,7 @@ repos:
               src/core_codemods/docs/.*|
               src/codemodder/dependency.py |
               integration_tests/.*|
-              tests/codemods/test_remove_debug_breakpoint.py |
-              tests/test_codemodder.py
+              tests/.*
           )$
     -   id: check-added-large-files
 -   repo: https://github.com/psf/black

--- a/integration_tests/test_remove_debug_breakpoint.py
+++ b/integration_tests/test_remove_debug_breakpoint.py
@@ -1,0 +1,20 @@
+from core_codemods.remove_debug_breakpoint import RemoveDebugBreakpoint
+from integration_tests.base_test import (
+    BaseIntegrationTest,
+    original_and_expected_from_code_path,
+)
+
+
+class TestRemoveDebugBreakpoint(BaseIntegrationTest):
+    codemod = RemoveDebugBreakpoint
+    code_path = "tests/samples/remove_debug_breakpoint.py"
+    original_code, _ = original_and_expected_from_code_path(code_path, [])
+    expected_new_code = """
+print("hello")
+print("world")
+""".lstrip()
+    expected_diff = (
+        '--- \n+++ \n@@ -1,3 +1,2 @@\n print("hello")\n-breakpoint()\n print("world")\n'
+    )
+    expected_line_change = "2"
+    change_description = RemoveDebugBreakpoint.CHANGE_DESCRIPTION

--- a/src/codemodder/scripts/generate_docs.py
+++ b/src/codemodder/scripts/generate_docs.py
@@ -192,7 +192,7 @@ If you want to allow those protocols, change the incoming PR to look more like t
     ),
     "remove-debug-breakpoint": DocMetadata(
         importance="Medium",
-        guidance_explained="Breakpoints are used for development debugging and can easily be forgotten before deploying code.",
+        guidance_explained="Breakpoints are generally used only for debugging and can easily be forgotten before deploying code.",
     ),
 }
 

--- a/src/codemodder/scripts/generate_docs.py
+++ b/src/codemodder/scripts/generate_docs.py
@@ -190,6 +190,10 @@ If you want to allow those protocols, change the incoming PR to look more like t
         importance="Low",
         guidance_explained="Since the `global` keyword is intended for use in non-module scopes, using it at the module scope is unnecessary.",
     ),
+    "remove-debug-breakpoint": DocMetadata(
+        importance="Medium",
+        guidance_explained="Breakpoints are used for development debugging and can easily be forgotten before deploying code.",
+    ),
 }
 
 

--- a/src/core_codemods/__init__.py
+++ b/src/core_codemods/__init__.py
@@ -41,6 +41,8 @@ from .exception_without_raise import ExceptionWithoutRaise
 from .literal_or_new_object_identity import LiteralOrNewObjectIdentity
 from .subprocess_shell_false import SubprocessShellFalse
 from .remove_module_global import RemoveModuleGlobal
+from .remove_debug_breakpoint import RemoveDebugBreakpoint
+
 
 registry = CodemodCollection(
     origin="pixee",
@@ -88,5 +90,6 @@ registry = CodemodCollection(
         ExceptionWithoutRaise,
         LiteralOrNewObjectIdentity,
         RemoveModuleGlobal,
+        RemoveDebugBreakpoint,
     ],
 )

--- a/src/core_codemods/docs/pixee_python_remove-debug-breakpoint.md
+++ b/src/core_codemods/docs/pixee_python_remove-debug-breakpoint.md
@@ -1,0 +1,7 @@
+This codemod removes any calls to `breakpoint()` or `pdb.set_trace()` which should only be used for active debugging and not in production code.
+
+```diff
+ print("hello")
+- breakpoint()
+ print("world")
+```

--- a/src/core_codemods/docs/pixee_python_remove-debug-breakpoint.md
+++ b/src/core_codemods/docs/pixee_python_remove-debug-breakpoint.md
@@ -1,4 +1,6 @@
-This codemod removes any calls to `breakpoint()` or `pdb.set_trace()` which should only be used for active debugging and not in production code.
+This codemod removes any calls to `breakpoint()` or `pdb.set_trace()` which are generally only used for interactive debugging and should not be deployed in production code.
+
+In most cases if these calls are included in committed code, they were left there by mistake and indicate a potential problem.
 
 ```diff
  print("hello")

--- a/src/core_codemods/remove_debug_breakpoint.py
+++ b/src/core_codemods/remove_debug_breakpoint.py
@@ -21,4 +21,9 @@ class RemoveDebugBreakpoint(BaseCodemod, NameResolutionMixin, AncestorPatternsMi
                 ) == "breakpoint" and self.is_builtin_function(call_node):
                     self.report_change(original_node)
                     return cst.RemovalSentinel.REMOVE
+                if self.find_base_name(call_node) == "pdb.set_trace":
+                    self.remove_unused_import(call_node)
+                    self.report_change(original_node)
+                    return cst.RemovalSentinel.REMOVE
+
         return original_node

--- a/src/core_codemods/remove_debug_breakpoint.py
+++ b/src/core_codemods/remove_debug_breakpoint.py
@@ -6,9 +6,9 @@ from codemodder.codemods.utils_mixin import NameResolutionMixin, AncestorPattern
 
 class RemoveDebugBreakpoint(BaseCodemod, NameResolutionMixin, AncestorPatternsMixin):
     NAME = "remove-debug-breakpoint"
-    SUMMARY = "TODORemove Module-level Global Call"
+    SUMMARY = "Remove Breakpoint"
     REVIEW_GUIDANCE = ReviewGuidance.MERGE_WITHOUT_REVIEW
-    DESCRIPTION = "TODORemove Lines with `global` keyword at Module Level"
+    DESCRIPTION = "Remove calls to builtin `breakpoint` or `pdb.set_trace."
     REFERENCES: list = []
 
     def leave_Expr(

--- a/src/core_codemods/remove_debug_breakpoint.py
+++ b/src/core_codemods/remove_debug_breakpoint.py
@@ -6,14 +6,19 @@ from codemodder.codemods.utils_mixin import NameResolutionMixin, AncestorPattern
 
 class RemoveDebugBreakpoint(BaseCodemod, NameResolutionMixin, AncestorPatternsMixin):
     NAME = "remove-debug-breakpoint"
-    SUMMARY = "Remove Breakpoint"
+    SUMMARY = "Remove Calls to `builtin` `breakpoint` and `pdb.set_trace"
     REVIEW_GUIDANCE = ReviewGuidance.MERGE_WITHOUT_REVIEW
-    DESCRIPTION = "Remove calls to builtin `breakpoint` or `pdb.set_trace."
+    DESCRIPTION = "Remove breakpoint call"
     REFERENCES: list = []
 
     def leave_Expr(
         self, original_node: cst.Expr, _
     ) -> Union[cst.Expr, cst.RemovalSentinel]:
+        if not self.filter_by_path_includes_or_excludes(
+            self.node_position(original_node)
+        ):
+            return original_node
+
         match call_node := original_node.value:
             case cst.Call():
                 if self.find_base_name(

--- a/src/core_codemods/remove_debug_breakpoint.py
+++ b/src/core_codemods/remove_debug_breakpoint.py
@@ -1,0 +1,24 @@
+import libcst as cst
+from typing import Union
+from codemodder.codemods.api import BaseCodemod, ReviewGuidance
+from codemodder.codemods.utils_mixin import NameResolutionMixin, AncestorPatternsMixin
+
+
+class RemoveDebugBreakpoint(BaseCodemod, NameResolutionMixin, AncestorPatternsMixin):
+    NAME = "remove-debug-breakpoint"
+    SUMMARY = "TODORemove Module-level Global Call"
+    REVIEW_GUIDANCE = ReviewGuidance.MERGE_WITHOUT_REVIEW
+    DESCRIPTION = "TODORemove Lines with `global` keyword at Module Level"
+    REFERENCES: list = []
+
+    def leave_Expr(
+        self, original_node: cst.Expr, _
+    ) -> Union[cst.Expr, cst.RemovalSentinel]:
+        match call_node := original_node.value:
+            case cst.Call():
+                if self.find_base_name(
+                    call_node
+                ) == "breakpoint" and self.is_builtin_function(call_node):
+                    self.report_change(original_node)
+                    return cst.RemovalSentinel.REMOVE
+        return original_node

--- a/tests/codemods/test_remove_debug_breakpoint.py
+++ b/tests/codemods/test_remove_debug_breakpoint.py
@@ -34,7 +34,7 @@ class TestRemoveDebugBreakpoint(BaseCodemodTest):
         expected = """\
         def something():
             var = 1
-            print(var);
+            print(var); 
         something()
         """
         self.run_and_assert(tmpdir, dedent(input_code), dedent(expected))

--- a/tests/codemods/test_remove_debug_breakpoint.py
+++ b/tests/codemods/test_remove_debug_breakpoint.py
@@ -1,0 +1,74 @@
+from core_codemods.remove_debug_breakpoint import RemoveDebugBreakpoint
+from tests.codemods.base_codemod_test import BaseCodemodTest
+from textwrap import dedent
+
+
+class TestRemoveDebugBreakpoint(BaseCodemodTest):
+    codemod = RemoveDebugBreakpoint
+
+    def test_name(self):
+        assert self.codemod.name() == "remove-debug-breakpoint"
+
+    def test_builtin_breakpoint(self, tmpdir):
+        input_code = """\
+        def something():
+            var = 1
+            breakpoint()
+        something()
+        """
+        expected = """\
+        def something():
+            var = 1
+        something()
+        """
+        self.run_and_assert(tmpdir, dedent(input_code), dedent(expected))
+        assert len(self.file_context.codemod_changes) == 1
+
+    def test_inline_pdb(self, tmpdir):
+        input_code = """\
+        def something():
+            var = 1
+            import pdb; pdb.set_trace()
+        something()
+        """
+        expected = """\
+        def something():
+            var = 1
+        something()
+        """
+        self.run_and_assert(tmpdir, dedent(input_code), dedent(expected))
+        assert len(self.file_context.codemod_changes) == 1
+
+    def test_pdb_import(self, tmpdir):
+        input_code = """\
+        import pdb
+        def something():
+            var = 1
+            pdb.set_trace()
+        something()
+        """
+        expected = """\
+        def something():
+            var = 1
+        something()
+        """
+        self.run_and_assert(tmpdir, dedent(input_code), dedent(expected))
+        assert len(self.file_context.codemod_changes) == 1
+
+    def test_pdb_from_import(self, tmpdir):
+        input_code = """\
+        from pdb import set_trace()
+        def something():
+            var = 1
+            set_trace()
+        something()
+        """
+        expected = """\
+        def something():
+            var = 1
+        something()
+        """
+        self.run_and_assert(tmpdir, dedent(input_code), dedent(expected))
+        assert len(self.file_context.codemod_changes) == 1
+
+        # what about line line print(1); breakpoint

--- a/tests/codemods/test_remove_debug_breakpoint.py
+++ b/tests/codemods/test_remove_debug_breakpoint.py
@@ -24,6 +24,22 @@ class TestRemoveDebugBreakpoint(BaseCodemodTest):
         self.run_and_assert(tmpdir, dedent(input_code), dedent(expected))
         assert len(self.file_context.codemod_changes) == 1
 
+    def test_builtin_breakpoint_multiple_statements(self, tmpdir):
+        input_code = """\
+        def something():
+            var = 1
+            print(var); breakpoint()
+        something()
+        """
+        expected = """\
+        def something():
+            var = 1
+            print(var);
+        something()
+        """
+        self.run_and_assert(tmpdir, dedent(input_code), dedent(expected))
+        assert len(self.file_context.codemod_changes) == 1
+
     def test_inline_pdb(self, tmpdir):
         input_code = """\
         def something():
@@ -57,7 +73,7 @@ class TestRemoveDebugBreakpoint(BaseCodemodTest):
 
     def test_pdb_from_import(self, tmpdir):
         input_code = """\
-        from pdb import set_trace()
+        from pdb import set_trace
         def something():
             var = 1
             set_trace()
@@ -70,5 +86,3 @@ class TestRemoveDebugBreakpoint(BaseCodemodTest):
         """
         self.run_and_assert(tmpdir, dedent(input_code), dedent(expected))
         assert len(self.file_context.codemod_changes) == 1
-
-        # what about line line print(1); breakpoint

--- a/tests/codemods/test_remove_debug_breakpoint.py
+++ b/tests/codemods/test_remove_debug_breakpoint.py
@@ -1,6 +1,5 @@
 from core_codemods.remove_debug_breakpoint import RemoveDebugBreakpoint
 from tests.codemods.base_codemod_test import BaseCodemodTest
-from textwrap import dedent
 
 
 class TestRemoveDebugBreakpoint(BaseCodemodTest):
@@ -21,7 +20,7 @@ class TestRemoveDebugBreakpoint(BaseCodemodTest):
             var = 1
         something()
         """
-        self.run_and_assert(tmpdir, dedent(input_code), dedent(expected))
+        self.run_and_assert(tmpdir, input_code, expected)
         assert len(self.file_context.codemod_changes) == 1
 
     def test_builtin_breakpoint_multiple_statements(self, tmpdir):
@@ -37,7 +36,7 @@ class TestRemoveDebugBreakpoint(BaseCodemodTest):
             print(var); 
         something()
         """
-        self.run_and_assert(tmpdir, dedent(input_code), dedent(expected))
+        self.run_and_assert(tmpdir, input_code, expected)
         assert len(self.file_context.codemod_changes) == 1
 
     def test_inline_pdb(self, tmpdir):
@@ -52,7 +51,7 @@ class TestRemoveDebugBreakpoint(BaseCodemodTest):
             var = 1
         something()
         """
-        self.run_and_assert(tmpdir, dedent(input_code), dedent(expected))
+        self.run_and_assert(tmpdir, input_code, expected)
         assert len(self.file_context.codemod_changes) == 1
 
     def test_pdb_import(self, tmpdir):
@@ -68,7 +67,7 @@ class TestRemoveDebugBreakpoint(BaseCodemodTest):
             var = 1
         something()
         """
-        self.run_and_assert(tmpdir, dedent(input_code), dedent(expected))
+        self.run_and_assert(tmpdir, input_code, expected)
         assert len(self.file_context.codemod_changes) == 1
 
     def test_pdb_from_import(self, tmpdir):
@@ -84,5 +83,5 @@ class TestRemoveDebugBreakpoint(BaseCodemodTest):
             var = 1
         something()
         """
-        self.run_and_assert(tmpdir, dedent(input_code), dedent(expected))
+        self.run_and_assert(tmpdir, input_code, expected)
         assert len(self.file_context.codemod_changes) == 1

--- a/tests/samples/remove_debug_breakpoint.py
+++ b/tests/samples/remove_debug_breakpoint.py
@@ -1,0 +1,3 @@
+print("hello")
+breakpoint()
+print("world")


### PR DESCRIPTION
## Overview
*Codemod that removes `breakpoint()` or `pdb.set_trace()` from code *
