### PR TITLE
add include/exclude check to codemods that did not have it

### DIFF
--- a/src/core_codemods/combine_startswith_endswith.py
+++ b/src/core_codemods/combine_startswith_endswith.py
@@ -17,7 +17,7 @@ class CombineStartswithEndswith(BaseCodemod, NameResolutionMixin):
         if not self.filter_by_path_includes_or_excludes(
             self.node_position(original_node)
         ):
-            return original_node
+            return updated_node
 
         if self.matches_startswith_endswith_or_pattern(original_node):
             left_call = cst.ensure_type(updated_node.left, cst.Call)

--- a/src/core_codemods/django_receiver_on_top.py
+++ b/src/core_codemods/django_receiver_on_top.py
@@ -23,11 +23,8 @@ class DjangoReceiverOnTop(BaseCodemod, NameResolutionMixin):
     ) -> Union[
         cst.BaseStatement, cst.FlattenSentinel[cst.BaseStatement], cst.RemovalSentinel
     ]:
-        if not self.filter_by_path_includes_or_excludes(
-            self.node_position(original_node)
-        ):
-            return original_node
-
+        # TODO: add filter by include or exclude that works for nodes
+        # that that have different start/end numbers.
         maybe_receiver_with_index = None
         for i, decorator in enumerate(original_node.decorators):
             true_name = self.find_base_name(decorator.decorator)

--- a/src/core_codemods/django_receiver_on_top.py
+++ b/src/core_codemods/django_receiver_on_top.py
@@ -23,6 +23,11 @@ class DjangoReceiverOnTop(BaseCodemod, NameResolutionMixin):
     ) -> Union[
         cst.BaseStatement, cst.FlattenSentinel[cst.BaseStatement], cst.RemovalSentinel
     ]:
+        if not self.filter_by_path_includes_or_excludes(
+            self.node_position(original_node)
+        ):
+            return original_node
+
         maybe_receiver_with_index = None
         for i, decorator in enumerate(original_node.decorators):
             true_name = self.find_base_name(decorator.decorator)

--- a/src/core_codemods/exception_without_raise.py
+++ b/src/core_codemods/exception_without_raise.py
@@ -30,7 +30,7 @@ class ExceptionWithoutRaise(BaseCodemod, NameResolutionMixin):
         if not self.filter_by_path_includes_or_excludes(
             self.node_position(original_node)
         ):
-            return original_node
+            return updated_node
 
         match original_node:
             case cst.SimpleStatementLine(

--- a/src/core_codemods/exception_without_raise.py
+++ b/src/core_codemods/exception_without_raise.py
@@ -27,6 +27,11 @@ class ExceptionWithoutRaise(BaseCodemod, NameResolutionMixin):
     ) -> Union[
         cst.BaseStatement, cst.FlattenSentinel[cst.BaseStatement], cst.RemovalSentinel
     ]:
+        if not self.filter_by_path_includes_or_excludes(
+            self.node_position(original_node)
+        ):
+            return original_node
+
         match original_node:
             case cst.SimpleStatementLine(
                 body=[cst.Expr(cst.Name() | cst.Attribute() as name)]

--- a/src/core_codemods/fix_deprecated_abstractproperty.py
+++ b/src/core_codemods/fix_deprecated_abstractproperty.py
@@ -22,7 +22,7 @@ class FixDeprecatedAbstractproperty(BaseCodemod, NameResolutionMixin):
         if not self.filter_by_path_includes_or_excludes(
             self.node_position(original_node)
         ):
-            return original_node
+            return updated_node
 
         if (
             base_name := self.find_base_name(original_node.decorator)

--- a/src/core_codemods/fix_deprecated_abstractproperty.py
+++ b/src/core_codemods/fix_deprecated_abstractproperty.py
@@ -19,6 +19,11 @@ class FixDeprecatedAbstractproperty(BaseCodemod, NameResolutionMixin):
     def leave_Decorator(
         self, original_node: cst.Decorator, updated_node: cst.Decorator
     ):
+        if not self.filter_by_path_includes_or_excludes(
+            self.node_position(original_node)
+        ):
+            return original_node
+
         if (
             base_name := self.find_base_name(original_node.decorator)
         ) and base_name == "abc.abstractproperty":

--- a/src/core_codemods/fix_mutable_params.py
+++ b/src/core_codemods/fix_mutable_params.py
@@ -154,10 +154,8 @@ class FixMutableParams(BaseCodemod):
         updated_node: cst.FunctionDef,
     ):
         """Transforms function definitions with mutable default parameters"""
-        if not self.filter_by_path_includes_or_excludes(
-            self.node_position(original_node)
-        ):
-            return original_node
+        # TODO: add filter by include or exclude that works for nodes
+        # that that have different start/end numbers.
         (
             updated_params,
             new_var_decls,

--- a/src/core_codemods/fix_mutable_params.py
+++ b/src/core_codemods/fix_mutable_params.py
@@ -154,6 +154,10 @@ class FixMutableParams(BaseCodemod):
         updated_node: cst.FunctionDef,
     ):
         """Transforms function definitions with mutable default parameters"""
+        if not self.filter_by_path_includes_or_excludes(
+            self.node_position(original_node)
+        ):
+            return original_node
         (
             updated_params,
             new_var_decls,

--- a/src/core_codemods/https_connection.py
+++ b/src/core_codemods/https_connection.py
@@ -24,7 +24,12 @@ class HTTPSConnectionModifier(ImportedCallModifier[Set[str]]):
         return new_args
 
     def update_attribute(self, true_name, original_node, updated_node, new_args):
-        del true_name, original_node
+        del true_name
+        if not self.filter_by_path_includes_or_excludes(
+            self.node_position(original_node)
+        ):
+            return original_node
+
         return updated_node.with_changes(
             args=new_args,
             func=updated_node.func.with_changes(
@@ -34,6 +39,11 @@ class HTTPSConnectionModifier(ImportedCallModifier[Set[str]]):
 
     def update_simple_name(self, true_name, original_node, updated_node, new_args):
         del true_name
+        if not self.filter_by_path_includes_or_excludes(
+            self.node_position(original_node)
+        ):
+            return original_node
+
         AddImportsVisitor.add_needed_import(self.context, "urllib3")
         RemoveImportsVisitor.remove_unused_import_by_node(self.context, original_node)
         return updated_node.with_changes(

--- a/src/core_codemods/https_connection.py
+++ b/src/core_codemods/https_connection.py
@@ -24,12 +24,7 @@ class HTTPSConnectionModifier(ImportedCallModifier[Set[str]]):
         return new_args
 
     def update_attribute(self, true_name, original_node, updated_node, new_args):
-        del true_name
-        if not self.filter_by_path_includes_or_excludes(
-            self.node_position(original_node)
-        ):
-            return original_node
-
+        del true_name, original_node
         return updated_node.with_changes(
             args=new_args,
             func=updated_node.func.with_changes(
@@ -39,11 +34,6 @@ class HTTPSConnectionModifier(ImportedCallModifier[Set[str]]):
 
     def update_simple_name(self, true_name, original_node, updated_node, new_args):
         del true_name
-        if not self.filter_by_path_includes_or_excludes(
-            self.node_position(original_node)
-        ):
-            return original_node
-
         AddImportsVisitor.add_needed_import(self.context, "urllib3")
         RemoveImportsVisitor.remove_unused_import_by_node(self.context, original_node)
         return updated_node.with_changes(

--- a/src/core_codemods/remove_debug_breakpoint.py
+++ b/src/core_codemods/remove_debug_breakpoint.py
@@ -12,12 +12,14 @@ class RemoveDebugBreakpoint(BaseCodemod, NameResolutionMixin, AncestorPatternsMi
     REFERENCES: list = []
 
     def leave_Expr(
-        self, original_node: cst.Expr, _
+        self,
+        original_node: cst.Expr,
+        updated_node: cst.Expr,
     ) -> Union[cst.Expr, cst.RemovalSentinel]:
         if not self.filter_by_path_includes_or_excludes(
             self.node_position(original_node)
         ):
-            return original_node
+            return updated_node
 
         match call_node := original_node.value:
             case cst.Call():
@@ -29,4 +31,4 @@ class RemoveDebugBreakpoint(BaseCodemod, NameResolutionMixin, AncestorPatternsMi
                     self.report_change(original_node)
                     return cst.RemovalSentinel.REMOVE
 
-        return original_node
+        return updated_node

--- a/src/core_codemods/remove_module_global.py
+++ b/src/core_codemods/remove_module_global.py
@@ -13,12 +13,14 @@ class RemoveModuleGlobal(BaseCodemod, NameResolutionMixin):
     REFERENCES: list = []
 
     def leave_Global(
-        self, original_node: cst.Global, _
+        self,
+        original_node: cst.Global,
+        updated_node: cst.Global,
     ) -> Union[cst.Global, cst.RemovalSentinel,]:
         if not self.filter_by_path_includes_or_excludes(
             self.node_position(original_node)
         ):
-            return original_node
+            return updated_node
         scope = self.get_metadata(ScopeProvider, original_node)
         if isinstance(scope, GlobalScope):
             self.report_change(original_node)

--- a/src/core_codemods/remove_unnecessary_f_str.py
+++ b/src/core_codemods/remove_unnecessary_f_str.py
@@ -35,6 +35,11 @@ class RemoveUnnecessaryFStr(BaseCodemod, UnnecessaryFormatString):
         updated_node: cst.FormattedString,
     ):
         transformed_node = super()._check_formatted_string(_original_node, updated_node)
+        if not self.filter_by_path_includes_or_excludes(
+            self.node_position(transformed_node)
+        ):
+            return transformed_node
+
         if not _original_node.deep_equals(transformed_node):
             self.report_change(_original_node)
         return transformed_node

--- a/src/core_codemods/remove_unnecessary_f_str.py
+++ b/src/core_codemods/remove_unnecessary_f_str.py
@@ -34,12 +34,12 @@ class RemoveUnnecessaryFStr(BaseCodemod, UnnecessaryFormatString):
         _original_node: cst.FormattedString,
         updated_node: cst.FormattedString,
     ):
-        transformed_node = super()._check_formatted_string(_original_node, updated_node)
         if not self.filter_by_path_includes_or_excludes(
-            self.node_position(transformed_node)
+            self.node_position(_original_node)
         ):
-            return transformed_node
+            return _original_node
 
+        transformed_node = super()._check_formatted_string(_original_node, updated_node)
         if not _original_node.deep_equals(transformed_node):
             self.report_change(_original_node)
         return transformed_node

--- a/src/core_codemods/remove_unnecessary_f_str.py
+++ b/src/core_codemods/remove_unnecessary_f_str.py
@@ -37,7 +37,7 @@ class RemoveUnnecessaryFStr(BaseCodemod, UnnecessaryFormatString):
         if not self.filter_by_path_includes_or_excludes(
             self.node_position(_original_node)
         ):
-            return _original_node
+            return updated_node
 
         transformed_node = super()._check_formatted_string(_original_node, updated_node)
         if not _original_node.deep_equals(transformed_node):

--- a/src/core_codemods/subprocess_shell_false.py
+++ b/src/core_codemods/subprocess_shell_false.py
@@ -33,7 +33,7 @@ class SubprocessShellFalse(BaseCodemod, NameResolutionMixin):
         if not self.filter_by_path_includes_or_excludes(
             self.node_position(original_node)
         ):
-            return original_node
+            return updated_node
 
         if self.find_base_name(original_node.func) in self.SUBPROCESS_FUNCS:
             for arg in original_node.args:

--- a/src/core_codemods/use_generator.py
+++ b/src/core_codemods/use_generator.py
@@ -25,6 +25,11 @@ class UseGenerator(BaseCodemod, NameResolutionMixin):
     ]
 
     def leave_Call(self, original_node: cst.Call, updated_node: cst.Call):
+        if not self.filter_by_path_includes_or_excludes(
+            self.node_position(original_node)
+        ):
+            return original_node
+
         match original_node.func:
             # NOTE: could also support things like `list` and `tuple`
             # but it's a less compelling use case

--- a/src/core_codemods/use_generator.py
+++ b/src/core_codemods/use_generator.py
@@ -28,7 +28,7 @@ class UseGenerator(BaseCodemod, NameResolutionMixin):
         if not self.filter_by_path_includes_or_excludes(
             self.node_position(original_node)
         ):
-            return original_node
+            return updated_node
 
         match original_node.func:
             # NOTE: could also support things like `list` and `tuple`

--- a/src/core_codemods/use_walrus_if.py
+++ b/src/core_codemods/use_walrus_if.py
@@ -118,11 +118,8 @@ class UseWalrusIf(BaseCodemod):
         )
 
     def leave_If(self, original_node, updated_node):
-        if not self.filter_by_path_includes_or_excludes(
-            self.node_position(original_node)
-        ):
-            return original_node
-
+        # TODO: add filter by include or exclude that works for nodes
+        # that that have different start/end numbers.
         if (result := self._if_stack.pop()) is not None:
             position, named_expr = result
             is_name = m.matches(updated_node.test, m.Name())

--- a/src/core_codemods/use_walrus_if.py
+++ b/src/core_codemods/use_walrus_if.py
@@ -139,11 +139,6 @@ class UseWalrusIf(BaseCodemod):
 
     def leave_Assign(self, original_node: cst.Assign, updated_node: cst.Assign):
         del updated_node
-        if not self.filter_by_path_includes_or_excludes(
-            self.node_position(original_node)
-        ):
-            return original_node
-
         if named_expr := self.assigns.get(original_node):
             position = self.node_position(original_node)
             self._modify_next_if.append((position, named_expr))
@@ -157,11 +152,6 @@ class UseWalrusIf(BaseCodemod):
 
         This feels like a bug in libCST but we'll work around it for now.
         """
-        if not self.filter_by_path_includes_or_excludes(
-            self.node_position(original_node)
-        ):
-            return original_node
-
         if not updated_node.body:
             trailing_whitespace = (
                 (

--- a/src/core_codemods/use_walrus_if.py
+++ b/src/core_codemods/use_walrus_if.py
@@ -118,6 +118,11 @@ class UseWalrusIf(BaseCodemod):
         )
 
     def leave_If(self, original_node, updated_node):
+        if not self.filter_by_path_includes_or_excludes(
+            self.node_position(original_node)
+        ):
+            return original_node
+
         if (result := self._if_stack.pop()) is not None:
             position, named_expr = result
             is_name = m.matches(updated_node.test, m.Name())
@@ -134,6 +139,11 @@ class UseWalrusIf(BaseCodemod):
 
     def leave_Assign(self, original_node: cst.Assign, updated_node: cst.Assign):
         del updated_node
+        if not self.filter_by_path_includes_or_excludes(
+            self.node_position(original_node)
+        ):
+            return original_node
+
         if named_expr := self.assigns.get(original_node):
             position = self.node_position(original_node)
             self._modify_next_if.append((position, named_expr))
@@ -147,6 +157,11 @@ class UseWalrusIf(BaseCodemod):
 
         This feels like a bug in libCST but we'll work around it for now.
         """
+        if not self.filter_by_path_includes_or_excludes(
+            self.node_position(original_node)
+        ):
+            return original_node
+
         if not updated_node.body:
             trailing_whitespace = (
                 (

--- a/tests/codemods/test_combine_startswith_endswith.py
+++ b/tests/codemods/test_combine_startswith_endswith.py
@@ -38,3 +38,13 @@ class TestCombineStartswithEndswith(BaseCodemodTest):
     def test_no_change(self, tmpdir, code):
         self.run_and_assert(tmpdir, code, code)
         assert len(self.file_context.codemod_changes) == 0
+
+    def test_exclude_line(self, tmpdir):
+        input_code = expected = """\
+        x = "foo"
+        x.startswith("foo") or x.startswith("f")
+        """
+        lines_to_exclude = [2]
+        self.assert_no_change_line_excluded(
+            tmpdir, input_code, expected, lines_to_exclude
+        )

--- a/tests/codemods/test_exception_without_raise.py
+++ b/tests/codemods/test_exception_without_raise.py
@@ -54,3 +54,13 @@ class TestExceptionWithoutRaise(BaseCodemodTest):
         """
         self.run_and_assert(tmpdir, dedent(input_code), dedent(input_code))
         assert len(self.file_context.codemod_changes) == 0
+
+    def test_exclude_line(self, tmpdir):
+        input_code = expected = """\
+        print(1)
+        ValueError("Bad value!")
+        """
+        lines_to_exclude = [2]
+        self.assert_no_change_line_excluded(
+            tmpdir, input_code, expected, lines_to_exclude
+        )

--- a/tests/codemods/test_fix_deprecated_abstractproperty.py
+++ b/tests/codemods/test_fix_deprecated_abstractproperty.py
@@ -121,3 +121,17 @@ class TestFixDeprecatedAbstractproperty(BaseCodemodTest):
                 pass
         """
         self.run_and_assert(tmpdir, original_code, new_code)
+
+    def test_exclude_line(self, tmpdir):
+        input_code = expected = """\
+        import abc
+
+        class A:
+            @abc.abstractproperty
+            def foo(self):
+                pass
+        """
+        lines_to_exclude = [4]
+        self.assert_no_change_line_excluded(
+            tmpdir, input_code, expected, lines_to_exclude
+        )

--- a/tests/codemods/test_remove_debug_breakpoint.py
+++ b/tests/codemods/test_remove_debug_breakpoint.py
@@ -85,3 +85,13 @@ class TestRemoveDebugBreakpoint(BaseCodemodTest):
         """
         self.run_and_assert(tmpdir, input_code, expected)
         assert len(self.file_context.codemod_changes) == 1
+
+    def test_exclude_line(self, tmpdir):
+        input_code = expected = """\
+        x = "foo"
+        breakpoint()
+        """
+        lines_to_exclude = [2]
+        self.assert_no_change_line_excluded(
+            tmpdir, input_code, expected, lines_to_exclude
+        )

--- a/tests/codemods/test_remove_unnecessary_f_str.py
+++ b/tests/codemods/test_remove_unnecessary_f_str.py
@@ -32,3 +32,12 @@ bad: str = r'bad\d+'
 """
         self.run_and_assert(tmpdir, before, after)
         assert len(self.file_context.codemod_changes) == 3
+
+    def test_exclude_line(self, tmpdir):
+        input_code = expected = """\
+        bad: str = f"bad" + "bad"
+        """
+        lines_to_exclude = [1]
+        self.assert_no_change_line_excluded(
+            tmpdir, input_code, expected, lines_to_exclude
+        )

--- a/tests/codemods/test_subprocess_shell_false.py
+++ b/tests/codemods/test_subprocess_shell_false.py
@@ -56,3 +56,13 @@ class TestSubprocessShellFalse(BaseCodemodTest):
         """
         self.run_and_assert(tmpdir, input_code, input_code)
         assert len(self.file_context.codemod_changes) == 0
+
+    def test_exclude_line(self, tmpdir):
+        input_code = expected = """\
+        import subprocess
+        subprocess.run(args, shell=True)
+        """
+        lines_to_exclude = [2]
+        self.assert_no_change_line_excluded(
+            tmpdir, input_code, expected, lines_to_exclude
+        )

--- a/tests/codemods/test_use_generator.py
+++ b/tests/codemods/test_use_generator.py
@@ -29,3 +29,12 @@ class TestUseGenerator(BaseCodemodTest):
         x = any([i for i in range(10)])
         """
         self.run_and_assert(tmpdir, original_code, expected)
+
+    def test_exclude_line(self, tmpdir):
+        input_code = expected = """\
+        x = any([i for i in range(10)])
+        """
+        lines_to_exclude = [1]
+        self.assert_no_change_line_excluded(
+            tmpdir, input_code, expected, lines_to_exclude
+        )


### PR DESCRIPTION
## Overview
* some non-semgrep codemods missed the include/exclude check*

## Description
* Right now any codemod that inherits directly from BaseCodemod is susceptible to being implemented without this check because the API doesn't enforce it. 
* It's hard right now to enforce adding this check because a codemod could implement any arbitrary number of `leave_Node` methods
* I tried for a reasonable amount of time to add a pytest check to alert us if we wrote a codemod that did not pass thru `filter_by_path_includes_or_excludes`, but this is harder than it looks. I was hoping to add it to the existing BaseTest class so any new codemods would benefit from it. I have some basic code that doesn't work very well, so maybe I can iterate on it later on.
