### PR TITLE
codemod to deprecate logging.warn

### DIFF
--- a/integration_tests/test_fix_deprecated_logging_warn.py
+++ b/integration_tests/test_fix_deprecated_logging_warn.py
@@ -1,0 +1,16 @@
+from core_codemods.fix_deprecated_logging_warn import FixDeprecatedLoggingWarn
+from integration_tests.base_test import (
+    BaseIntegrationTest,
+    original_and_expected_from_code_path,
+)
+
+
+class TestFixDeprecatedLoggingWarn(BaseIntegrationTest):
+    codemod = FixDeprecatedLoggingWarn
+    code_path = "tests/samples/fix_deprecated_logging_warn.py"
+    original_code, expected_new_code = original_and_expected_from_code_path(
+        code_path, [(3, 'log.warning("hello")\n')]
+    )
+    expected_diff = '--- \n+++ \n@@ -1,4 +1,4 @@\n import logging\n \n log = logging.getLogger("my logger")\n-log.warn("hello")\n+log.warning("hello")\n'
+    expected_line_change = "4"
+    change_description = FixDeprecatedLoggingWarn.CHANGE_DESCRIPTION

--- a/src/codemodder/scripts/generate_docs.py
+++ b/src/codemodder/scripts/generate_docs.py
@@ -198,6 +198,10 @@ If you want to allow those protocols, change the incoming PR to look more like t
         importance="Low",
         guidance_explained="Simplifying expressions involving `startswith` or `endswith` calls is safe.",
     ),
+    "fix-deprecated-logging-warn": DocMetadata(
+        importance="Low",
+        guidance_explained="This change fixes deprecated uses and is safe.",
+    ),
 }
 
 

--- a/src/core_codemods/__init__.py
+++ b/src/core_codemods/__init__.py
@@ -43,6 +43,7 @@ from .subprocess_shell_false import SubprocessShellFalse
 from .remove_module_global import RemoveModuleGlobal
 from .remove_debug_breakpoint import RemoveDebugBreakpoint
 from .combine_startswith_endswith import CombineStartswithEndswith
+from .fix_deprecated_logging_warn import FixDeprecatedLoggingWarn
 
 registry = CodemodCollection(
     origin="pixee",
@@ -92,5 +93,6 @@ registry = CodemodCollection(
         RemoveModuleGlobal,
         RemoveDebugBreakpoint,
         CombineStartswithEndswith,
+        FixDeprecatedLoggingWarn,
     ],
 )

--- a/src/core_codemods/docs/pixee_python_fix-deprecated-logging-warn.md
+++ b/src/core_codemods/docs/pixee_python_fix-deprecated-logging-warn.md
@@ -1,0 +1,13 @@
+The `warn` method from `logging` has been [deprecated](https://docs.python.org/3/library/logging.html#logging.Logger.warning) since Python 3.3. 
+
+Our changes look like the following:
+```diff
+ import logging
+
+- logging.warn("hello")
++ logging.warning("hello")
+ ...
+ log = logging.getLogger("my logger")
+- log.warn("hello")
++ log.warning("hello") 
+```

--- a/src/core_codemods/docs/pixee_python_fix-deprecated-logging-warn.md
+++ b/src/core_codemods/docs/pixee_python_fix-deprecated-logging-warn.md
@@ -1,4 +1,4 @@
-The `warn` method from `logging` has been [deprecated](https://docs.python.org/3/library/logging.html#logging.Logger.warning) since Python 3.3. 
+The `warn` method from `logging` has been [deprecated](https://docs.python.org/3/library/logging.html#logging.Logger.warning) in favor of `warning` since Python 3.3. Since the old method `warn` has been retained for a long time, there are a lot of developers that are unaware of this change and consequently a lot of code using the older method.
 
 Our changes look like the following:
 ```diff

--- a/src/core_codemods/fix_deprecated_logging_warn.py
+++ b/src/core_codemods/fix_deprecated_logging_warn.py
@@ -1,0 +1,55 @@
+import libcst as cst
+from codemodder.codemods.api import SemgrepCodemod, ReviewGuidance
+from codemodder.codemods.utils_mixin import NameResolutionMixin
+
+
+class FixDeprecatedLoggingWarn(SemgrepCodemod, NameResolutionMixin):
+    NAME = "fix-deprecated-logging-warn"
+    SUMMARY = "Replace Deprecated `logging.warn`"
+    REVIEW_GUIDANCE = ReviewGuidance.MERGE_WITHOUT_REVIEW
+    DESCRIPTION = "Replace deprecated `logging.warn` with `logging.warning`"
+    REFERENCES = [
+        {
+            "url": "https://docs.python.org/3/library/logging.html#logging.Logger.warning",
+            "description": "",
+        },
+    ]
+    _module_name = "logging"
+
+    @classmethod
+    def rule(cls):
+        return """
+        rules:
+            - pattern-either:
+              - patterns:
+                - pattern: logging.warn(...)
+                - pattern-inside: |
+                    import logging
+                    ...
+              - patterns:
+                - pattern: logging.getLogger(...).warn(...)
+                - pattern-inside: |
+                    import logging
+                    ...
+              - patterns:
+                - pattern: $VAR.warn(...)
+                - pattern-inside: |
+                    import logging
+                    ...
+                    $VAR = logging.getLogger(...)
+                    ...
+
+        """
+
+    def on_result_found(self, original_node, updated_node):
+        warning = cst.Name(value="warning")
+        match original_node.func:
+            case cst.Name():
+                self.add_needed_import(self._module_name, "warning")
+                self.remove_unused_import(original_node.func)
+                return updated_node.with_changes(func=warning)
+            case cst.Attribute():
+                return updated_node.with_changes(
+                    func=updated_node.func.with_changes(attr=warning)
+                )
+        return original_node

--- a/tests/samples/fix_deprecated_logging_warn.py
+++ b/tests/samples/fix_deprecated_logging_warn.py
@@ -1,0 +1,4 @@
+import logging
+
+log = logging.getLogger("my logger")
+log.warn("hello")


### PR DESCRIPTION
## Overview
*codemod that will fix `logging.warn` or `{logger}.warn` to `....warning`*

