### PR TITLE
Codemodder should add a "dependency already present" to codetf result

### DIFF
--- a/integration_tests/test_program.py
+++ b/integration_tests/test_program.py
@@ -1,7 +1,21 @@
+import json
+import os
 import subprocess
+import sys
 from core_codemods.remove_assertion_in_pytest_raises import (
     RemoveAssertionInPytestRaises,
 )
+from codemodder.dependency import (
+    build_dependency_notification,
+    build_dependency_is_present_notification,
+    Security,
+)
+from .base_test import DependencyTestMixin, CleanRepoMixin
+
+
+SAMPLES_DIR = "tests/samples"
+# Enable import of test modules from test directory
+sys.path.append(SAMPLES_DIR)
 
 
 class TestProgramFails:
@@ -42,3 +56,59 @@ class TestProgramFails:
         )
         assert completed_process.returncode == 0
         assert RemoveAssertionInPytestRaises.id not in completed_process.stdout
+
+
+class TestTwoCodemods(DependencyTestMixin, CleanRepoMixin):
+    output_path = "test-codetf.txt"
+    requirements_path = "tests/samples/requirements.txt"
+    original_requirements = "# file used to test dependency management\nrequests==2.31.0\nblack==23.7.*\nmypy~=1.4\npylint>1\n"
+    expected_new_reqs = "# file used to test dependency management\nrequests==2.31.0\nblack==23.7.*\nmypy~=1.4\npylint>1\nsecurity~=1.2.0\n"
+
+    def test_two_codemods_add_same_dependency(self):
+        """
+        Asserts codeTF output in case when two codemods would add the same
+        dependency to the project.
+        1. The dependency should only be added once to the dependency file.
+        2. At this time, the first codemod that runs will have a codetf description for
+            the dependency getting added, while the second codemod will state the dependency
+            is already present. We may want to change this behavior in the future.
+        """
+        code_path = os.path.relpath("tests/samples/make_*.py", SAMPLES_DIR)
+        first_codemod = "sandbox-process-creation"
+        second_codemod = "url-sandbox"
+        command = [
+            "codemodder",
+            SAMPLES_DIR,
+            "--output",
+            self.output_path,
+            f"--codemod-include={first_codemod},{second_codemod}",
+            f"--path-include={code_path}",
+            '--path-exclude=""',
+        ]
+
+        self.check_dependencies_before()
+        completed_process = subprocess.run(
+            command,
+            check=False,
+            shell=False,
+        )
+        assert completed_process.returncode == 0
+
+        self.check_dependencies_after()
+
+        with open(self.output_path, "r", encoding="utf-8") as f:
+            codetf = json.load(f)
+
+        process_creation_results = codetf["results"][0]
+        assert first_codemod in process_creation_results["codemod"]
+        assert (
+            build_dependency_notification("requirements.txt", Security)
+            in process_creation_results["description"]
+        )
+
+        url_sandbox_results = codetf["results"][1]
+        assert second_codemod in url_sandbox_results["codemod"]
+        assert (
+            build_dependency_is_present_notification("requirements.txt", Security)
+            in url_sandbox_results["description"]
+        )

--- a/src/codemodder/context.py
+++ b/src/codemodder/context.py
@@ -140,7 +140,6 @@ class CodemodExecutionContext:  # pylint: disable=too-many-instance-attributes
                 )
                 for dep in dependencies:
                     record[dep] = package_store
-                break
             else:
                 self._dependency_update_by_codemod[codemod_id] = (
                     Update.PRESENT,

--- a/src/codemodder/dependency.py
+++ b/src/codemodder/dependency.py
@@ -86,6 +86,14 @@ This codemod relies on an external dependency. We have automatically added this 
 There are a number of places where Python project dependencies can be expressed, including `setup.py`, `pyproject.toml`, `setup.cfg`, and `requirements.txt` files. If this change is incorrect, or if you are using another packaging system such as `poetry`, it may be necessary for you to manually add the dependency to the proper location in your project.
 """
 
+DEPENDENCY_IS_PRESENT_NOTIFICATION = """
+## Dependency Updates
+
+This codemod relies on an external dependency. We have detected that this dependency already exists in your project's `{filename}` file. 
+
+{description} 
+"""
+
 FAILED_DEPENDENCY_NOTIFICATION = """
 ## Dependency Updates
 
@@ -132,6 +140,15 @@ If you are using another build system, please refer to the documentation for tha
 
 def build_dependency_notification(filename: str, dependency: Dependency) -> str:
     return DEPENDENCY_NOTIFICATION.format(
+        filename=filename,
+        description=dependency.description,
+    )
+
+
+def build_dependency_is_present_notification(
+    filename: str, dependency: Dependency
+) -> str:
+    return DEPENDENCY_IS_PRESENT_NOTIFICATION.format(
         filename=filename,
         description=dependency.description,
     )

--- a/src/codemodder/dependency.py
+++ b/src/codemodder/dependency.py
@@ -81,7 +81,7 @@ DEPENDENCY_NOTIFICATION = """
 
 This codemod relies on an external dependency. We have automatically added this dependency to your project's `{filename}` file. 
 
-{description} 
+- `{name}`: {description} 
 
 There are a number of places where Python project dependencies can be expressed, including `setup.py`, `pyproject.toml`, `setup.cfg`, and `requirements.txt` files. If this change is incorrect, or if you are using another packaging system such as `poetry`, it may be necessary for you to manually add the dependency to the proper location in your project.
 """
@@ -91,7 +91,7 @@ DEPENDENCY_IS_PRESENT_NOTIFICATION = """
 
 This codemod relies on an external dependency. We have detected that this dependency already exists in your project's `{filename}` file. 
 
-{description} 
+- `{name}`: {description} 
 """
 
 FAILED_DEPENDENCY_NOTIFICATION = """
@@ -99,7 +99,7 @@ FAILED_DEPENDENCY_NOTIFICATION = """
 
 This codemod relies on an external dependency. However, we were unable to automatically add the dependency to your project. 
 
-{description} 
+- `{name}`: {description} 
 
 There are a number of places where Python project dependencies can be expressed, including `setup.py`, `pyproject.toml`, `setup.cfg`, and `requirements.txt` files. You may need to manually add this dependency to the proper location in your project.
 
@@ -142,6 +142,7 @@ def build_dependency_notification(filename: str, dependency: Dependency) -> str:
     return DEPENDENCY_NOTIFICATION.format(
         filename=filename,
         description=dependency.description,
+        name=dependency.requirement.name,
     )
 
 
@@ -151,6 +152,7 @@ def build_dependency_is_present_notification(
     return DEPENDENCY_IS_PRESENT_NOTIFICATION.format(
         filename=filename,
         description=dependency.description,
+        name=dependency.requirement.name,
     )
 
 
@@ -158,4 +160,5 @@ def build_failed_dependency_notification(dependency: Dependency) -> str:
     return FAILED_DEPENDENCY_NOTIFICATION.format(
         description=dependency.description,
         requirement=dependency.requirement,
+        name=dependency.requirement.name,
     )

--- a/tests/test_context.py
+++ b/tests/test_context.py
@@ -42,7 +42,7 @@ class TestContext:
             f"We have automatically added this dependency to your project's `{pkg_store.type.value}` file."
             in description
         )
-        assert Security.description in description
+        assert f"- `{Security.requirement.name}`: {Security.description}" in description
         assert "### Manual Installation\n" not in description
 
     def test_failed_dependency_description(self, mocker):
@@ -63,7 +63,7 @@ class TestContext:
 
         assert description.startswith(codemod.description)
         assert "## Dependency Updates\n" in description
-        assert Security.description in description
+        assert f"- `{Security.requirement.name}`: {Security.description}" in description
         assert "### Manual Installation\n" in description
         assert (
             f"""For `setup.py`:
@@ -109,5 +109,5 @@ class TestContext:
             f"We have detected that this dependency already exists in your project's `{pkg_store.type.value}` file."
             in description
         )
-        assert Security.description in description
+        assert f"- `{Security.requirement.name}`: {Security.description}" in description
         assert "### Manual Installation\n" not in description


### PR DESCRIPTION
## Overview
*When a dependency that codemodder would add already exists in the project, report a specific codetf description message.*

## Description

* This PR is a bit "shallow" in that in the long-term we really would need to handle a codemod being able to add multiple dependencies, some that may already exist, some that need to be added. However, we decided to not handle for that at this time.
* We also decided to punt on the case for what to do if two codemods run that would add the same dependency. At this time, the current behavior is tested in the new integration test:  the first codemod that runs gets the "we added a new dependency to the project" message, while the second codemod gets a "dependency already present" message. We can come back to this later.
