### PR TITLE
new setupcfg writer

### DIFF
--- a/src/codemodder/dependency_management/dependency_manager.py
+++ b/src/codemodder/dependency_management/dependency_manager.py
@@ -8,6 +8,7 @@ from codemodder.dependency_management.pyproject_writer import PyprojectWriter
 from codemodder.dependency_management.setup_py_writer import (
     SetupPyWriter,
 )
+from codemodder.dependency_management.setupcfg_writer import SetupCfgWriter
 
 from codemodder.project_analysis.file_parsers.package_store import (
     PackageStore,
@@ -41,6 +42,10 @@ class DependencyManager:
                 ).write(dependencies, dry_run)
             case FileType.SETUP_PY:
                 return SetupPyWriter(
+                    self.dependencies_store, self.parent_directory
+                ).write(dependencies, dry_run)
+            case FileType.SETUP_CFG:
+                return SetupCfgWriter(
                     self.dependencies_store, self.parent_directory
                 ).write(dependencies, dry_run)
         return None

--- a/src/codemodder/dependency_management/setupcfg_writer.py
+++ b/src/codemodder/dependency_management/setupcfg_writer.py
@@ -1,0 +1,124 @@
+import configparser
+
+from typing import Optional
+from codemodder.dependency import Dependency
+from codemodder.change import ChangeSet
+from codemodder.dependency_management.base_dependency_writer import DependencyWriter
+from codemodder.diff import create_diff_and_linenums
+from codemodder.logging import logger
+
+
+import re
+
+
+def find_leading_whitespace(s):
+    match = re.match(r"(\s+)", s)
+    if match:
+        return match.group(1)
+    return ""
+
+
+def added_line_nums_strategy(lines, i):
+    return lines[i]
+
+
+class SetupCfgWriter(DependencyWriter):
+    def add_to_file(
+        self, dependencies: list[Dependency], dry_run: bool = False
+    ) -> Optional[ChangeSet]:
+        config = configparser.ConfigParser()
+
+        try:
+            config.read(self.path)
+        except configparser.ParsingError:
+            logger.debug("Unable to parse setup.cfg file.")
+            return None
+
+        if "options" not in config or not (
+            defined_dependencies := config["options"].get("install_requires", "")
+        ):
+            logger.debug("Unable to add dependencies to setup.cfg file.")
+            return None
+
+        with open(self.path, "r", encoding="utf-8") as f:
+            original_lines = f.readlines()
+
+        new_lines = self.build_new_lines(
+            original_lines, defined_dependencies, dependencies
+        )
+        if not new_lines:
+            logger.debug("Unable to add dependencies to setup.cfg file.")
+            return None
+
+        if not dry_run:
+            try:
+                with open(self.path, "w", encoding="utf-8") as f:
+                    f.writelines(new_lines)
+            except Exception:
+                logger.debug("Unable to add dependencies to setup.cfg file.")
+                return None
+
+        diff, added_line_nums = create_diff_and_linenums(original_lines, new_lines)
+
+        changes = self.build_changes(
+            dependencies, added_line_nums_strategy, added_line_nums
+        )
+        return ChangeSet(
+            str(self.path.relative_to(self.parent_directory)),
+            diff,
+            changes=changes,
+        )
+
+    def build_new_lines(
+        self,
+        original_lines: list[str],
+        defined_dependencies: str,
+        dependencies_to_add: list[Dependency],
+    ) -> Optional[list[str]]:
+        """
+        configparser does not retain formatting or comment lines, so we have to build
+        the output newline manually.
+        """
+        clean_lines = list(map(lambda s: s.strip(), original_lines))
+
+        newline_separated = len(defined_dependencies.split("\n")) > 1
+        if newline_separated:
+            last_dep_line = defined_dependencies.split("\n")[-1]
+            dep_sep = "\n"
+        else:
+            # deps are in same line as install_requires key separated by commas
+            last_dep_line = [
+                line for line in clean_lines if line.endswith(defined_dependencies)
+            ][-1]
+            dep_sep = ","
+
+        try:
+            last_dep_idx = clean_lines.index(last_dep_line)
+        except ValueError:
+            # we were unable to find the last req line due to some formatting issue
+            logger.debug("Unable to add dependencies to setup.cfg file.")
+            return None
+
+        if newline_separated:
+            formatting = find_leading_whitespace(original_lines[last_dep_idx])
+            new_deps = [
+                f"{formatting}{dep.requirement}{dep_sep}" for dep in dependencies_to_add
+            ]
+            new_lines = (
+                original_lines[: last_dep_idx + 1]
+                + new_deps
+                + original_lines[last_dep_idx + 1 :]
+            )
+        else:
+            # new_deps added to existing deps line
+            new_dep = ",".join(
+                [f"{dep.requirement}{dep_sep}" for dep in dependencies_to_add]
+            )
+            new_dep_line = f"{original_lines[last_dep_idx].rstrip()}, {new_dep}\n"
+            new_lines = (
+                original_lines[:last_dep_idx]
+                + [new_dep_line]
+                + original_lines[last_dep_idx + 1 :]
+            )
+
+        return new_lines

--- a/src/codemodder/dependency_management/setupcfg_writer.py
+++ b/src/codemodder/dependency_management/setupcfg_writer.py
@@ -15,7 +15,7 @@ def find_leading_whitespace(s):
     match = re.match(r"(\s+)", s)
     if match:
         return match.group(1)
-    return ""
+    return ""  # pragma: no cover
 
 
 def added_line_nums_strategy(lines, i):
@@ -79,7 +79,7 @@ class SetupCfgWriter(DependencyWriter):
         configparser does not retain formatting or comment lines, so we have to build
         the output newline manually.
         """
-        clean_lines = list(map(lambda s: s.strip(), original_lines))
+        clean_lines = [s.strip() for s in original_lines]
 
         newline_separated = len(defined_dependencies.split("\n")) > 1
         if newline_separated:

--- a/src/codemodder/project_analysis/file_parsers/setup_cfg_file_parser.py
+++ b/src/codemodder/project_analysis/file_parsers/setup_cfg_file_parser.py
@@ -20,7 +20,7 @@ class SetupCfgParser(BaseParser):
             config.read(file)
         except configparser.ParsingError:
             logger.debug("Unable to parse setup.cfg file.")
-            return None
+            return None  # pragma: no cover
 
         if "options" not in config:
             return None

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -79,3 +79,25 @@ def pkg_with_reqs_txt_unknown_encoding(tmp_path_factory):
     reqs = "\xf0\x28\x8c\xbc"
     req_file.write_text(reqs)
     return base_dir
+
+
+@pytest.fixture(scope="module")
+def pkg_with_setup_cfg(tmp_path_factory):
+    base_dir = tmp_path_factory.mktemp("foo")
+    req_file = base_dir / "setup.cfg"
+    reqs = """\
+        [metadata]
+        name = my_package
+        version = attr: my_package.VERSION
+
+        # some other stuff
+
+        [options]
+        include_package_data = True
+        python_requires = >=3.7
+        install_requires =
+            requests
+            importlib-metadata; python_version<"3.8"
+    """
+    req_file.write_text(reqs)
+    return base_dir

--- a/tests/dependency_management/test_dependency_manager.py
+++ b/tests/dependency_management/test_dependency_manager.py
@@ -3,7 +3,10 @@ import pytest
 from codemodder.change import ChangeSet
 from codemodder.dependency import DefusedXML, Security
 from codemodder.dependency_management import DependencyManager
-from codemodder.project_analysis.file_parsers import RequirementsTxtParser
+from codemodder.project_analysis.file_parsers import (
+    RequirementsTxtParser,
+    SetupCfgParser,
+)
 from codemodder.project_analysis.file_parsers.package_store import PackageStore
 
 
@@ -33,3 +36,15 @@ class TestDependencyManager:
 
         changeset = dm.write(dependencies)
         assert isinstance(changeset, ChangeSet)
+        assert len(changeset.changes)
+
+    def test_write_for_setup_cfg(self, pkg_with_setup_cfg):
+        parser = SetupCfgParser(pkg_with_setup_cfg)
+        stores = parser.parse()
+        assert len(stores) == 1
+        dm = DependencyManager(stores[0], pkg_with_setup_cfg)
+        dependencies = [DefusedXML, Security]
+
+        changeset = dm.write(dependencies)
+        assert isinstance(changeset, ChangeSet)
+        assert len(changeset.changes)

--- a/tests/dependency_management/test_pyproject_writer.py
+++ b/tests/dependency_management/test_pyproject_writer.py
@@ -169,6 +169,7 @@ def test_dont_add_existing_dependency(tmpdir):
             "libcst~=1.1.0",
             "pylint~=3.0.0",
             "PyYAML~=6.0.0",
+            "security~=1.2.0",
         ]
     """
 

--- a/tests/dependency_management/test_setupcfgt_writer.py
+++ b/tests/dependency_management/test_setupcfgt_writer.py
@@ -1,4 +1,5 @@
 from textwrap import dedent
+import mock
 import pytest
 
 from codemodder.dependency_management.setupcfg_writer import SetupCfgWriter
@@ -219,6 +220,42 @@ def test_cfg_bad_formatting(tmpdir):
         install_requires =
         requests
         importlib-metadata; python_version<"3.8"
+    """
+
+    setup_cfg = tmpdir.join("setup.cfg")
+    setup_cfg.write(dedent(orig_setupcfg))
+
+    store = PackageStore(
+        type=FileType.SETUP_CFG,
+        file=str(setup_cfg),
+        dependencies=set(),
+        py_versions=[">=3.7"],
+    )
+
+    writer = SetupCfgWriter(store, tmpdir)
+    dependencies = [Security, Security]
+    writer.write(dependencies)
+    assert setup_cfg.read() == dedent(orig_setupcfg)
+
+
+@mock.patch(
+    "codemodder.dependency_management.setupcfg_writer.SetupCfgWriter.build_new_lines",
+    return_value=None,
+)
+def test_cfg_cant_build_newlines(_, tmpdir):
+    orig_setupcfg = """\
+        [metadata]
+        name = my_package
+        version = attr: my_package.VERSION
+
+        # some other stuff
+
+        [options]
+        include_package_data = True
+        python_requires = >=3.7
+        install_requires =
+            requests
+            importlib-metadata; python_version<"3.8"
     """
 
     setup_cfg = tmpdir.join("setup.cfg")

--- a/tests/dependency_management/test_setupcfgt_writer.py
+++ b/tests/dependency_management/test_setupcfgt_writer.py
@@ -1,0 +1,302 @@
+from textwrap import dedent
+import pytest
+
+from codemodder.dependency_management.setupcfg_writer import SetupCfgWriter
+from codemodder.dependency import DefusedXML, Security
+from codemodder.project_analysis.file_parsers.package_store import (
+    PackageStore,
+    FileType,
+)
+
+
+@pytest.mark.parametrize("dry_run", [True, False])
+def test_update_dependencies(tmpdir, dry_run):
+    orig_setupcfg = """\
+        [metadata]
+        name = my_package
+        version = attr: my_package.VERSION
+
+        # some other stuff
+
+        [options]
+        include_package_data = True
+        python_requires = >=3.7
+        install_requires =
+            requests
+            importlib-metadata; python_version<"3.8"
+    """
+
+    setup_cfg = tmpdir.join("setup.cfg")
+    setup_cfg.write(dedent(orig_setupcfg))
+
+    store = PackageStore(
+        type=FileType.SETUP_CFG,
+        file=str(setup_cfg),
+        dependencies=set(),
+        py_versions=[">=3.7"],
+    )
+
+    writer = SetupCfgWriter(store, tmpdir)
+    dependencies = [DefusedXML, Security]
+    changeset = writer.write(dependencies, dry_run=dry_run)
+
+    updated_setupcfg = """\
+        [metadata]
+        name = my_package
+        version = attr: my_package.VERSION
+
+        # some other stuff
+
+        [options]
+        include_package_data = True
+        python_requires = >=3.7
+        install_requires =
+            requests
+            importlib-metadata; python_version<"3.8"
+            defusedxml~=0.7.1
+            security~=1.2.0
+    """
+
+    assert setup_cfg.read() == (
+        dedent(orig_setupcfg) if dry_run else dedent(updated_setupcfg)
+    )
+
+    assert changeset is not None
+    assert changeset.path == setup_cfg.basename
+    res = (
+        "--- \n"
+        "+++ \n"
+        "@@ -10,3 +10,5 @@\n"
+        """ install_requires =\n"""
+        """     requests\n"""
+        """     importlib-metadata; python_version<"3.8"\n"""
+        """+    defusedxml~=0.7.1\n"""
+        """+    security~=1.2.0\n"""
+    )
+    assert changeset.diff == res
+    assert len(changeset.changes) == 2
+    change_one = changeset.changes[0]
+
+    assert change_one.lineNumber == 13
+    assert change_one.description == DefusedXML.build_description()
+    assert change_one.properties == {
+        "contextual_description": True,
+        "contextual_description_position": "right",
+    }
+    change_two = changeset.changes[1]
+    assert change_two.lineNumber == 14
+    assert change_two.description == Security.build_description()
+    assert change_two.properties == {
+        "contextual_description": True,
+        "contextual_description_position": "right",
+    }
+
+
+def test_add_same_dependency_only_once(tmpdir):
+    orig_setupcfg = """\
+        [metadata]
+        name = my_package
+        version = attr: my_package.VERSION
+
+        # some other stuff
+
+        [options]
+        include_package_data = True
+        python_requires = >=3.7
+        install_requires =
+            requests
+            importlib-metadata; python_version<"3.8"
+    """
+
+    setup_cfg = tmpdir.join("setup.cfg")
+    setup_cfg.write(dedent(orig_setupcfg))
+
+    store = PackageStore(
+        type=FileType.SETUP_CFG,
+        file=str(setup_cfg),
+        dependencies=set(),
+        py_versions=[">=3.7"],
+    )
+
+    writer = SetupCfgWriter(store, tmpdir)
+    dependencies = [Security, Security]
+    writer.write(dependencies)
+
+    updated_setupcfg = """\
+        [metadata]
+        name = my_package
+        version = attr: my_package.VERSION
+
+        # some other stuff
+
+        [options]
+        include_package_data = True
+        python_requires = >=3.7
+        install_requires =
+            requests
+            importlib-metadata; python_version<"3.8"
+            security~=1.2.0
+    """
+
+    assert setup_cfg.read() == dedent(updated_setupcfg)
+
+
+def test_dont_add_existing_dependency(tmpdir):
+    orig_setupcfg = """\
+        [metadata]
+        name = my_package
+        version = attr: my_package.VERSION
+
+        # some other stuff
+
+        [options]
+        include_package_data = True
+        python_requires = >=3.7
+        install_requires =
+            requests
+            security~=1.2.0
+            importlib-metadata; python_version<"3.8"
+    """
+
+    setup_cfg = tmpdir.join("setup.cfg")
+    setup_cfg.write(dedent(orig_setupcfg))
+
+    store = PackageStore(
+        type=FileType.SETUP_CFG,
+        file=str(setup_cfg),
+        dependencies=set([Security.requirement]),
+        py_versions=[">=3.7"],
+    )
+
+    writer = SetupCfgWriter(store, tmpdir)
+    dependencies = [Security]
+    writer.write(dependencies)
+
+    assert setup_cfg.read() == dedent(orig_setupcfg)
+
+
+def test_no_dependencies(tmpdir):
+    orig_setupcfg = """\
+        [metadata]
+        name = my_package
+        version = attr: my_package.VERSION
+
+        # some other stuff
+
+        [options]
+        include_package_data = True
+        python_requires = >=3.7
+        install_requires =
+    """
+    setup_cfg = tmpdir.join("setup.cfg")
+    setup_cfg.write(dedent(orig_setupcfg))
+
+    store = PackageStore(
+        type=FileType.SETUP_CFG,
+        file=str(setup_cfg),
+        dependencies=set(),
+        py_versions=[">=3.7"],
+    )
+
+    writer = SetupCfgWriter(store, tmpdir)
+    dependencies = [Security]
+    writer.write(dependencies)
+
+    assert setup_cfg.read() == dedent(orig_setupcfg)
+
+
+def test_cfg_bad_formatting(tmpdir):
+    orig_setupcfg = """\
+        [metadata]
+        name = my_package
+        version = attr: my_package.VERSION
+
+        # some other stuff
+
+        [options]
+        include_package_data = True
+        python_requires = >=3.7
+        install_requires =
+        requests
+        importlib-metadata; python_version<"3.8"
+    """
+
+    setup_cfg = tmpdir.join("setup.cfg")
+    setup_cfg.write(dedent(orig_setupcfg))
+
+    store = PackageStore(
+        type=FileType.SETUP_CFG,
+        file=str(setup_cfg),
+        dependencies=set(),
+        py_versions=[">=3.7"],
+    )
+
+    writer = SetupCfgWriter(store, tmpdir)
+    dependencies = [Security, Security]
+    writer.write(dependencies)
+    assert setup_cfg.read() == dedent(orig_setupcfg)
+
+
+def test_cfg_inline_dependencies(tmpdir):
+    orig_setupcfg = """\
+        [metadata]
+        name = my_package
+        version = attr: my_package.VERSION
+
+        # some other stuff
+
+        [options]
+        include_package_data = True
+        python_requires = >=3.7
+        install_requires = requests, importlib-metadata; python_version<"3.8"
+    """
+
+    setup_cfg = tmpdir.join("setup.cfg")
+    setup_cfg.write(dedent(orig_setupcfg))
+
+    store = PackageStore(
+        type=FileType.SETUP_CFG,
+        file=str(setup_cfg),
+        dependencies=set(),
+        py_versions=[">=3.7"],
+    )
+
+    writer = SetupCfgWriter(store, tmpdir)
+    dependencies = [Security, Security]
+    changeset = writer.write(dependencies)
+
+    updated_setupcfg = """\
+        [metadata]
+        name = my_package
+        version = attr: my_package.VERSION
+
+        # some other stuff
+
+        [options]
+        include_package_data = True
+        python_requires = >=3.7
+        install_requires = requests, importlib-metadata; python_version<"3.8", security~=1.2.0,
+    """
+
+    assert setup_cfg.read() == dedent(updated_setupcfg)
+
+    res = (
+        "--- \n"
+        "+++ \n"
+        "@@ -7,4 +7,4 @@\n"
+        """ [options]\n"""
+        """ include_package_data = True\n"""
+        """ python_requires = >=3.7\n"""
+        """-install_requires = requests, importlib-metadata; python_version<"3.8"\n"""
+        """+install_requires = requests, importlib-metadata; python_version<"3.8", security~=1.2.0,\n"""
+    )
+    assert changeset.diff == res
+    assert len(changeset.changes) == 1
+    change_one = changeset.changes[0]
+
+    assert change_one.lineNumber == 10
+    assert change_one.description == Security.build_description()
+    assert change_one.properties == {
+        "contextual_description": True,
+        "contextual_description_position": "right",
+    }


### PR DESCRIPTION
## Overview
*Adds a setup.cfg file writer for new dependencies*

## Description

* This writer relies on `configparser` only to detect the existing dependencies in the setup.cfg file. We can't rely on it to update and write to file because `configparser` doesn't retain some formatting and comment lines.
* I tried some other parsers to see if they could work, but none did. Instead, this is an attempt to manually write the new dependencies to file with some formatting heuristics and as much reasonable error catching as I could think.
