### PR TITLE
Codemod: remove-assertion-in-pytest-raises

### DIFF
--- a/integration_tests/test_remove_assertion_in_pytest_raises.py
+++ b/integration_tests/test_remove_assertion_in_pytest_raises.py
@@ -34,7 +34,7 @@ class TestRemoveAssertionInPytestRaises(BaseIntegrationTest):
     )
     # fmt: on
 
-    expected_line_change = "7"
+    expected_line_change = "4"
     change_description = RemoveAssertionInPytestRaisesTransformer.change_description
     num_changed_files = 1
-    num_changes = 2
+    num_changes = 1

--- a/integration_tests/test_remove_assertion_in_pytest_raises.py
+++ b/integration_tests/test_remove_assertion_in_pytest_raises.py
@@ -1,0 +1,40 @@
+from core_codemods.remove_assertion_in_pytest_raises import (
+    RemoveAssertionInPytestRaises,
+    RemoveAssertionInPytestRaisesTransformer,
+)
+from integration_tests.base_test import (
+    BaseIntegrationTest,
+    original_and_expected_from_code_path,
+)
+
+
+class TestRemoveAssertionInPytestRaises(BaseIntegrationTest):
+    codemod = RemoveAssertionInPytestRaises
+    code_path = "tests/samples/remove_assertion_in_pytest_raises.py"
+    original_code, expected_new_code = original_and_expected_from_code_path(
+        code_path,
+        [
+            (5, """    assert 1\n"""),
+            (6, """    assert 2\n"""),
+        ],
+    )
+
+    # fmt: off
+    expected_diff =(
+    """--- \n"""
+    """+++ \n"""
+    """@@ -3,5 +3,5 @@\n"""
+    """ def test_foo():\n"""
+    """     with pytest.raises(ZeroDivisionError):\n"""
+    """         error = 1/0\n"""
+    """-        assert 1\n"""
+    """-        assert 2\n"""
+    """+    assert 1\n"""
+    """+    assert 2\n"""
+    )
+    # fmt: on
+
+    expected_line_change = "7"
+    change_description = RemoveAssertionInPytestRaisesTransformer.change_description
+    num_changed_files = 1
+    num_changes = 4

--- a/integration_tests/test_remove_assertion_in_pytest_raises.py
+++ b/integration_tests/test_remove_assertion_in_pytest_raises.py
@@ -37,4 +37,4 @@ class TestRemoveAssertionInPytestRaises(BaseIntegrationTest):
     expected_line_change = "7"
     change_description = RemoveAssertionInPytestRaisesTransformer.change_description
     num_changed_files = 1
-    num_changes = 4
+    num_changes = 2

--- a/src/codemodder/scripts/generate_docs.py
+++ b/src/codemodder/scripts/generate_docs.py
@@ -214,6 +214,10 @@ If you want to allow those protocols, change the incoming PR to look more like t
         importance="Low",
         guidance_explained="Values compared to empty sequences should be verified in case they are falsy values that are not a sequence.",
     ),
+    "remove-assertion-in-pytest-raises": DocMetadata(
+        importance="Low",
+        guidance_explained="We believe this change is safe and will not cause any issues.",
+    ),
 }
 
 

--- a/src/core_codemods/__init__.py
+++ b/src/core_codemods/__init__.py
@@ -47,6 +47,7 @@ from .fix_deprecated_logging_warn import FixDeprecatedLoggingWarn
 from .flask_enable_csrf_protection import FlaskEnableCSRFProtection
 from .replace_flask_send_file import ReplaceFlaskSendFile
 from .fix_empty_sequence_comparison import FixEmptySequenceComparison
+from .remove_assertion_in_pytest_raises import RemoveAssertionInPytestRaises
 
 registry = CodemodCollection(
     origin="pixee",
@@ -100,5 +101,6 @@ registry = CodemodCollection(
         FlaskEnableCSRFProtection,
         ReplaceFlaskSendFile,
         FixEmptySequenceComparison,
+        RemoveAssertionInPytestRaises,
     ],
 )

--- a/src/core_codemods/docs/pixee_python_remove-assertion-in-pytest-raises.md
+++ b/src/core_codemods/docs/pixee_python_remove-assertion-in-pytest-raises.md
@@ -1,0 +1,15 @@
+The context manager object `pytest.raises(<exception>)` will assert if the code contained within its scope will raise an exception of type `<exception>`. The documentation points that the exception must be raised in the last line of its scope and any line afterwards won't be executed. 
+Including asserts at the end of the scope is a common error. This codemod addresses that by moving them out of the scope.
+Our changes look something like this:
+
+```diff
+import pytest
+
+def test_foo():
+    with pytest.raises(ZeroDivisionError):
+        error = 1/0
+-       assert 1
+-       assert 2
++   assert 1
++   assert 2
+```

--- a/src/core_codemods/remove_assertion_in_pytest_raises.py
+++ b/src/core_codemods/remove_assertion_in_pytest_raises.py
@@ -91,10 +91,8 @@ class RemoveAssertionInPytestRaisesTransformer(
     ) -> Union[
         cst.BaseStatement, cst.FlattenSentinel[cst.BaseStatement], cst.RemovalSentinel
     ]:
-        if not self.filter_by_path_includes_or_excludes(
-            self.node_position(original_node)
-        ):
-            return updated_node
+        # TODO: add filter by include or exclude that works for nodes
+        # that that have different start/end numbers.
 
         # Are all items pytest.raises?
         if not self._all_pytest_raises(original_node):

--- a/src/core_codemods/remove_assertion_in_pytest_raises.py
+++ b/src/core_codemods/remove_assertion_in_pytest_raises.py
@@ -1,0 +1,110 @@
+from typing import Union
+import libcst as cst
+from codemodder.codemods.base_codemod import Metadata, Reference, ReviewGuidance
+from codemodder.codemods.libcst_transformer import (
+    LibcstResultTransformer,
+    LibcstTransformerPipeline,
+)
+from codemodder.codemods.utils_mixin import NameResolutionMixin
+from core_codemods.api.core_codemod import CoreCodemod
+
+
+class RemoveAssertionInPytestRaisesTransformer(
+    LibcstResultTransformer, NameResolutionMixin
+):
+    change_description = "Moved assertion out of with statement body"
+
+    def leave_With(
+        self, original_node: cst.With, updated_node: cst.With
+    ) -> Union[
+        cst.BaseStatement, cst.FlattenSentinel[cst.BaseStatement], cst.RemovalSentinel
+    ]:
+        if not self.filter_by_path_includes_or_excludes(original_node):
+            return updated_node
+
+        # Are all items pytest.raises?
+        for item in original_node.items:
+            match item:
+                case cst.WithItem(item=cst.Call() as call):
+                    maybe_call_base_name = self.find_base_name(call)
+                    if (
+                        not maybe_call_base_name
+                        or maybe_call_base_name != "pytest.raises"
+                    ):
+                        return updated_node
+
+                case _:
+                    return updated_node
+
+        assert_stmts: list[cst.SimpleStatementLine] = []
+        assert_position = len(original_node.body.body)
+        new_statement_before_asserts = None
+        match original_node.body:
+            case cst.SimpleStatementSuite():
+                for stmt in reversed(original_node.body.body):
+                    match stmt:
+                        case cst.Assert():
+                            assert_position = assert_position - 1
+                            assert_stmts.append(
+                                cst.SimpleStatementLine(
+                                    body=[
+                                        stmt.with_changes(
+                                            semicolon=cst.MaybeSentinel.DEFAULT
+                                        )
+                                    ]
+                                )
+                            )
+                            self.report_change(stmt)
+                        case _:
+                            break
+                new_statement_before_asserts = original_node.body.body[
+                    assert_position - 1
+                ].with_changes(semicolon=cst.MaybeSentinel.DEFAULT)
+
+            case cst.IndentedBlock():
+                for simple_stmt in reversed(original_node.body.body):
+                    match simple_stmt:
+                        case cst.SimpleStatementLine(body=[*head, cst.Assert() as ast]):
+                            assert_position = assert_position - 1
+                            self.report_change(ast)
+                            if head:
+                                # TODO foo(); assert 1; assert 2
+                                pass
+                            else:
+                                assert_stmts.append(simple_stmt)
+                        case _:
+                            break
+                new_statement_before_asserts = original_node.body.body[
+                    assert_position - 1
+                ]
+
+        if assert_stmts:
+            assert_stmts.reverse()
+            new_with = updated_node.with_changes(
+                body=updated_node.body.with_changes(
+                    body=[
+                        *updated_node.body.body[: assert_position - 1],
+                        new_statement_before_asserts,
+                    ]
+                )
+            )
+            return cst.FlattenSentinel([new_with, *assert_stmts])
+
+        return updated_node
+
+
+RemoveAssertionInPytestRaises = CoreCodemod(
+    metadata=Metadata(
+        name="remove-assertion-in-pytest-raises",
+        summary="Moves assertions out of with statement body",
+        review_guidance=ReviewGuidance.MERGE_WITHOUT_REVIEW,
+        references=[
+            Reference(
+                url="https://docs.pytest.org/en/7.4.x/reference/reference.html#pytest-raises",
+                description="",
+            ),
+        ],
+    ),
+    transformer=LibcstTransformerPipeline(RemoveAssertionInPytestRaisesTransformer),
+    detector=None,
+)

--- a/tests/codemods/test_remove_assertion_in_pytest_raises.py
+++ b/tests/codemods/test_remove_assertion_in_pytest_raises.py
@@ -27,6 +27,23 @@ class TestRemoveAssertionInPytestRaises(BaseCodemodTest):
         """
         self.run_and_assert(tmpdir, input_code, expected)
 
+    def test_all_asserts(self, tmpdir):
+        # this is more of an edge case
+        input_code = """\
+        import pytest
+        def foo():
+            with pytest.raises(ZeroDivisionError):
+                assert True
+        """
+        expected = """\
+        import pytest
+        def foo():
+            with pytest.raises(ZeroDivisionError):
+                pass
+            assert True
+        """
+        self.run_and_assert(tmpdir, input_code, expected)
+
     def test_multiple_raises(self, tmpdir):
         input_code = """\
         import pytest
@@ -54,6 +71,41 @@ class TestRemoveAssertionInPytestRaises(BaseCodemodTest):
                 1/0
                 assert 1
                 assert 2
+        """
+        expected = """\
+        import pytest
+        def foo():
+            with pytest.raises(ZeroDivisionError):
+                1/0
+            assert 1
+            assert 2
+        """
+        self.run_and_assert(tmpdir, input_code, expected, num_changes=2)
+
+    def test_multiple_asserts_mixed_early(self, tmpdir):
+        input_code = """\
+        import pytest
+        def foo():
+            with pytest.raises(ZeroDivisionError):
+                1/0; assert 1; assert 2
+        """
+        expected = """\
+        import pytest
+        def foo():
+            with pytest.raises(ZeroDivisionError):
+                1/0
+            assert 1
+            assert 2
+        """
+        self.run_and_assert(tmpdir, input_code, expected, num_changes=2)
+
+    def test_multiple_asserts_mixed(self, tmpdir):
+        input_code = """\
+        import pytest
+        def foo():
+            with pytest.raises(ZeroDivisionError):
+                1/0
+                assert 1; assert 2
         """
         expected = """\
         import pytest

--- a/tests/codemods/test_remove_assertion_in_pytest_raises.py
+++ b/tests/codemods/test_remove_assertion_in_pytest_raises.py
@@ -1,0 +1,105 @@
+from core_codemods.remove_assertion_in_pytest_raises import (
+    RemoveAssertionInPytestRaises,
+)
+from tests.codemods.base_codemod_test import BaseCodemodTest
+
+
+class TestRemoveAssertionInPytestRaises(BaseCodemodTest):
+    codemod = RemoveAssertionInPytestRaises
+
+    def test_name(self):
+        assert self.codemod.name == "remove-assertion-in-pytest-raises"
+
+    def test_simple(self, tmpdir):
+        input_code = """\
+        import pytest
+        def foo():
+            with pytest.raises(ZeroDivisionError):
+                1/0
+                assert True
+        """
+        expected = """\
+        import pytest
+        def foo():
+            with pytest.raises(ZeroDivisionError):
+                1/0
+            assert True
+        """
+        self.run_and_assert(tmpdir, input_code, expected)
+
+    def test_multiple_raises(self, tmpdir):
+        input_code = """\
+        import pytest
+        def foo():
+            with pytest.raises(ZeroDivisionError), pytest.raises(IndexError):
+                1/0
+                [1,2][3]
+                assert True
+        """
+        expected = """\
+        import pytest
+        def foo():
+            with pytest.raises(ZeroDivisionError), pytest.raises(IndexError):
+                1/0
+                [1,2][3]
+            assert True
+        """
+        self.run_and_assert(tmpdir, input_code, expected)
+
+    def test_multiple_asserts(self, tmpdir):
+        input_code = """\
+        import pytest
+        def foo():
+            with pytest.raises(ZeroDivisionError):
+                1/0
+                assert 1
+                assert 2
+        """
+        expected = """\
+        import pytest
+        def foo():
+            with pytest.raises(ZeroDivisionError):
+                1/0
+            assert 1
+            assert 2
+        """
+        self.run_and_assert(tmpdir, input_code, expected, num_changes=2)
+
+    def test_simple_suite(self, tmpdir):
+        input_code = """\
+        import pytest
+        def foo():
+            with pytest.raises(ZeroDivisionError): 1/0; assert True
+        """
+        expected = """\
+        import pytest
+        def foo():
+            with pytest.raises(ZeroDivisionError): 1/0
+            assert True
+        """
+        self.run_and_assert(tmpdir, input_code, expected)
+
+    def test_multiple_suite(self, tmpdir):
+        input_code = """\
+        import pytest
+        def foo():
+            with pytest.raises(ZeroDivisionError): 1/0; assert True; assert False;
+        """
+        expected = """\
+        import pytest
+        def foo():
+            with pytest.raises(ZeroDivisionError): 1/0
+            assert True
+            assert False
+        """
+        self.run_and_assert(tmpdir, input_code, expected, num_changes=2)
+
+    def test_with_item_not_raises(self, tmpdir):
+        input_code = """\
+        import pytest
+        def foo():
+            with pytest.raises(ZeroDivisionError), open('') as file:
+                1/0
+                assert True
+        """
+        self.run_and_assert(tmpdir, input_code, input_code)

--- a/tests/codemods/test_remove_assertion_in_pytest_raises.py
+++ b/tests/codemods/test_remove_assertion_in_pytest_raises.py
@@ -199,19 +199,3 @@ class TestRemoveAssertionInPytestRaises(BaseCodemodTest):
                 1/0
         """
         self.run_and_assert(tmpdir, input_code, input_code)
-
-    def test_exclude_line(self, tmpdir):
-        input_code = expected = """\
-        import pytest
-        def foo():
-            with pytest.raises(ZeroDivisionError), open('') as file:
-                1/0
-                assert True
-        """
-        lines_to_exclude = [2]
-        self.run_and_assert(
-            tmpdir,
-            input_code,
-            expected,
-            lines_to_exclude=lines_to_exclude,
-        )

--- a/tests/samples/remove_assertion_in_pytest_raises.py
+++ b/tests/samples/remove_assertion_in_pytest_raises.py
@@ -1,0 +1,7 @@
+import pytest
+
+def test_foo():
+    with pytest.raises(ZeroDivisionError):
+        error = 1/0
+        assert 1
+        assert 2


### PR DESCRIPTION
## Overview
Adds a codemod that removes assertions from the bottom of `pytest.raises` context manager.
