### PR TITLE
Prepend builtins base name

### DIFF
--- a/src/codemodder/codemods/utils_mixin.py
+++ b/src/codemodder/codemods/utils_mixin.py
@@ -35,6 +35,9 @@ class NameResolutionMixin(MetadataDependent):
                         alias.evaluated_name,
                     ):
                         return self.base_name_for_import(import_node, alias)
+            case BuiltinAssignment():
+                return "builtins." + node.value
+
         return node.value
 
     def find_base_name(self, node):

--- a/src/codemodder/utils/utils.py
+++ b/src/codemodder/utils/utils.py
@@ -14,8 +14,6 @@ def list_subclasses(base_kls) -> set[str]:
 
 
 def full_qualified_name_from_class(cls) -> str:
-    if cls.__module__ == "builtins":
-        return cls.__qualname__
     return f"{cls.__module__}.{cls.__qualname__}"
 
 

--- a/src/core_codemods/remove_debug_breakpoint.py
+++ b/src/core_codemods/remove_debug_breakpoint.py
@@ -21,9 +21,7 @@ class RemoveDebugBreakpoint(BaseCodemod, NameResolutionMixin, AncestorPatternsMi
 
         match call_node := original_node.value:
             case cst.Call():
-                if self.find_base_name(
-                    call_node
-                ) == "breakpoint" and self.is_builtin_function(call_node):
+                if self.find_base_name(call_node) == "builtins.breakpoint":
                     self.report_change(original_node)
                     return cst.RemovalSentinel.REMOVE
                 if self.find_base_name(call_node) == "pdb.set_trace":

--- a/tests/test_nameresolution_mixin.py
+++ b/tests/test_nameresolution_mixin.py
@@ -92,12 +92,12 @@ class TestNameResolutionMixin:
                 node = expr.value
 
                 maybe_name = self.find_base_name(node.func)
-                assert maybe_name == "exec.capitalize"
+                assert maybe_name == "builtins.print"
                 return tree
 
         input_code = dedent(
             """\
-        exec.capitalize()
+        print('hello world')
         """
         )
         tree = cst.parse_module(input_code)

--- a/tests/test_nameresolution_mixin.py
+++ b/tests/test_nameresolution_mixin.py
@@ -84,7 +84,26 @@ class TestNameResolutionMixin:
         tree = cst.parse_module(input_code)
         TestCodemod(CodemodContext()).transform_module(tree)
 
-    def test_get_base_name_no_import(self):
+    def test_get_base_name_no_assignment(self):
+        class TestCodemod(Codemod, NameResolutionMixin):
+            def transform_module_impl(self, tree: cst.Module) -> cst.Module:
+                stmt = cst.ensure_type(tree.body[-1], cst.SimpleStatementLine)
+                expr = cst.ensure_type(stmt.body[0], cst.Expr)
+                node = expr.value
+
+                maybe_name = self.find_base_name(node.func)
+                assert maybe_name == "foo"
+                return tree
+
+        input_code = dedent(
+            """\
+        foo('hello world')
+        """
+        )
+        tree = cst.parse_module(input_code)
+        TestCodemod(CodemodContext()).transform_module(tree)
+
+    def test_get_base_name_built_in(self):
         class TestCodemod(Codemod, NameResolutionMixin):
             def transform_module_impl(self, tree: cst.Module) -> cst.Module:
                 stmt = cst.ensure_type(tree.body[-1], cst.SimpleStatementLine)


### PR DESCRIPTION
## Overview
find_base_name will now prepend builtins for builtin names.
~~A caveat of this change is that `libcst` considers any name that is not imported or originates in the module as builtin. This means that in:~~
```python
foo()
```
~~`foo` is considered builtin.~~
Disregard this caveat, it's actually working correctly. I assume that it was behaving like this because of a test case I had to change.
