### PR TITLE
Added expression propagation for literal-or-new-object-identity codemod

### DIFF
--- a/src/codemodder/codemods/utils_mixin.py
+++ b/src/codemodder/codemods/utils_mixin.py
@@ -184,7 +184,7 @@ class NameResolutionMixin(MetadataDependent):
     def find_single_assignment(
         self,
         node: Union[cst.Name, cst.Attribute, cst.Call, cst.Subscript, cst.Decorator],
-    ) -> Optional[Assignment]:
+    ) -> Optional[BaseAssignment]:
         """
         Given a MetadataWrapper and a CSTNode representing an access, find if there is a single assignment that it refers to.
         """
@@ -395,7 +395,7 @@ class NameAndAncestorResolutionMixin(NameResolutionMixin, AncestorPatternsMixin)
 
     def _resolve_name_transitive(self, node: cst.Name) -> Optional[cst.BaseExpression]:
         maybe_assignment = self.find_single_assignment(node)
-        if maybe_assignment:
+        if maybe_assignment and isinstance(maybe_assignment, Assignment):
             if maybe_target_assignment := self.is_target_of_assignment(
                 maybe_assignment.node
             ):

--- a/src/core_codemods/literal_or_new_object_identity.py
+++ b/src/core_codemods/literal_or_new_object_identity.py
@@ -2,10 +2,10 @@ import libcst as cst
 from codemodder.codemods.api import BaseCodemod
 from codemodder.codemods.base_codemod import ReviewGuidance
 
-from codemodder.codemods.utils_mixin import NameResolutionMixin
+from codemodder.codemods.utils_mixin import NameAndAncestorResolutionMixin
 
 
-class LiteralOrNewObjectIdentity(BaseCodemod, NameResolutionMixin):
+class LiteralOrNewObjectIdentity(BaseCodemod, NameAndAncestorResolutionMixin):
     NAME = "literal-or-new-object-identity"
     SUMMARY = "Replaces is operator with == for literal or new object comparisons"
     REVIEW_GUIDANCE = ReviewGuidance.MERGE_WITHOUT_REVIEW
@@ -40,7 +40,8 @@ class LiteralOrNewObjectIdentity(BaseCodemod, NameResolutionMixin):
                     left=left, comparisons=[cst.ComparisonTarget() as target]
                 ):
                     if isinstance(target.operator, cst.Is | cst.IsNot):
-                        right = target.comparator
+                        left = self.resolve_expression(left)
+                        right = self.resolve_expression(target.comparator)
                         if self._is_object_creation_or_literal(
                             left
                         ) or self._is_object_creation_or_literal(right):

--- a/tests/codemods/test_literal_or_new_object_identity.py
+++ b/tests/codemods/test_literal_or_new_object_identity.py
@@ -19,6 +19,18 @@ class TestLiteralOrNewObjectIdentity(BaseCodemodTest):
         self.run_and_assert(tmpdir, dedent(input_code), dedent(expected))
         assert len(self.file_context.codemod_changes) == 1
 
+    def test_list_indirect(self, tmpdir):
+        input_code = """\
+        some_list = [1,2,3]
+        l is some_list
+        """
+        expected = """\
+        some_list = [1,2,3]
+        l == some_list
+        """
+        self.run_and_assert(tmpdir, dedent(input_code), dedent(expected))
+        assert len(self.file_context.codemod_changes) == 1
+
     def test_list_lhs(self, tmpdir):
         input_code = """\
         [1,2,3] is l


### PR DESCRIPTION
## Overview
Literals will now propagate through variables for detection in literal-or-new-object-identity codemod.