### PR TITLE
Fix secure-random to ignore `random.SystemRandom`

### DIFF
--- a/src/core_codemods/secure_random.py
+++ b/src/core_codemods/secure_random.py
@@ -24,6 +24,7 @@ class SecureRandom(SimpleCodemod):
     detector_pattern = """
         - patterns:
           - pattern: random.$F(...)
+          - pattern-not: random.SystemRandom()
           - pattern-inside: |
               import random
               ...

--- a/tests/codemods/test_secure_random.py
+++ b/tests/codemods/test_secure_random.py
@@ -174,3 +174,27 @@ class TestSecureRandom(BaseSemgrepCodemodTest):
         """
 
         self.run_and_assert(tmpdir, input_code, expected_output)
+
+    def test_random_systemrandom(self, tmpdir):
+        input_code = """
+        import random
+
+        rand = random.SystemRandom()
+        """
+        self.run_and_assert(tmpdir, input_code, input_code)
+
+    def test_random_systemrandom_importfrom(self, tmpdir):
+        input_code = """
+        from random import SystemRandom
+
+        rand = SystemRandom()
+        """
+        self.run_and_assert(tmpdir, input_code, input_code)
+
+    def test_random_systemrandom_import_alias(self, tmpdir):
+        input_code = """
+        import random as domran
+
+        rand = domran.SystemRandom()
+        """
+        self.run_and_assert(tmpdir, input_code, input_code)


### PR DESCRIPTION
## Overview
*Using `random.SystemRandom` is secure and should not be replaced*

## Details
* I'm probably going to backport this as another bugfix release