### PR TITLE
remove dedent and \ from unit tests

### DIFF
--- a/tests/codemods/test_combine_startswith_endswith.py
+++ b/tests/codemods/test_combine_startswith_endswith.py
@@ -13,11 +13,11 @@ class TestCombineStartswithEndswith(BaseCodemodTest):
 
     @each_func
     def test_combine(self, tmpdir, func):
-        input_code = f"""\
+        input_code = f"""
         x = "foo"
         x.{func}("foo") or x.{func}("f")
         """
-        expected = f"""\
+        expected = f"""
         x = "foo"
         x.{func}(("foo", "f"))
         """
@@ -40,11 +40,11 @@ class TestCombineStartswithEndswith(BaseCodemodTest):
     def test_exclude_line(self, tmpdir):
         input_code = (
             expected
-        ) = """\
+        ) = """
         x = "foo"
         x.startswith("foo") or x.startswith("f")
         """
-        lines_to_exclude = [2]
+        lines_to_exclude = [3]
         self.run_and_assert(
             tmpdir,
             input_code,

--- a/tests/codemods/test_django_json_response_type.py
+++ b/tests/codemods/test_django_json_response_type.py
@@ -1,6 +1,5 @@
 from core_codemods.django_json_response_type import DjangoJsonResponseType
 from tests.codemods.base_codemod_test import BaseSemgrepCodemodTest
-from textwrap import dedent
 
 
 class TestDjangoJsonResponseType(BaseSemgrepCodemodTest):
@@ -10,7 +9,7 @@ class TestDjangoJsonResponseType(BaseSemgrepCodemodTest):
         assert self.codemod.name == "django-json-response-type"
 
     def test_simple(self, tmpdir):
-        input_code = """\
+        input_code = """
         from django.http import HttpResponse
         import json
 
@@ -18,7 +17,7 @@ class TestDjangoJsonResponseType(BaseSemgrepCodemodTest):
             json_response = json.dumps({ "user_input": request.GET.get("input") })
             return HttpResponse(json_response)
         """
-        expected = """\
+        expected = """
         from django.http import HttpResponse
         import json
 
@@ -26,10 +25,10 @@ class TestDjangoJsonResponseType(BaseSemgrepCodemodTest):
             json_response = json.dumps({ "user_input": request.GET.get("input") })
             return HttpResponse(json_response, content_type="application/json")
         """
-        self.run_and_assert(tmpdir, dedent(input_code), dedent(expected))
+        self.run_and_assert(tmpdir, input_code, expected)
 
     def test_alias(self, tmpdir):
-        input_code = """\
+        input_code = """
         from django.http import HttpResponse as response
         import json as jsan
 
@@ -37,7 +36,7 @@ class TestDjangoJsonResponseType(BaseSemgrepCodemodTest):
             json_response = jsan.dumps({ "user_input": request.GET.get("input") })
             return response(json_response)
         """
-        expected = """\
+        expected = """
         from django.http import HttpResponse as response
         import json as jsan
 
@@ -45,27 +44,27 @@ class TestDjangoJsonResponseType(BaseSemgrepCodemodTest):
             json_response = jsan.dumps({ "user_input": request.GET.get("input") })
             return response(json_response, content_type="application/json")
         """
-        self.run_and_assert(tmpdir, dedent(input_code), dedent(expected))
+        self.run_and_assert(tmpdir, input_code, expected)
 
     def test_direct(self, tmpdir):
-        input_code = """\
+        input_code = """
         from django.http import HttpResponse
         import json
 
         def foo(request):
             return HttpResponse(json.dumps({ "user_input": request.GET.get("input") }))
         """
-        expected = """\
+        expected = """
         from django.http import HttpResponse
         import json
 
         def foo(request):
             return HttpResponse(json.dumps({ "user_input": request.GET.get("input") }), content_type="application/json")
         """
-        self.run_and_assert(tmpdir, dedent(input_code), dedent(expected))
+        self.run_and_assert(tmpdir, input_code, expected)
 
     def test_content_type_set(self, tmpdir):
-        input_code = """\
+        input_code = """
         from django.http import HttpResponse
         import json
 
@@ -73,10 +72,10 @@ class TestDjangoJsonResponseType(BaseSemgrepCodemodTest):
             json_response = json.dumps({ "user_input": request.GET.get("input") })
             return HttpResponse(json_response, content_type='application/json')
         """
-        self.run_and_assert(tmpdir, dedent(input_code), dedent(input_code))
+        self.run_and_assert(tmpdir, input_code, input_code)
 
     def test_no_json_input(self, tmpdir):
-        input_code = """\
+        input_code = """
         from django.http import HttpResponse
         import json
 
@@ -84,4 +83,4 @@ class TestDjangoJsonResponseType(BaseSemgrepCodemodTest):
             dict_reponse = { "user_input": request.GET.get("input") }
             return HttpResponse(dict_response)
         """
-        self.run_and_assert(tmpdir, dedent(input_code), dedent(input_code))
+        self.run_and_assert(tmpdir, input_code, input_code)

--- a/tests/codemods/test_django_receiver_on_top.py
+++ b/tests/codemods/test_django_receiver_on_top.py
@@ -1,6 +1,5 @@
 from core_codemods.django_receiver_on_top import DjangoReceiverOnTop
 from tests.codemods.base_codemod_test import BaseCodemodTest
-from textwrap import dedent
 
 
 class TestDjangoReceiverOnTop(BaseCodemodTest):
@@ -10,7 +9,7 @@ class TestDjangoReceiverOnTop(BaseCodemodTest):
         assert self.codemod.name == "django-receiver-on-top"
 
     def test_simple(self, tmpdir):
-        input_code = """\
+        input_code = """
         from django.dispatch import receiver
 
         @csrf_exempt
@@ -18,7 +17,7 @@ class TestDjangoReceiverOnTop(BaseCodemodTest):
         def foo():
             pass
         """
-        expected = """\
+        expected = """
         from django.dispatch import receiver
 
         @receiver(request_finished)
@@ -26,10 +25,10 @@ class TestDjangoReceiverOnTop(BaseCodemodTest):
         def foo():
             pass
         """
-        self.run_and_assert(tmpdir, dedent(input_code), dedent(expected))
+        self.run_and_assert(tmpdir, input_code, expected)
 
     def test_simple_alias(self, tmpdir):
-        input_code = """\
+        input_code = """
         from django.dispatch import receiver as rec
 
         @csrf_exempt
@@ -37,7 +36,7 @@ class TestDjangoReceiverOnTop(BaseCodemodTest):
         def foo():
             pass
         """
-        expected = """\
+        expected = """
         from django.dispatch import receiver as rec
 
         @rec(request_finished)
@@ -45,18 +44,18 @@ class TestDjangoReceiverOnTop(BaseCodemodTest):
         def foo():
             pass
         """
-        self.run_and_assert(tmpdir, dedent(input_code), dedent(expected))
+        self.run_and_assert(tmpdir, input_code, expected)
 
     def test_no_receiver(self, tmpdir):
-        input_code = """\
+        input_code = """
         @csrf_exempt
         def foo():
             pass
         """
-        self.run_and_assert(tmpdir, dedent(input_code), dedent(input_code))
+        self.run_and_assert(tmpdir, input_code, input_code)
 
     def test_receiver_but_not_djangos(self, tmpdir):
-        input_code = """\
+        input_code = """
         from not_django import receiver
 
         @csrf_exempt
@@ -64,10 +63,10 @@ class TestDjangoReceiverOnTop(BaseCodemodTest):
         def foo():
             pass
         """
-        self.run_and_assert(tmpdir, dedent(input_code), dedent(input_code))
+        self.run_and_assert(tmpdir, input_code, input_code)
 
     def test_receiver_on_top(self, tmpdir):
-        input_code = """\
+        input_code = """
         from django.dispatch import receiver
 
         @receiver(request_finished)
@@ -75,4 +74,4 @@ class TestDjangoReceiverOnTop(BaseCodemodTest):
         def foo():
             pass
         """
-        self.run_and_assert(tmpdir, dedent(input_code), dedent(input_code))
+        self.run_and_assert(tmpdir, input_code, input_code)

--- a/tests/codemods/test_exception_without_raise.py
+++ b/tests/codemods/test_exception_without_raise.py
@@ -1,6 +1,5 @@
 from tests.codemods.base_codemod_test import BaseCodemodTest
 from core_codemods.exception_without_raise import ExceptionWithoutRaise
-from textwrap import dedent
 
 
 class TestExceptionWithoutRaise(BaseCodemodTest):
@@ -10,54 +9,54 @@ class TestExceptionWithoutRaise(BaseCodemodTest):
         assert self.codemod.name == "exception-without-raise"
 
     def test_simple(self, tmpdir):
-        input_code = """\
+        input_code = """
         ValueError
         """
-        expected = """\
+        expected = """
         raise ValueError
         """
-        self.run_and_assert(tmpdir, dedent(input_code), dedent(expected))
+        self.run_and_assert(tmpdir, input_code, expected)
 
     def test_simple_call(self, tmpdir):
-        input_code = """\
+        input_code = """
         ValueError("Bad value!")
         """
-        expected = """\
+        expected = """
         raise ValueError("Bad value!")
         """
-        self.run_and_assert(tmpdir, dedent(input_code), dedent(expected))
+        self.run_and_assert(tmpdir, input_code, expected)
 
     def test_alias(self, tmpdir):
-        input_code = """\
+        input_code = """
         from decimal import Overflow as error
         error
         """
-        expected = """\
+        expected = """
         from decimal import Overflow as error
         raise error
         """
-        self.run_and_assert(tmpdir, dedent(input_code), dedent(expected))
+        self.run_and_assert(tmpdir, input_code, expected)
 
     def test_unknown_exception(self, tmpdir):
-        input_code = """\
+        input_code = """
         Something
         """
-        self.run_and_assert(tmpdir, dedent(input_code), dedent(input_code))
+        self.run_and_assert(tmpdir, input_code, input_code)
 
     def test_raised_exception(self, tmpdir):
-        input_code = """\
+        input_code = """
         raise ValueError
         """
-        self.run_and_assert(tmpdir, dedent(input_code), dedent(input_code))
+        self.run_and_assert(tmpdir, input_code, input_code)
 
     def test_exclude_line(self, tmpdir):
         input_code = (
             expected
-        ) = """\
+        ) = """
         print(1)
         ValueError("Bad value!")
         """
-        lines_to_exclude = [2]
+        lines_to_exclude = [3]
         self.run_and_assert(
             tmpdir,
             input_code,

--- a/tests/codemods/test_file_resource_leak.py
+++ b/tests/codemods/test_file_resource_leak.py
@@ -1,6 +1,5 @@
 from tests.codemods.base_codemod_test import BaseCodemodTest
 from core_codemods.file_resource_leak import FileResourceLeak
-from textwrap import dedent
 
 
 class TestFileResourceLeak(BaseCodemodTest):
@@ -10,137 +9,137 @@ class TestFileResourceLeak(BaseCodemodTest):
         assert self.codemod.name == "fix-file-resource-leak"
 
     def test_simple(self, tmpdir):
-        input_code = """\
+        input_code = """
         file = open('test.txt', 'r')
         file.read()
         """
-        expected = """\
+        expected = """
         with open('test.txt', 'r') as file:
             file.read()
         """
-        self.run_and_assert(tmpdir, dedent(input_code), dedent(expected))
+        self.run_and_assert(tmpdir, input_code, expected)
 
     def test_simple_annotated(self, tmpdir):
-        input_code = """\
+        input_code = """
         file: int = open('test.txt', 'r')
         file.read()
         """
-        expected = """\
+        expected = """
         with open('test.txt', 'r') as file:
             file.read()
         """
-        self.run_and_assert(tmpdir, dedent(input_code), dedent(expected))
+        self.run_and_assert(tmpdir, input_code, expected)
 
     def test_just_open(self, tmpdir):
         # strange as this change may be, it still leaks if left untouched
-        input_code = """\
+        input_code = """
         file = open('test.txt', 'r')
         """
-        expected = """\
+        expected = """
         with open('test.txt', 'r') as file:
             pass
         """
-        self.run_and_assert(tmpdir, dedent(input_code), dedent(expected))
+        self.run_and_assert(tmpdir, input_code, expected)
 
     def test_multiple_assignments(self, tmpdir):
-        input_code = """\
+        input_code = """
         file = file2 = open('test.txt', 'r')
         file.read()
         """
-        expected = """\
+        expected = """
         with open('test.txt', 'r') as file, file as file2:
             file.read()
         """
-        self.run_and_assert(tmpdir, dedent(input_code), dedent(expected))
+        self.run_and_assert(tmpdir, input_code, expected)
 
     def test_minimal_block(self, tmpdir):
-        input_code = """\
+        input_code = """
         file = open('test.txt', 'r')
         file.read()
         pass
         """
-        expected = """\
+        expected = """
         with open('test.txt', 'r') as file:
             file.read()
         pass
         """
-        self.run_and_assert(tmpdir, dedent(input_code), dedent(expected))
+        self.run_and_assert(tmpdir, input_code, expected)
 
     # negative tests below
 
     def test_is_closed(self, tmpdir):
-        input_code = """\
+        input_code = """
         file = open('test.txt', 'r')
         file.read()
         file.close()
         """
-        self.run_and_assert(tmpdir, dedent(input_code), dedent(input_code))
+        self.run_and_assert(tmpdir, input_code, input_code)
 
     def test_is_closed_with_exit(self, tmpdir):
-        input_code = """\
+        input_code = """
         file = open('test.txt', 'r')
         file.read()
         file.__exit__()
         """
-        self.run_and_assert(tmpdir, dedent(input_code), dedent(input_code))
+        self.run_and_assert(tmpdir, input_code, input_code)
 
     def test_is_closed_with_statement(self, tmpdir):
-        input_code = """\
+        input_code = """
         file = open('test.txt', 'r')
         with file:
             file.read()
         """
-        self.run_and_assert(tmpdir, dedent(input_code), dedent(input_code))
+        self.run_and_assert(tmpdir, input_code, input_code)
 
     def test_is_closed_with_statement_and_contextlib(self, tmpdir):
-        input_code = """\
+        input_code = """
         import contextlib
         file = open('test.txt', 'r')
         with contextlib.closing(file):
             file.read()
         """
-        self.run_and_assert(tmpdir, dedent(input_code), dedent(input_code))
+        self.run_and_assert(tmpdir, input_code, input_code)
 
     def test_is_closed_transitivelly(self, tmpdir):
-        input_code = """\
+        input_code = """
         file = open('test.txt', 'r')
         same_file = file
         same_file.close()
         """
-        self.run_and_assert(tmpdir, dedent(input_code), dedent(input_code))
+        self.run_and_assert(tmpdir, input_code, input_code)
 
     def test_escapes_with_assignment(self, tmpdir):
-        input_code = """\
+        input_code = """
         file = open('test.txt', 'r')
         Object.attribute = file
         """
-        self.run_and_assert(tmpdir, dedent(input_code), dedent(input_code))
+        self.run_and_assert(tmpdir, input_code, input_code)
 
     def test_escapes_as_function_argument(self, tmpdir):
-        input_code = """\
+        input_code = """
         file = open('test.txt', 'r')
         foo(file)
         """
-        self.run_and_assert(tmpdir, dedent(input_code), dedent(input_code))
+        self.run_and_assert(tmpdir, input_code, input_code)
 
     def test_escapes_returned(self, tmpdir):
-        input_code = """\
+        input_code = """
         def foo():
             file = open('test.txt', 'r')
             return file
         """
-        self.run_and_assert(tmpdir, dedent(input_code), dedent(input_code))
+        self.run_and_assert(tmpdir, input_code, input_code)
 
     def test_escapes_yielded(self, tmpdir):
-        input_code = """\
+        input_code = """
         def foo():
             file = open('test.txt', 'r')
             yield file
         """
-        self.run_and_assert(tmpdir, dedent(input_code), dedent(input_code))
+        self.run_and_assert(tmpdir, input_code, input_code)
 
     def test_escapes_outside_reference(self, tmpdir):
-        input_code = """\
+        input_code = """
         out = None
         if True:
             file = open('test.txt', 'r')
@@ -148,4 +147,4 @@ class TestFileResourceLeak(BaseCodemodTest):
             file.read()
         out.read()
         """
-        self.run_and_assert(tmpdir, dedent(input_code), dedent(input_code))
+        self.run_and_assert(tmpdir, input_code, input_code)

--- a/tests/codemods/test_fix_assert_tuple.py
+++ b/tests/codemods/test_fix_assert_tuple.py
@@ -31,12 +31,12 @@ class TestFixAssertTuple(BaseCodemodTest):
             assert change.lineNumber == idx + 1
 
     def test_change_line_pos(self, tmpdir):
-        input_code = """\
+        input_code = """
         print(1)
         assert (1, 2, )
         print(2)
         """
-        expected_output = """\
+        expected_output = """
         print(1)
         assert 1
         assert 2
@@ -44,17 +44,17 @@ class TestFixAssertTuple(BaseCodemodTest):
         """
 
         self.run_and_assert(tmpdir, input_code, expected_output, num_changes=2)
-        first_assert_line = 2
+        first_assert_line = 3
         for idx, change in enumerate(self.changeset[0].changes):
             assert change.lineNumber == idx + first_assert_line
 
     def test_change_with_message(self, tmpdir):
-        input_code = """\
+        input_code = """
         print(1)
         assert (1, 2, ), "some message"
         print(2)
         """
-        expected_output = """\
+        expected_output = """
         print(1)
         assert 1, "some message"
         assert 2, "some message"
@@ -79,10 +79,10 @@ class TestFixAssertTuple(BaseCodemodTest):
     def test_exclude_line(self, tmpdir):
         input_code = (
             expected
-        ) = """\
+        ) = """
         assert (1, 2)
         """
-        lines_to_exclude = [1]
+        lines_to_exclude = [2]
         self.run_and_assert(
             tmpdir,
             input_code,

--- a/tests/codemods/test_fix_deprecated_abstractproperty.py
+++ b/tests/codemods/test_fix_deprecated_abstractproperty.py
@@ -127,7 +127,7 @@ class TestFixDeprecatedAbstractproperty(BaseCodemodTest):
     def test_exclude_line(self, tmpdir):
         input_code = (
             expected
-        ) = """\
+        ) = """
         import abc
 
         class A:
@@ -135,7 +135,7 @@ class TestFixDeprecatedAbstractproperty(BaseCodemodTest):
             def foo(self):
                 pass
         """
-        lines_to_exclude = [4]
+        lines_to_exclude = [5]
         self.run_and_assert(
             tmpdir,
             input_code,

--- a/tests/codemods/test_fix_deprecated_logging_warn.py
+++ b/tests/codemods/test_fix_deprecated_logging_warn.py
@@ -51,19 +51,19 @@ class TestFixDeprecatedLoggingWarn(BaseSemgrepCodemodTest):
         "input_code,expected_output",
         [
             (
-                """\
+                """
                 from logging import warn as warn_func
                 warn_func('something')""",
-                """\
+                """
                 from logging import warning
                 warning('something')""",
             ),
             (
-                """\
+                """
                 from logging import getLogger as make_logger
                 logger = make_logger('anything')
                 logger.warn('something')""",
-                """\
+                """
                 from logging import getLogger as make_logger
                 logger = make_logger('anything')
                 logger.warning('something')""",
@@ -92,7 +92,7 @@ class TestFixDeprecatedLoggingWarn(BaseSemgrepCodemodTest):
 
     @pytest.mark.xfail(reason="Not currently supported")
     def test_log_as_arg(self, tmpdir):
-        code = """\
+        code = """
         import logging
         log = logging.getLogger('foo')
         def some_function(logger):

--- a/tests/codemods/test_fix_empty_sequence_comparison.py
+++ b/tests/codemods/test_fix_empty_sequence_comparison.py
@@ -230,12 +230,12 @@ class TestFixEmptySequenceComparisonIfStatements(BaseCodemodTest):
     def test_exclude_line(self, tmpdir):
         input_code = (
             expected
-        ) = """\
+        ) = """
         x = [1]
         if x != []:
             pass
         """
-        lines_to_exclude = [2]
+        lines_to_exclude = [3]
         self.run_and_assert(
             tmpdir,
             input_code,

--- a/tests/codemods/test_flask_enable_csrf_protection.py
+++ b/tests/codemods/test_flask_enable_csrf_protection.py
@@ -1,6 +1,5 @@
 from core_codemods.flask_enable_csrf_protection import FlaskEnableCSRFProtection
 from tests.codemods.base_codemod_test import BaseCodemodTest
-from textwrap import dedent
 
 
 class TestFlaskEnableCSRFProtection(BaseCodemodTest):
@@ -10,40 +9,40 @@ class TestFlaskEnableCSRFProtection(BaseCodemodTest):
         assert self.codemod.name == "flask-enable-csrf-protection"
 
     def test_simple(self, tmpdir):
-        input_code = """\
+        input_code = """
         from flask import Flask
         app = Flask(__name__)
         """
-        expected = """\
+        expected = """
         from flask import Flask
         from flask_wtf.csrf import CSRFProtect
 
         app = Flask(__name__)
         csrf_app = CSRFProtect(app)
         """
-        self.run_and_assert(tmpdir, dedent(input_code), dedent(expected))
+        self.run_and_assert(tmpdir, input_code, expected)
 
     def test_simple_alias(self, tmpdir):
-        input_code = """\
+        input_code = """
         from flask import Flask as Flosk
         app = Flosk(__name__)
         """
-        expected = """\
+        expected = """
         from flask import Flask as Flosk
         from flask_wtf.csrf import CSRFProtect
 
         app = Flosk(__name__)
         csrf_app = CSRFProtect(app)
         """
-        self.run_and_assert(tmpdir, dedent(input_code), dedent(expected))
+        self.run_and_assert(tmpdir, input_code, expected)
 
     def test_multiple(self, tmpdir):
-        input_code = """\
+        input_code = """
         from flask import Flask
         app = Flask(__name__)
         app2 = Flask(__name__)
         """
-        expected = """\
+        expected = """
         from flask import Flask
         from flask_wtf.csrf import CSRFProtect
 
@@ -52,40 +51,40 @@ class TestFlaskEnableCSRFProtection(BaseCodemodTest):
         app2 = Flask(__name__)
         csrf_app2 = CSRFProtect(app2)
         """
-        self.run_and_assert(tmpdir, dedent(input_code), dedent(expected), num_changes=2)
+        self.run_and_assert(tmpdir, input_code, expected, num_changes=2)
 
     def test_multiple_inline(self, tmpdir):
-        input_code = """\
+        input_code = """
         from flask import Flask
         app = Flask(__name__); app2 = Flask(__name__)
         """
-        expected = """\
+        expected = """
         from flask import Flask
         from flask_wtf.csrf import CSRFProtect
 
         app = Flask(__name__); app2 = Flask(__name__); csrf_app = CSRFProtect(app); csrf_app2 = CSRFProtect(app2)
         """
-        self.run_and_assert(tmpdir, dedent(input_code), dedent(expected))
+        self.run_and_assert(tmpdir, input_code, expected)
 
     def test_multiple_inline_suite(self, tmpdir):
-        input_code = """\
+        input_code = """
         from flask import Flask
         if True: app = Flask(__name__); app2 = Flask(__name__)
         """
-        expected = """\
+        expected = """
         from flask import Flask
         from flask_wtf.csrf import CSRFProtect
 
         if True: app = Flask(__name__); app2 = Flask(__name__); csrf_app = CSRFProtect(app); csrf_app2 = CSRFProtect(app2)
         """
-        self.run_and_assert(tmpdir, dedent(input_code), dedent(expected))
+        self.run_and_assert(tmpdir, input_code, expected)
 
     def test_simple_protected(self, tmpdir):
-        input_code = """\
+        input_code = """
         from flask import Flask
         from flask_wtf.csrf import CSRFProtect
 
         app = Flask(__name__)
         csrf_app = CSRFProtect(app)
         """
-        self.run_and_assert(tmpdir, dedent(input_code), dedent(input_code))
+        self.run_and_assert(tmpdir, input_code, input_code)

--- a/tests/codemods/test_flask_json_response_type.py
+++ b/tests/codemods/test_flask_json_response_type.py
@@ -1,6 +1,5 @@
 from core_codemods.flask_json_response_type import FlaskJsonResponseType
 from tests.codemods.base_codemod_test import BaseCodemodTest
-from textwrap import dedent
 
 
 class TestFlaskJsonResponseType(BaseCodemodTest):
@@ -10,7 +9,7 @@ class TestFlaskJsonResponseType(BaseCodemodTest):
         assert self.codemod.name == "flask-json-response-type"
 
     def test_simple(self, tmpdir):
-        input_code = """\
+        input_code = """
         from flask import make_response, Flask
         import json
 
@@ -21,7 +20,7 @@ class TestFlaskJsonResponseType(BaseCodemodTest):
             json_response = json.dumps({ "user_input": request.GET.get("input") })
             return make_response(json_response)
         """
-        expected = """\
+        expected = """
         from flask import make_response, Flask
         import json
 
@@ -32,10 +31,10 @@ class TestFlaskJsonResponseType(BaseCodemodTest):
             json_response = json.dumps({ "user_input": request.GET.get("input") })
             return make_response(json_response, {'Content-Type': 'application/json'})
         """
-        self.run_and_assert(tmpdir, dedent(input_code), dedent(expected))
+        self.run_and_assert(tmpdir, input_code, expected)
 
     def test_simple_indirect(self, tmpdir):
-        input_code = """\
+        input_code = """
         from flask import make_response, Flask
         import json
 
@@ -47,7 +46,7 @@ class TestFlaskJsonResponseType(BaseCodemodTest):
             response = make_response(json_response)
             return response
         """
-        expected = """\
+        expected = """
         from flask import make_response, Flask
         import json
 
@@ -59,10 +58,10 @@ class TestFlaskJsonResponseType(BaseCodemodTest):
             response = make_response(json_response, {'Content-Type': 'application/json'})
             return response
         """
-        self.run_and_assert(tmpdir, dedent(input_code), dedent(expected))
+        self.run_and_assert(tmpdir, input_code, expected)
 
     def test_simple_tuple_arg(self, tmpdir):
-        input_code = """\
+        input_code = """
         from flask import make_response, Flask
         import json
 
@@ -73,7 +72,7 @@ class TestFlaskJsonResponseType(BaseCodemodTest):
             json_response = json.dumps({ "user_input": request.GET.get("input") })
             return make_response((json_response, 404))
         """
-        expected = """\
+        expected = """
         from flask import make_response, Flask
         import json
 
@@ -84,10 +83,10 @@ class TestFlaskJsonResponseType(BaseCodemodTest):
             json_response = json.dumps({ "user_input": request.GET.get("input") })
             return make_response((json_response, 404, {'Content-Type': 'application/json'}))
         """
-        self.run_and_assert(tmpdir, dedent(input_code), dedent(expected))
+        self.run_and_assert(tmpdir, input_code, expected)
 
     def test_simple_return_json(self, tmpdir):
-        input_code = """\
+        input_code = """
         from flask import Flask
         import json
 
@@ -98,7 +97,7 @@ class TestFlaskJsonResponseType(BaseCodemodTest):
             json_response = json.dumps({ "user_input": request.GET.get("input") })
             return json_response
         """
-        expected = """\
+        expected = """
         from flask import Flask
         import json
 
@@ -109,10 +108,10 @@ class TestFlaskJsonResponseType(BaseCodemodTest):
             json_response = json.dumps({ "user_input": request.GET.get("input") })
             return (json_response, {'Content-Type': 'application/json'})
         """
-        self.run_and_assert(tmpdir, dedent(input_code), dedent(expected))
+        self.run_and_assert(tmpdir, input_code, expected)
 
     def test_simple_tuple(self, tmpdir):
-        input_code = """\
+        input_code = """
         from flask import Flask
         import json
 
@@ -123,7 +122,7 @@ class TestFlaskJsonResponseType(BaseCodemodTest):
             json_response = json.dumps({ "user_input": request.GET.get("input") })
             return (json_response, 404)
         """
-        expected = """\
+        expected = """
         from flask import Flask
         import json
 
@@ -134,10 +133,10 @@ class TestFlaskJsonResponseType(BaseCodemodTest):
             json_response = json.dumps({ "user_input": request.GET.get("input") })
             return (json_response, 404, {'Content-Type': 'application/json'})
         """
-        self.run_and_assert(tmpdir, dedent(input_code), dedent(expected))
+        self.run_and_assert(tmpdir, input_code, expected)
 
     def test_alias(self, tmpdir):
-        input_code = """\
+        input_code = """
         from flask import make_response as response, Flask
         import json
 
@@ -148,7 +147,7 @@ class TestFlaskJsonResponseType(BaseCodemodTest):
             json_response = json.dumps({ "user_input": request.GET.get("input") })
             return response(json_response)
         """
-        expected = """\
+        expected = """
         from flask import make_response as response, Flask
         import json
 
@@ -159,10 +158,10 @@ class TestFlaskJsonResponseType(BaseCodemodTest):
             json_response = json.dumps({ "user_input": request.GET.get("input") })
             return response(json_response, {'Content-Type': 'application/json'})
         """
-        self.run_and_assert(tmpdir, dedent(input_code), dedent(expected))
+        self.run_and_assert(tmpdir, input_code, expected)
 
     def test_indirect_dict(self, tmpdir):
-        input_code = """\
+        input_code = """
         from flask import make_response, Flask
         import json
 
@@ -174,7 +173,7 @@ class TestFlaskJsonResponseType(BaseCodemodTest):
             headers = {'key': 'value'}
             return make_response(json_response, headers)
         """
-        expected = """\
+        expected = """
         from flask import make_response, Flask
         import json
 
@@ -186,10 +185,10 @@ class TestFlaskJsonResponseType(BaseCodemodTest):
             headers = {'key': 'value', 'Content-Type': 'application/json'}
             return make_response(json_response, headers)
         """
-        self.run_and_assert(tmpdir, dedent(input_code), dedent(expected))
+        self.run_and_assert(tmpdir, input_code, expected)
 
     def test_direct_return(self, tmpdir):
-        input_code = """\
+        input_code = """
         from flask import make_response, Flask
         import json
 
@@ -199,7 +198,7 @@ class TestFlaskJsonResponseType(BaseCodemodTest):
         def foo(request):
             return make_response(json.dumps({ "user_input": request.GET.get("input") }))
         """
-        expected = """\
+        expected = """
         from flask import make_response, Flask
         import json
 
@@ -209,10 +208,10 @@ class TestFlaskJsonResponseType(BaseCodemodTest):
         def foo(request):
             return make_response(json.dumps({ "user_input": request.GET.get("input") }), {'Content-Type': 'application/json'})
         """
-        self.run_and_assert(tmpdir, dedent(input_code), dedent(expected))
+        self.run_and_assert(tmpdir, input_code, expected)
 
     def test_tuple_dict_no_key(self, tmpdir):
-        input_code = """\
+        input_code = """
         from flask import make_response, Flask
         import json
 
@@ -223,7 +222,7 @@ class TestFlaskJsonResponseType(BaseCodemodTest):
             json_response = json.dumps({ "user_input": request.GET.get("input") })
             return (make_response(json_response), {})
         """
-        expected = """\
+        expected = """
         from flask import make_response, Flask
         import json
 
@@ -234,10 +233,10 @@ class TestFlaskJsonResponseType(BaseCodemodTest):
             json_response = json.dumps({ "user_input": request.GET.get("input") })
             return (make_response(json_response), {'Content-Type': 'application/json'})
         """
-        self.run_and_assert(tmpdir, dedent(input_code), dedent(expected))
+        self.run_and_assert(tmpdir, input_code, expected)
 
     def test_no_route_decorator(self, tmpdir):
-        input_code = """\
+        input_code = """
         from flask import make_response, Flask
         import json
 
@@ -247,10 +246,10 @@ class TestFlaskJsonResponseType(BaseCodemodTest):
             json_response = json.dumps({ "user_input": request.GET.get("input") })
             return make_response(json_response)
         """
-        self.run_and_assert(tmpdir, dedent(input_code), dedent(input_code))
+        self.run_and_assert(tmpdir, input_code, input_code)
 
     def test_content_type_set(self, tmpdir):
-        input_code = """\
+        input_code = """
         from flask import make_response, Flask
         import json
 
@@ -261,10 +260,10 @@ class TestFlaskJsonResponseType(BaseCodemodTest):
             json_response = json.dumps({ "user_input": request.GET.get("input") })
             return (make_response(json_response), {'Content-Type': 'application/json'})
         """
-        self.run_and_assert(tmpdir, dedent(input_code), dedent(input_code))
+        self.run_and_assert(tmpdir, input_code, input_code)
 
     def test_content_type_maybe_set_star(self, tmpdir):
-        input_code = """\
+        input_code = """
         from flask import make_response, Flask
         import json
         from foo import another_dict
@@ -276,10 +275,10 @@ class TestFlaskJsonResponseType(BaseCodemodTest):
             json_response = json.dumps({ "user_input": request.GET.get("input") })
             return (make_response(json_response), {**another_dict})
         """
-        self.run_and_assert(tmpdir, dedent(input_code), dedent(input_code))
+        self.run_and_assert(tmpdir, input_code, input_code)
 
     def test_content_type_maybe_set(self, tmpdir):
-        input_code = """\
+        input_code = """
         from flask import make_response, Flask
         import json
         from foo import key
@@ -291,10 +290,10 @@ class TestFlaskJsonResponseType(BaseCodemodTest):
             json_response = json.dumps({ "user_input": request.GET.get("input") })
             return (make_response(json_response), {key:'application/json'})
         """
-        self.run_and_assert(tmpdir, dedent(input_code), dedent(input_code))
+        self.run_and_assert(tmpdir, input_code, input_code)
 
     def test_no_json_dumps_input(self, tmpdir):
-        input_code = """\
+        input_code = """
         from flask import make_response, Flask
         import json
 
@@ -305,10 +304,10 @@ class TestFlaskJsonResponseType(BaseCodemodTest):
             dict_response = { "user_input": request.GET.get("input") }
             return make_response(dict_response)
         """
-        self.run_and_assert(tmpdir, dedent(input_code), dedent(input_code))
+        self.run_and_assert(tmpdir, input_code, input_code)
 
     def test_unknown_call_response(self, tmpdir):
-        input_code = """\
+        input_code = """
         from flask import make_response, Flask
         import json
         from foo import bar
@@ -320,4 +319,4 @@ class TestFlaskJsonResponseType(BaseCodemodTest):
             dict_response = { "user_input": request.GET.get("input") }
             return bar(dict_response)
         """
-        self.run_and_assert(tmpdir, dedent(input_code), dedent(input_code))
+        self.run_and_assert(tmpdir, input_code, input_code)

--- a/tests/codemods/test_harden_pyyaml.py
+++ b/tests/codemods/test_harden_pyyaml.py
@@ -91,7 +91,7 @@ class TestHardenPyyamlClassInherit(BaseSemgrepCodemodTest):
     codemod = HardenPyyaml
 
     def test_safe_loader(self, tmpdir):
-        input_code = """\
+        input_code = """
         import yaml
 
         class MyCustomLoader(yaml.SafeLoader):
@@ -104,14 +104,14 @@ class TestHardenPyyamlClassInherit(BaseSemgrepCodemodTest):
 
     @loaders
     def test_unsafe_loaders(self, tmpdir, loader):
-        input_code = f"""\
+        input_code = f"""
         import yaml
 
         class MyCustomLoader(yaml.{loader}):
             def __init__(self, *args, **kwargs):
                 super(MyCustomLoader, self).__init__(*args, **kwargs)
         """
-        expected = """\
+        expected = """
         import yaml
 
         class MyCustomLoader(yaml.SafeLoader):
@@ -121,14 +121,14 @@ class TestHardenPyyamlClassInherit(BaseSemgrepCodemodTest):
         self.run_and_assert(tmpdir, input_code, expected)
 
     def test_from_import(self, tmpdir):
-        input_code = """\
+        input_code = """
         from yaml import UnsafeLoader
 
         class MyCustomLoader(UnsafeLoader):
             def __init__(self, *args, **kwargs):
                 super(MyCustomLoader, self).__init__(*args, **kwargs)
         """
-        expected = """\
+        expected = """
         from yaml import SafeLoader
 
         class MyCustomLoader(SafeLoader):
@@ -138,14 +138,14 @@ class TestHardenPyyamlClassInherit(BaseSemgrepCodemodTest):
         self.run_and_assert(tmpdir, input_code, expected)
 
     def test_import_alias(self, tmpdir):
-        input_code = """\
+        input_code = """
         import yaml as yam
 
         class MyCustomLoader(yam.UnsafeLoader):
             def __init__(self, *args, **kwargs):
                 super(MyCustomLoader, self).__init__(*args, **kwargs)
         """
-        expected = """\
+        expected = """
         import yaml as yam
 
         class MyCustomLoader(yam.SafeLoader):
@@ -155,7 +155,7 @@ class TestHardenPyyamlClassInherit(BaseSemgrepCodemodTest):
         self.run_and_assert(tmpdir, input_code, expected)
 
     def test_multiple_bases(self, tmpdir):
-        input_code = """\
+        input_code = """
         from abc import ABC
         import yaml as yam
         from whatever import Loader
@@ -164,7 +164,7 @@ class TestHardenPyyamlClassInherit(BaseSemgrepCodemodTest):
             def __init__(self, *args, **kwargs):
                 super(MyCustomLoader, self).__init__(*args, **kwargs)
         """
-        expected = """\
+        expected = """
         from abc import ABC
         import yaml as yam
         from whatever import Loader
@@ -176,14 +176,14 @@ class TestHardenPyyamlClassInherit(BaseSemgrepCodemodTest):
         self.run_and_assert(tmpdir, input_code, expected)
 
     def test_different_yaml(self, tmpdir):
-        input_code = """\
+        input_code = """
         from yaml import UnsafeLoader
         import whatever as yaml
 
         class MyLoader(UnsafeLoader, yaml.Loader):
             ...
         """
-        expected = """\
+        expected = """
         from yaml import SafeLoader
         import whatever as yaml
 

--- a/tests/codemods/test_literal_or_new_object_identity.py
+++ b/tests/codemods/test_literal_or_new_object_identity.py
@@ -1,6 +1,5 @@
 from core_codemods.literal_or_new_object_identity import LiteralOrNewObjectIdentity
 from tests.codemods.base_codemod_test import BaseCodemodTest
-from textwrap import dedent
 
 
 class TestLiteralOrNewObjectIdentity(BaseCodemodTest):
@@ -10,168 +9,168 @@ class TestLiteralOrNewObjectIdentity(BaseCodemodTest):
         assert self.codemod.name == "literal-or-new-object-identity"
 
     def test_list(self, tmpdir):
-        input_code = """\
+        input_code = """
         l is [1,2,3]
         """
-        expected = """\
+        expected = """
         l == [1,2,3]
         """
-        self.run_and_assert(tmpdir, dedent(input_code), dedent(expected))
+        self.run_and_assert(tmpdir, input_code, expected)
 
     def test_list_indirect(self, tmpdir):
-        input_code = """\
+        input_code = """
         some_list = [1,2,3]
         l is some_list
         """
-        expected = """\
+        expected = """
         some_list = [1,2,3]
         l == some_list
         """
-        self.run_and_assert(tmpdir, dedent(input_code), dedent(expected))
+        self.run_and_assert(tmpdir, input_code, expected)
 
     def test_list_lhs(self, tmpdir):
-        input_code = """\
+        input_code = """
         [1,2,3] is l
         """
-        expected = """\
+        expected = """
         [1,2,3] == l
         """
-        self.run_and_assert(tmpdir, dedent(input_code), dedent(expected))
+        self.run_and_assert(tmpdir, input_code, expected)
 
     def test_list_function(self, tmpdir):
-        input_code = """\
+        input_code = """
         l is list({1,2,3})
         """
-        expected = """\
+        expected = """
         l == list({1,2,3})
         """
-        self.run_and_assert(tmpdir, dedent(input_code), dedent(expected))
+        self.run_and_assert(tmpdir, input_code, expected)
 
     def test_dict(self, tmpdir):
-        input_code = """\
+        input_code = """
         l is {1:2}
         """
-        expected = """\
+        expected = """
         l == {1:2}
         """
-        self.run_and_assert(tmpdir, dedent(input_code), dedent(expected))
+        self.run_and_assert(tmpdir, input_code, expected)
 
     def test_dict_function(self, tmpdir):
-        input_code = """\
+        input_code = """
         l is dict({1,2,3})
         """
-        expected = """\
+        expected = """
         l == dict({1,2,3})
         """
-        self.run_and_assert(tmpdir, dedent(input_code), dedent(expected))
+        self.run_and_assert(tmpdir, input_code, expected)
 
     def test_tuple(self, tmpdir):
-        input_code = """\
+        input_code = """
         l is (1,2,3)
         """
-        expected = """\
+        expected = """
         l == (1,2,3)
         """
-        self.run_and_assert(tmpdir, dedent(input_code), dedent(expected))
+        self.run_and_assert(tmpdir, input_code, expected)
 
     def test_tuple_function(self, tmpdir):
-        input_code = """\
+        input_code = """
         l is tuple({1,2,3})
         """
-        expected = """\
+        expected = """
         l == tuple({1,2,3})
         """
-        self.run_and_assert(tmpdir, dedent(input_code), dedent(expected))
+        self.run_and_assert(tmpdir, input_code, expected)
 
     def test_set(self, tmpdir):
-        input_code = """\
+        input_code = """
         l is {1,2,3}
         """
-        expected = """\
+        expected = """
         l == {1,2,3}
         """
-        self.run_and_assert(tmpdir, dedent(input_code), dedent(expected))
+        self.run_and_assert(tmpdir, input_code, expected)
 
     def test_set_function(self, tmpdir):
-        input_code = """\
+        input_code = """
         l is set([1,2,3])
         """
-        expected = """\
+        expected = """
         l == set([1,2,3])
         """
-        self.run_and_assert(tmpdir, dedent(input_code), dedent(expected))
+        self.run_and_assert(tmpdir, input_code, expected)
 
     def test_int(self, tmpdir):
-        input_code = """\
+        input_code = """
         l is 1
         """
-        expected = """\
+        expected = """
         l == 1
         """
-        self.run_and_assert(tmpdir, dedent(input_code), dedent(expected))
+        self.run_and_assert(tmpdir, input_code, expected)
 
     def test_float(self, tmpdir):
-        input_code = """\
+        input_code = """
         l is 1.0
         """
-        expected = """\
+        expected = """
         l == 1.0
         """
-        self.run_and_assert(tmpdir, dedent(input_code), dedent(expected))
+        self.run_and_assert(tmpdir, input_code, expected)
 
     def test_imaginary(self, tmpdir):
-        input_code = """\
+        input_code = """
         l is 1j
         """
-        expected = """\
+        expected = """
         l == 1j
         """
-        self.run_and_assert(tmpdir, dedent(input_code), dedent(expected))
+        self.run_and_assert(tmpdir, input_code, expected)
 
     def test_str(self, tmpdir):
-        input_code = """\
+        input_code = """
         l is '1'
         """
-        expected = """\
+        expected = """
         l == '1'
         """
-        self.run_and_assert(tmpdir, dedent(input_code), dedent(expected))
+        self.run_and_assert(tmpdir, input_code, expected)
 
     def test_fstr(self, tmpdir):
-        input_code = """\
+        input_code = """
         l is f'1'
         """
-        expected = """\
+        expected = """
         l == f'1'
         """
-        self.run_and_assert(tmpdir, dedent(input_code), dedent(expected))
+        self.run_and_assert(tmpdir, input_code, expected)
 
     def test_concatenated_str(self, tmpdir):
-        input_code = """\
+        input_code = """
         l is '1' ',2'
         """
-        expected = """\
+        expected = """
         l == '1' ',2'
         """
-        self.run_and_assert(tmpdir, dedent(input_code), dedent(expected))
+        self.run_and_assert(tmpdir, input_code, expected)
 
     def test_negative(self, tmpdir):
-        input_code = """\
+        input_code = """
         l is not [1,2,3]
         """
-        expected = """\
+        expected = """
         l != [1,2,3]
         """
-        self.run_and_assert(tmpdir, dedent(input_code), dedent(expected))
+        self.run_and_assert(tmpdir, input_code, expected)
 
     def test_do_nothing(self, tmpdir):
-        input_code = """\
+        input_code = """
         l == [1,2,3]
         """
-        self.run_and_assert(tmpdir, dedent(input_code), dedent(input_code))
+        self.run_and_assert(tmpdir, input_code, input_code)
 
     def test_do_nothing_negative(self, tmpdir):
-        input_code = """\
+        input_code = """
         l != [1,2,3]
         """
-        self.run_and_assert(tmpdir, dedent(input_code), dedent(input_code))
+        self.run_and_assert(tmpdir, input_code, input_code)

--- a/tests/codemods/test_numpy_nan_equality.py
+++ b/tests/codemods/test_numpy_nan_equality.py
@@ -1,6 +1,5 @@
 from core_codemods.numpy_nan_equality import NumpyNanEquality
 from tests.codemods.base_codemod_test import BaseCodemodTest
-from textwrap import dedent
 
 
 class TestNumpyNanEquality(BaseCodemodTest):
@@ -10,130 +9,130 @@ class TestNumpyNanEquality(BaseCodemodTest):
         assert self.codemod.name == "numpy-nan-equality"
 
     def test_simple(self, tmpdir):
-        input_code = """\
+        input_code = """
         import numpy
         if a == numpy.nan:
             pass
         """
-        expected = """\
+        expected = """
         import numpy
         if numpy.isnan(a):
             pass
         """
-        self.run_and_assert(tmpdir, dedent(input_code), dedent(expected))
+        self.run_and_assert(tmpdir, input_code, expected)
 
     def test_simple_inequality(self, tmpdir):
-        input_code = """\
+        input_code = """
         import numpy
         if a != numpy.nan:
             pass
         """
-        expected = """\
+        expected = """
         import numpy
         if not numpy.isnan(a):
             pass
         """
-        self.run_and_assert(tmpdir, dedent(input_code), dedent(expected))
+        self.run_and_assert(tmpdir, input_code, expected)
 
     def test_simple_inequality_2(self, tmpdir):
-        input_code = """\
+        input_code = """
         import numpy
         if not (a != numpy.nan):
             pass
         """
-        expected = """\
+        expected = """
         import numpy
         if not (not numpy.isnan(a)):
             pass
         """
-        self.run_and_assert(tmpdir, dedent(input_code), dedent(expected))
+        self.run_and_assert(tmpdir, input_code, expected)
 
     def test_simple_parenthesis(self, tmpdir):
-        input_code = """\
+        input_code = """
         import numpy
         if (  a == numpy.nan  ):
             pass
         """
-        expected = """\
+        expected = """
         import numpy
         if (  numpy.isnan(a)  ):
             pass
         """
-        self.run_and_assert(tmpdir, dedent(input_code), dedent(expected))
+        self.run_and_assert(tmpdir, input_code, expected)
 
     def test_conjunction(self, tmpdir):
-        input_code = """\
+        input_code = """
         import numpy
         if a != numpy.nan and b!= numpy.nan:
             pass
         """
-        expected = """\
+        expected = """
         import numpy
         if not numpy.isnan(a) and not numpy.isnan(b):
             pass
         """
-        self.run_and_assert(tmpdir, dedent(input_code), dedent(expected), num_changes=2)
+        self.run_and_assert(tmpdir, input_code, expected, num_changes=2)
 
     def test_from_numpy(self, tmpdir):
-        input_code = """\
+        input_code = """
         from numpy import nan
         if a == nan:
             pass
         """
-        expected = """\
+        expected = """
         import numpy
 
         if numpy.isnan(a):
             pass
         """
-        self.run_and_assert(tmpdir, dedent(input_code), dedent(expected))
+        self.run_and_assert(tmpdir, input_code, expected)
 
     def test_simple_left(self, tmpdir):
-        input_code = """\
+        input_code = """
         import numpy
         if numpy.nan == a:
             pass
         """
-        expected = """\
+        expected = """
         import numpy
         if numpy.isnan(a):
             pass
         """
-        self.run_and_assert(tmpdir, dedent(input_code), dedent(expected))
+        self.run_and_assert(tmpdir, input_code, expected)
 
     def test_alias(self, tmpdir):
-        input_code = """\
+        input_code = """
         import numpy as np
         if a == np.nan:
             pass
         """
-        expected = """\
+        expected = """
         import numpy as np
         if np.isnan(a):
             pass
         """
-        self.run_and_assert(tmpdir, dedent(input_code), dedent(expected))
+        self.run_and_assert(tmpdir, input_code, expected)
 
     def test_multiple_comparisons(self, tmpdir):
-        input_code = """\
+        input_code = """
         import numpy as np
         if a == np.nan == b == c == d <= e:
             pass
         """
-        self.run_and_assert(tmpdir, dedent(input_code), dedent(input_code))
+        self.run_and_assert(tmpdir, input_code, input_code)
 
     def test_not_numpy(self, tmpdir):
-        input_code = """\
+        input_code = """
         import not_numpy as np
         if a == np.nan:
             pass
         """
-        self.run_and_assert(tmpdir, dedent(input_code), dedent(input_code))
+        self.run_and_assert(tmpdir, input_code, input_code)
 
     def test_numpy_other_operator(self, tmpdir):
-        input_code = """\
+        input_code = """
         import numpy
         if a <= numpy.nan:
             pass
         """
-        self.run_and_assert(tmpdir, dedent(input_code), dedent(input_code))
+        self.run_and_assert(tmpdir, input_code, input_code)

--- a/tests/codemods/test_remove_assertion_in_pytest_raises.py
+++ b/tests/codemods/test_remove_assertion_in_pytest_raises.py
@@ -11,14 +11,14 @@ class TestRemoveAssertionInPytestRaises(BaseCodemodTest):
         assert self.codemod.name == "remove-assertion-in-pytest-raises"
 
     def test_simple(self, tmpdir):
-        input_code = """\
+        input_code = """
         import pytest
         def foo():
             with pytest.raises(ZeroDivisionError):
                 1/0
                 assert True
         """
-        expected = """\
+        expected = """
         import pytest
         def foo():
             with pytest.raises(ZeroDivisionError):
@@ -28,14 +28,14 @@ class TestRemoveAssertionInPytestRaises(BaseCodemodTest):
         self.run_and_assert(tmpdir, input_code, expected)
 
     def test_simple_alias(self, tmpdir):
-        input_code = """\
+        input_code = """
         from pytest import raises as rise
         def foo():
             with rise(ZeroDivisionError):
                 1/0
                 assert True
         """
-        expected = """\
+        expected = """
         from pytest import raises as rise
         def foo():
             with rise(ZeroDivisionError):
@@ -45,14 +45,14 @@ class TestRemoveAssertionInPytestRaises(BaseCodemodTest):
         self.run_and_assert(tmpdir, input_code, expected)
 
     def test_simple_from_import(self, tmpdir):
-        input_code = """\
+        input_code = """
         from pytest import raises
         def foo():
             with raises(ZeroDivisionError):
                 1/0
                 assert True
         """
-        expected = """\
+        expected = """
         from pytest import raises
         def foo():
             with raises(ZeroDivisionError):
@@ -63,13 +63,13 @@ class TestRemoveAssertionInPytestRaises(BaseCodemodTest):
 
     def test_all_asserts(self, tmpdir):
         # this is more of an edge case
-        input_code = """\
+        input_code = """
         import pytest
         def foo():
             with pytest.raises(ZeroDivisionError):
                 assert True
         """
-        expected = """\
+        expected = """
         import pytest
         def foo():
             with pytest.raises(ZeroDivisionError):
@@ -79,7 +79,7 @@ class TestRemoveAssertionInPytestRaises(BaseCodemodTest):
         self.run_and_assert(tmpdir, input_code, expected)
 
     def test_multiple_raises(self, tmpdir):
-        input_code = """\
+        input_code = """
         import pytest
         def foo():
             with pytest.raises(ZeroDivisionError), pytest.raises(IndexError):
@@ -87,7 +87,7 @@ class TestRemoveAssertionInPytestRaises(BaseCodemodTest):
                 [1,2][3]
                 assert True
         """
-        expected = """\
+        expected = """
         import pytest
         def foo():
             with pytest.raises(ZeroDivisionError), pytest.raises(IndexError):
@@ -98,7 +98,7 @@ class TestRemoveAssertionInPytestRaises(BaseCodemodTest):
         self.run_and_assert(tmpdir, input_code, expected)
 
     def test_multiple_asserts(self, tmpdir):
-        input_code = """\
+        input_code = """
         import pytest
         def foo():
             with pytest.raises(ZeroDivisionError):
@@ -106,7 +106,7 @@ class TestRemoveAssertionInPytestRaises(BaseCodemodTest):
                 assert 1
                 assert 2
         """
-        expected = """\
+        expected = """
         import pytest
         def foo():
             with pytest.raises(ZeroDivisionError):
@@ -117,13 +117,13 @@ class TestRemoveAssertionInPytestRaises(BaseCodemodTest):
         self.run_and_assert(tmpdir, input_code, expected)
 
     def test_multiple_asserts_mixed_early(self, tmpdir):
-        input_code = """\
+        input_code = """
         import pytest
         def foo():
             with pytest.raises(ZeroDivisionError):
                 1/0; assert 1; assert 2
         """
-        expected = """\
+        expected = """
         import pytest
         def foo():
             with pytest.raises(ZeroDivisionError):
@@ -134,14 +134,14 @@ class TestRemoveAssertionInPytestRaises(BaseCodemodTest):
         self.run_and_assert(tmpdir, input_code, expected)
 
     def test_multiple_asserts_mixed(self, tmpdir):
-        input_code = """\
+        input_code = """
         import pytest
         def foo():
             with pytest.raises(ZeroDivisionError):
                 1/0
                 assert 1; assert 2
         """
-        expected = """\
+        expected = """
         import pytest
         def foo():
             with pytest.raises(ZeroDivisionError):
@@ -152,12 +152,12 @@ class TestRemoveAssertionInPytestRaises(BaseCodemodTest):
         self.run_and_assert(tmpdir, input_code, expected)
 
     def test_simple_suite(self, tmpdir):
-        input_code = """\
+        input_code = """
         import pytest
         def foo():
             with pytest.raises(ZeroDivisionError): 1/0; assert True
         """
-        expected = """\
+        expected = """
         import pytest
         def foo():
             with pytest.raises(ZeroDivisionError): 1/0
@@ -166,12 +166,12 @@ class TestRemoveAssertionInPytestRaises(BaseCodemodTest):
         self.run_and_assert(tmpdir, input_code, expected)
 
     def test_multiple_suite(self, tmpdir):
-        input_code = """\
+        input_code = """
         import pytest
         def foo():
             with pytest.raises(ZeroDivisionError): 1/0; assert True; assert False;
         """
-        expected = """\
+        expected = """
         import pytest
         def foo():
             with pytest.raises(ZeroDivisionError): 1/0
@@ -181,7 +181,7 @@ class TestRemoveAssertionInPytestRaises(BaseCodemodTest):
         self.run_and_assert(tmpdir, input_code, expected)
 
     def test_with_item_not_raises(self, tmpdir):
-        input_code = """\
+        input_code = """
         import pytest
         def foo():
             with pytest.raises(ZeroDivisionError), open('') as file:
@@ -191,7 +191,7 @@ class TestRemoveAssertionInPytestRaises(BaseCodemodTest):
         self.run_and_assert(tmpdir, input_code, input_code)
 
     def test_no_assertion_at_end(self, tmpdir):
-        input_code = """\
+        input_code = """
         import pytest
         def foo():
             with pytest.raises(ZeroDivisionError), open('') as file:

--- a/tests/codemods/test_remove_debug_breakpoint.py
+++ b/tests/codemods/test_remove_debug_breakpoint.py
@@ -9,13 +9,13 @@ class TestRemoveDebugBreakpoint(BaseCodemodTest):
         assert self.codemod.name == "remove-debug-breakpoint"
 
     def test_builtin_breakpoint(self, tmpdir):
-        input_code = """\
+        input_code = """
         def something():
             var = 1
             breakpoint()
         something()
         """
-        expected = """\
+        expected = """
         def something():
             var = 1
         something()
@@ -23,13 +23,13 @@ class TestRemoveDebugBreakpoint(BaseCodemodTest):
         self.run_and_assert(tmpdir, input_code, expected)
 
     def test_builtin_breakpoint_multiple_statements(self, tmpdir):
-        input_code = """\
+        input_code = """
         def something():
             var = 1
             print(var); breakpoint()
         something()
         """
-        expected = """\
+        expected = """
         def something():
             var = 1
             print(var); 
@@ -38,13 +38,13 @@ class TestRemoveDebugBreakpoint(BaseCodemodTest):
         self.run_and_assert(tmpdir, input_code, expected)
 
     def test_inline_pdb(self, tmpdir):
-        input_code = """\
+        input_code = """
         def something():
             var = 1
             import pdb; pdb.set_trace()
         something()
         """
-        expected = """\
+        expected = """
         def something():
             var = 1
         something()
@@ -52,14 +52,14 @@ class TestRemoveDebugBreakpoint(BaseCodemodTest):
         self.run_and_assert(tmpdir, input_code, expected)
 
     def test_pdb_import(self, tmpdir):
-        input_code = """\
+        input_code = """
         import pdb
         def something():
             var = 1
             pdb.set_trace()
         something()
         """
-        expected = """\
+        expected = """
         def something():
             var = 1
         something()
@@ -67,14 +67,14 @@ class TestRemoveDebugBreakpoint(BaseCodemodTest):
         self.run_and_assert(tmpdir, input_code, expected)
 
     def test_pdb_from_import(self, tmpdir):
-        input_code = """\
+        input_code = """
         from pdb import set_trace
         def something():
             var = 1
             set_trace()
         something()
         """
-        expected = """\
+        expected = """
         def something():
             var = 1
         something()
@@ -84,11 +84,11 @@ class TestRemoveDebugBreakpoint(BaseCodemodTest):
     def test_exclude_line(self, tmpdir):
         input_code = (
             expected
-        ) = """\
+        ) = """
         x = "foo"
         breakpoint()
         """
-        lines_to_exclude = [2]
+        lines_to_exclude = [3]
         self.run_and_assert(
             tmpdir,
             input_code,

--- a/tests/codemods/test_remove_module_global.py
+++ b/tests/codemods/test_remove_module_global.py
@@ -1,4 +1,3 @@
-from textwrap import dedent
 from core_codemods.remove_module_global import RemoveModuleGlobal
 from tests.codemods.base_codemod_test import BaseCodemodTest
 
@@ -10,50 +9,50 @@ class TestJwtDecodeVerify(BaseCodemodTest):
         assert self.codemod.name == "remove-module-global"
 
     def test_simple(self, tmpdir):
-        input_code = """\
+        input_code = """
         price = 25
         global price
         """
-        expected = """\
+        expected = """
         price = 25
         """
-        self.run_and_assert(tmpdir, dedent(input_code), dedent(expected))
+        self.run_and_assert(tmpdir, input_code, expected)
 
     def test_reassigned(self, tmpdir):
-        input_code = """\
+        input_code = """
         price = 25
         print("hello")
         global price
         price = 30
         """
-        expected = """\
+        expected = """
         price = 25
         print("hello")
         price = 30
         """
-        self.run_and_assert(tmpdir, dedent(input_code), dedent(expected))
+        self.run_and_assert(tmpdir, input_code, expected)
 
     def test_attr_call(self, tmpdir):
-        input_code = """\
+        input_code = """
         class Price:
             pass
         PRICE = Price()
         global PRICE
         PRICE.__repr__
         """
-        expected = """\
+        expected = """
         class Price:
             pass
         PRICE = Price()
         PRICE.__repr__
         """
-        self.run_and_assert(tmpdir, dedent(input_code), dedent(expected))
+        self.run_and_assert(tmpdir, input_code, expected)
 
     def test_correct_scope(self, tmpdir):
-        input_code = """\
+        input_code = """
         price = 25
         def change_price():
             global price
             price = 30
         """
-        self.run_and_assert(tmpdir, dedent(input_code), dedent(input_code))
+        self.run_and_assert(tmpdir, input_code, input_code)

--- a/tests/codemods/test_remove_unnecessary_f_str.py
+++ b/tests/codemods/test_remove_unnecessary_f_str.py
@@ -34,10 +34,10 @@ class TestFStr(BaseCodemodTest):
     def test_exclude_line(self, tmpdir):
         input_code = (
             expected
-        ) = """\
+        ) = """
         bad: str = f"bad" + "bad"
         """
-        lines_to_exclude = [1]
+        lines_to_exclude = [2]
         self.run_and_assert(
             tmpdir,
             input_code,

--- a/tests/codemods/test_remove_unused_imports.py
+++ b/tests/codemods/test_remove_unused_imports.py
@@ -1,7 +1,6 @@
 from pathlib import Path
 from core_codemods.remove_unused_imports import RemoveUnusedImports
 from tests.codemods.base_codemod_test import BaseCodemodTest
-from textwrap import dedent
 
 
 class TestRemoveUnusedImports(BaseCodemodTest):
@@ -84,12 +83,10 @@ a.something
         self.run_and_assert(tmpdir, before, before)
 
     def test_dont_remove_if_noqa_trailing_multiline(self, tmpdir):
-        before = dedent(
-            """\
+        before = """
         from _pytest.assertion.util import (  # noqa: F401
             format_explanation as _format_explanation,
         )"""
-        )
 
         self.run_and_assert(tmpdir, before, before)
 

--- a/tests/codemods/test_replace_flask_send_file.py
+++ b/tests/codemods/test_replace_flask_send_file.py
@@ -11,7 +11,7 @@ class TestReplaceFlaskSendFile(BaseCodemodTest):
         assert self.codemod.name == "replace-flask-send-file"
 
     def test_direct_string(self, tmpdir):
-        input_code = """\
+        input_code = """
         from flask import Flask, send_file
 
         app = Flask(__name__)
@@ -20,7 +20,7 @@ class TestReplaceFlaskSendFile(BaseCodemodTest):
         def download_file(name):
             return send_file(f'path/to/{name}.txt')
         """
-        expected = """\
+        expected = """
         from flask import Flask
         import flask
         from pathlib import Path
@@ -34,7 +34,7 @@ class TestReplaceFlaskSendFile(BaseCodemodTest):
         self.run_and_assert(tmpdir, input_code, expected)
 
     def test_direct_simple_string(self, tmpdir):
-        input_code = """\
+        input_code = """
         from flask import Flask, send_file
 
         app = Flask(__name__)
@@ -43,7 +43,7 @@ class TestReplaceFlaskSendFile(BaseCodemodTest):
         def download_file(name):
             return send_file('path/to/file.txt')
         """
-        expected = """\
+        expected = """
         from flask import Flask
         import flask
         from pathlib import Path
@@ -57,7 +57,7 @@ class TestReplaceFlaskSendFile(BaseCodemodTest):
         self.run_and_assert(tmpdir, input_code, expected)
 
     def test_direct_string_convert_arguments(self, tmpdir):
-        input_code = """\
+        input_code = """
         from flask import Flask, send_file
 
         app = Flask(__name__)
@@ -66,7 +66,7 @@ class TestReplaceFlaskSendFile(BaseCodemodTest):
         def download_file(name):
             return send_file(f'path/to/{name}.txt', None, False, download_name = True)
         """
-        expected = """\
+        expected = """
         from flask import Flask
         import flask
         from pathlib import Path
@@ -80,7 +80,7 @@ class TestReplaceFlaskSendFile(BaseCodemodTest):
         self.run_and_assert(tmpdir, input_code, expected)
 
     def test_direct_path(self, tmpdir):
-        input_code = """\
+        input_code = """
         from flask import Flask, send_file
         from pathlib import Path
 
@@ -90,7 +90,7 @@ class TestReplaceFlaskSendFile(BaseCodemodTest):
         def download_file(name):
             return send_file(Path(f'path/to/{name}.txt'))
         """
-        expected = """\
+        expected = """
         from flask import Flask
         from pathlib import Path
         import flask
@@ -104,7 +104,7 @@ class TestReplaceFlaskSendFile(BaseCodemodTest):
         self.run_and_assert(tmpdir, input_code, expected)
 
     def test_indirect_path(self, tmpdir):
-        input_code = """\
+        input_code = """
         from flask import Flask, send_file
         from pathlib import Path
 
@@ -115,7 +115,7 @@ class TestReplaceFlaskSendFile(BaseCodemodTest):
             path = Path(f'path/to/{name}.txt')
             return send_file(path)
         """
-        expected = """\
+        expected = """
         from flask import Flask
         from pathlib import Path
         import flask
@@ -130,7 +130,7 @@ class TestReplaceFlaskSendFile(BaseCodemodTest):
         self.run_and_assert(tmpdir, input_code, expected)
 
     def test_indirect_path_alias(self, tmpdir):
-        input_code = """\
+        input_code = """
         from flask import Flask, send_file as send
         from pathlib import Path
 
@@ -141,7 +141,7 @@ class TestReplaceFlaskSendFile(BaseCodemodTest):
             path = Path(f'path/to/{name}.txt')
             return send(path)
         """
-        expected = """\
+        expected = """
         from flask import Flask
         from pathlib import Path
         import flask
@@ -156,7 +156,7 @@ class TestReplaceFlaskSendFile(BaseCodemodTest):
         self.run_and_assert(tmpdir, input_code, expected)
 
     def test_indirect_string(self, tmpdir):
-        input_code = """\
+        input_code = """
         from flask import Flask, send_file
 
         app = Flask(__name__)
@@ -166,7 +166,7 @@ class TestReplaceFlaskSendFile(BaseCodemodTest):
             path = f'path/to/{name}.txt'
             return send_file(path)
         """
-        expected = """\
+        expected = """
         from flask import Flask
         import flask
         from pathlib import Path
@@ -181,7 +181,7 @@ class TestReplaceFlaskSendFile(BaseCodemodTest):
         self.run_and_assert(tmpdir, input_code, expected)
 
     def test_unknown_type(self, tmpdir):
-        input_code = """\
+        input_code = """
         from flask import Flask, send_file
 
         app = Flask(__name__)

--- a/tests/codemods/test_secure_flask_cookie.py
+++ b/tests/codemods/test_secure_flask_cookie.py
@@ -1,7 +1,6 @@
 import pytest
 from core_codemods.secure_flask_cookie import SecureFlaskCookie
 from tests.codemods.base_codemod_test import BaseSemgrepCodemodTest
-from textwrap import dedent
 
 each_func = pytest.mark.parametrize("func", ["make_response", "Response"])
 
@@ -14,53 +13,53 @@ class TestSecureFlaskCookie(BaseSemgrepCodemodTest):
 
     @each_func
     def test_import(self, tmpdir, func):
-        input_code = f"""\
+        input_code = f"""
         import flask
 
         response = flask.{func}()
         var = "hello"
         response.set_cookie("name", "value")
         """
-        expexted_output = f"""\
+        expexted_output = f"""
         import flask
 
         response = flask.{func}()
         var = "hello"
         response.set_cookie("name", "value", secure=True, httponly=True, samesite='Lax')
         """
-        self.run_and_assert(tmpdir, dedent(input_code), dedent(expexted_output))
+        self.run_and_assert(tmpdir, input_code, expexted_output)
 
     @each_func
     def test_from_import(self, tmpdir, func):
-        input_code = f"""\
+        input_code = f"""
         from flask import {func}
 
         response = {func}()
         var = "hello"
         response.set_cookie("name", "value")
         """
-        expexted_output = f"""\
+        expexted_output = f"""
         from flask import {func}
 
         response = {func}()
         var = "hello"
         response.set_cookie("name", "value", secure=True, httponly=True, samesite='Lax')
         """
-        self.run_and_assert(tmpdir, dedent(input_code), dedent(expexted_output))
+        self.run_and_assert(tmpdir, input_code, expexted_output)
 
     @each_func
     def test_import_alias(self, tmpdir, func):
-        input_code = f"""\
+        input_code = f"""
         from flask import {func} as flask_resp
         var = "hello"
         flask_resp().set_cookie("name", "value")
         """
-        expexted_output = f"""\
+        expexted_output = f"""
         from flask import {func} as flask_resp
         var = "hello"
         flask_resp().set_cookie("name", "value", secure=True, httponly=True, samesite='Lax')
         """
-        self.run_and_assert(tmpdir, dedent(input_code), dedent(expexted_output))
+        self.run_and_assert(tmpdir, input_code, expexted_output)
 
     @pytest.mark.parametrize(
         "input_args,expected_args",
@@ -97,18 +96,18 @@ class TestSecureFlaskCookie(BaseSemgrepCodemodTest):
     )
     @each_func
     def test_verify_variations(self, tmpdir, func, input_args, expected_args):
-        input_code = f"""\
+        input_code = f"""
         import flask
 
         response = flask.{func}()
         var = "hello"
         response.set_cookie("name", "value", {input_args})
         """
-        expexted_output = f"""\
+        expexted_output = f"""
         import flask
 
         response = flask.{func}()
         var = "hello"
         response.set_cookie("name", "value", {expected_args})
         """
-        self.run_and_assert(tmpdir, dedent(input_code), dedent(expexted_output))
+        self.run_and_assert(tmpdir, input_code, expexted_output)

--- a/tests/codemods/test_secure_flask_session_config.py
+++ b/tests/codemods/test_secure_flask_session_config.py
@@ -1,7 +1,6 @@
 import pytest
 from core_codemods.secure_flask_session_config import SecureFlaskSessionConfig
 from tests.codemods.base_codemod_test import BaseCodemodTest
-from textwrap import dedent
 
 
 class TestSecureFlaskSessionConfig(BaseCodemodTest):
@@ -11,45 +10,45 @@ class TestSecureFlaskSessionConfig(BaseCodemodTest):
         assert self.codemod.name == "secure-flask-session-configuration"
 
     def test_no_flask_app(self, tmpdir):
-        input_code = """\
+        input_code = """
         import flask
 
         response = flask.Response()
         var = "hello"
         response.set_cookie("name", "value")
         """
-        self.run_and_assert(tmpdir, dedent(input_code), dedent(input_code))
+        self.run_and_assert(tmpdir, input_code, input_code)
 
     def test_app_defined_separate_module(self, tmpdir):
         # TODO: test this as an integration test with two real modules
-        input_code = """\
+        input_code = """
         from my_app_module import app
 
         app.config["SESSION_COOKIE_SECURE"] = False
         """
-        self.run_and_assert(tmpdir, dedent(input_code), dedent(input_code))
+        self.run_and_assert(tmpdir, input_code, input_code)
 
     def test_app_not_assigned(self, tmpdir):
-        input_code = """\
+        input_code = """
         import flask
 
         flask.Flask(__name__)
         print(1)
         """
-        self.run_and_assert(tmpdir, dedent(input_code), dedent(input_code))
+        self.run_and_assert(tmpdir, input_code, input_code)
 
     def test_app_accessed_config_not_called(self, tmpdir):
-        input_code = """\
+        input_code = """
         import flask
 
         app = flask.Flask(__name__)
         app.secret_key = "dev"
         # more code
         """
-        self.run_and_assert(tmpdir, dedent(input_code), dedent(input_code))
+        self.run_and_assert(tmpdir, input_code, input_code)
 
     def test_app_update_no_keyword(self, tmpdir):
-        input_code = """\
+        input_code = """
         import flask
 
         from flask import Flask
@@ -58,61 +57,61 @@ class TestSecureFlaskSessionConfig(BaseCodemodTest):
             app.secret_key = "dev"
             app.config.update(test_config)
         """
-        self.run_and_assert(tmpdir, dedent(input_code), dedent(input_code))
+        self.run_and_assert(tmpdir, input_code, input_code)
 
     def test_from_import(self, tmpdir):
-        input_code = """\
+        input_code = """
         from flask import Flask
 
         app = Flask(__name__)
         app.secret_key = "dev"
         app.config.update(SESSION_COOKIE_SECURE=False)
         """
-        expexted_output = """\
+        expexted_output = """
         from flask import Flask
 
         app = Flask(__name__)
         app.secret_key = "dev"
         app.config.update(SESSION_COOKIE_SECURE=True)
         """
-        self.run_and_assert(tmpdir, dedent(input_code), dedent(expexted_output))
+        self.run_and_assert(tmpdir, input_code, expexted_output)
 
     def test_import_alias(self, tmpdir):
-        input_code = """\
+        input_code = """
         from flask import Flask as flask_app
         app = flask_app(__name__)
         app.secret_key = "dev"
         # more code
         app.config.update(SESSION_COOKIE_SECURE=False)
         """
-        expexted_output = """\
+        expexted_output = """
         from flask import Flask as flask_app
         app = flask_app(__name__)
         app.secret_key = "dev"
         # more code
         app.config.update(SESSION_COOKIE_SECURE=True)
         """
-        self.run_and_assert(tmpdir, dedent(input_code), dedent(expexted_output))
+        self.run_and_assert(tmpdir, input_code, expexted_output)
 
     def test_annotated_assign(self, tmpdir):
-        input_code = """\
+        input_code = """
         import flask
         app: flask.Flask = flask.Flask(__name__)
         app.secret_key = "dev"
         # more code
         app.config.update(SESSION_COOKIE_SECURE=False)
         """
-        expexted_output = """\
+        expexted_output = """
         import flask
         app: flask.Flask = flask.Flask(__name__)
         app.secret_key = "dev"
         # more code
         app.config.update(SESSION_COOKIE_SECURE=True)
         """
-        self.run_and_assert(tmpdir, dedent(input_code), dedent(expexted_output))
+        self.run_and_assert(tmpdir, input_code, expexted_output)
 
     def test_other_assignment_type(self, tmpdir):
-        input_code = """\
+        input_code = """
         import flask
         class AppStore:
             pass
@@ -122,7 +121,7 @@ class TestSecureFlaskSessionConfig(BaseCodemodTest):
         # more code
         store.app.config.update(SESSION_COOKIE_SECURE=False)
         """
-        self.run_and_assert(tmpdir, dedent(input_code), dedent(input_code))
+        self.run_and_assert(tmpdir, input_code, input_code)
 
     @pytest.mark.parametrize(
         "config_lines,expected_config_lines,num_changes",
@@ -226,12 +225,12 @@ app.secret_key = "dev"
 {expected_config_lines}
 """
         self.run_and_assert(
-            tmpdir, dedent(input_code), dedent(expected_output), num_changes=num_changes
+            tmpdir, input_code, expected_output, num_changes=num_changes
         )
 
     @pytest.mark.skip()
     def test_func_scope(self, tmpdir):
-        input_code = """\
+        input_code = """
         from flask import Flask
         app = Flask(__name__)
 
@@ -246,8 +245,8 @@ app.secret_key = "dev"
             configure()
             app.run()
         """
-        expexted_output = """\
+        expexted_output = """
         # TODO correct fix could be multiple options,
         # either within configure() call or after it's called
         """
-        self.run_and_assert(tmpdir, dedent(input_code), dedent(expexted_output))
+        self.run_and_assert(tmpdir, input_code, expexted_output)

--- a/tests/codemods/test_sonar_django_json_response_type.py
+++ b/tests/codemods/test_sonar_django_json_response_type.py
@@ -13,7 +13,7 @@ class TestDjangoJsonResponseType(BaseSASTCodemodTest):
         assert self.codemod.name == "django-json-response-type-S5131"
 
     def test_simple(self, tmpdir):
-        input_code = """\
+        input_code = """
         from django.http import HttpResponse
         import json
 
@@ -21,7 +21,7 @@ class TestDjangoJsonResponseType(BaseSASTCodemodTest):
             json_response = json.dumps({ "user_input": request.GET.get("input") })
             return HttpResponse(json_response)
         """
-        expected = """\
+        expected = """
         from django.http import HttpResponse
         import json
 
@@ -35,8 +35,8 @@ class TestDjangoJsonResponseType(BaseSASTCodemodTest):
                     "rule": "pythonsecurity:S5131",
                     "component": f"{tmpdir / 'code.py'}",
                     "textRange": {
-                        "startLine": 6,
-                        "endLine": 6,
+                        "startLine": 7,
+                        "endLine": 7,
                         "startOffset": 12,
                         "endOffset": 39,
                     },

--- a/tests/codemods/test_sonar_django_receiver_on_top.py
+++ b/tests/codemods/test_sonar_django_receiver_on_top.py
@@ -1,7 +1,6 @@
 import json
 from core_codemods.sonar.sonar_django_receiver_on_top import SonarDjangoReceiverOnTop
 from tests.codemods.base_codemod_test import BaseSASTCodemodTest
-from textwrap import dedent
 
 
 class TestSonarDjangoReceiverOnTop(BaseSASTCodemodTest):
@@ -12,7 +11,7 @@ class TestSonarDjangoReceiverOnTop(BaseSASTCodemodTest):
         assert self.codemod.name == "django-receiver-on-top-S6552"
 
     def test_simple(self, tmpdir):
-        input_code = """\
+        input_code = """
         from django.dispatch import receiver
 
         @csrf_exempt
@@ -20,7 +19,7 @@ class TestSonarDjangoReceiverOnTop(BaseSASTCodemodTest):
         def foo():
             pass
         """
-        expected = """\
+        expected = """
         from django.dispatch import receiver
 
         @receiver(request_finished)
@@ -34,14 +33,12 @@ class TestSonarDjangoReceiverOnTop(BaseSASTCodemodTest):
                     "rule": "python:S6552",
                     "component": f"{tmpdir / 'code.py'}",
                     "textRange": {
-                        "startLine": 4,
-                        "endLine": 4,
+                        "startLine": 5,
+                        "endLine": 5,
                         "startOffset": 1,
                         "endOffset": 27,
                     },
                 }
             ]
         }
-        self.run_and_assert(
-            tmpdir, dedent(input_code), dedent(expected), results=json.dumps(issues)
-        )
+        self.run_and_assert(tmpdir, input_code, expected, results=json.dumps(issues))

--- a/tests/codemods/test_sonar_exception_without_raise.py
+++ b/tests/codemods/test_sonar_exception_without_raise.py
@@ -1,7 +1,6 @@
 import json
 from core_codemods.sonar.sonar_exception_without_raise import SonarExceptionWithoutRaise
 from tests.codemods.base_codemod_test import BaseSASTCodemodTest
-from textwrap import dedent
 
 
 class TestSonarExceptionWithoutRaise(BaseSASTCodemodTest):
@@ -12,10 +11,10 @@ class TestSonarExceptionWithoutRaise(BaseSASTCodemodTest):
         assert self.codemod.name == "exception-without-raise-S3984"
 
     def test_simple(self, tmpdir):
-        input_code = """\
+        input_code = """
         ValueError
         """
-        expected = """\
+        expected = """
         raise ValueError
         """
         issues = {
@@ -24,14 +23,12 @@ class TestSonarExceptionWithoutRaise(BaseSASTCodemodTest):
                     "rule": "python:S3984",
                     "component": f"{tmpdir / 'code.py'}",
                     "textRange": {
-                        "startLine": 1,
-                        "endLine": 1,
+                        "startLine": 2,
+                        "endLine": 2,
                         "startOffset": 1,
                         "endOffset": 10,
                     },
                 }
             ]
         }
-        self.run_and_assert(
-            tmpdir, dedent(input_code), dedent(expected), results=json.dumps(issues)
-        )
+        self.run_and_assert(tmpdir, input_code, expected, results=json.dumps(issues))

--- a/tests/codemods/test_sonar_fix_assert_tuple.py
+++ b/tests/codemods/test_sonar_fix_assert_tuple.py
@@ -11,10 +11,10 @@ class TestSonarFixAssertTuple(BaseSASTCodemodTest):
         assert self.codemod.name == "fix-assert-tuple-S5905"
 
     def test_simple(self, tmpdir):
-        input_code = """\
+        input_code = """
         assert (1,2,3)
         """
-        expected_output = """\
+        expected_output = """
         assert 1
         assert 2
         assert 3
@@ -25,8 +25,8 @@ class TestSonarFixAssertTuple(BaseSASTCodemodTest):
                     "rule": "python:S5905",
                     "component": f"{tmpdir / 'code.py'}",
                     "textRange": {
-                        "startLine": 1,
-                        "endLine": 1,
+                        "startLine": 2,
+                        "endLine": 2,
                         "startOffset": 8,
                         "endOffset": 15,
                     },

--- a/tests/codemods/test_sonar_flask_json_response_type.py
+++ b/tests/codemods/test_sonar_flask_json_response_type.py
@@ -13,7 +13,7 @@ class TestSonarFlaskJsonResponseType(BaseSASTCodemodTest):
         assert self.codemod.name == "flask-json-response-type-S5131"
 
     def test_simple(self, tmpdir):
-        input_code = """\
+        input_code = """
         from flask import make_response, Flask
         import json
 
@@ -24,7 +24,7 @@ class TestSonarFlaskJsonResponseType(BaseSASTCodemodTest):
             json_response = json.dumps({ "user_input": request.GET.get("input") })
             return make_response(json_response)
         """
-        expected = """\
+        expected = """
         from flask import make_response, Flask
         import json
 
@@ -41,8 +41,8 @@ class TestSonarFlaskJsonResponseType(BaseSASTCodemodTest):
                     "rule": "pythonsecurity:S5131",
                     "component": f"{tmpdir / 'code.py'}",
                     "textRange": {
-                        "startLine": 9,
-                        "endLine": 9,
+                        "startLine": 10,
+                        "endLine": 10,
                         "startOffset": 11,
                         "endOffset": 39,
                     },

--- a/tests/codemods/test_sonar_literal_or_new_object_identity.py
+++ b/tests/codemods/test_sonar_literal_or_new_object_identity.py
@@ -3,7 +3,6 @@ from core_codemods.sonar.sonar_literal_or_new_object_identity import (
     SonarLiteralOrNewObjectIdentity,
 )
 from tests.codemods.base_codemod_test import BaseSASTCodemodTest
-from textwrap import dedent
 
 
 class TestSonarLiteralOrNewObjectIdentity(BaseSASTCodemodTest):
@@ -14,10 +13,10 @@ class TestSonarLiteralOrNewObjectIdentity(BaseSASTCodemodTest):
         assert self.codemod.name == "literal-or-new-object-identity-S5796"
 
     def test_list(self, tmpdir):
-        input_code = """\
+        input_code = """
         l is [1,2,3]
         """
-        expected = """\
+        expected = """
         l == [1,2,3]
         """
         issues = {
@@ -26,14 +25,12 @@ class TestSonarLiteralOrNewObjectIdentity(BaseSASTCodemodTest):
                     "rule": "python:S5796",
                     "component": f"{tmpdir / 'code.py'}",
                     "textRange": {
-                        "startLine": 1,
-                        "endLine": 1,
+                        "startLine": 2,
+                        "endLine": 2,
                         "startOffset": 2,
                         "endOffset": 4,
                     },
                 }
             ]
         }
-        self.run_and_assert(
-            tmpdir, dedent(input_code), dedent(expected), results=json.dumps(issues)
-        )
+        self.run_and_assert(tmpdir, input_code, expected, results=json.dumps(issues))

--- a/tests/codemods/test_sonar_numpy_nan_equality.py
+++ b/tests/codemods/test_sonar_numpy_nan_equality.py
@@ -11,12 +11,12 @@ class TestSonarNumpyNanEquality(BaseSASTCodemodTest):
         assert self.codemod.name == "numpy-nan-equality-S6725"
 
     def test_simple(self, tmpdir):
-        input_code = """\
+        input_code = """
         import numpy
         if a == numpy.nan:
             pass
         """
-        expected = """\
+        expected = """
         import numpy
         if numpy.isnan(a):
             pass
@@ -27,8 +27,8 @@ class TestSonarNumpyNanEquality(BaseSASTCodemodTest):
                     "rule": "python:S6725",
                     "component": f"{tmpdir / 'code.py'}",
                     "textRange": {
-                        "startLine": 2,
-                        "endLine": 2,
+                        "startLine": 3,
+                        "endLine": 3,
                         "startOffset": 3,
                         "endOffset": 17,
                     },

--- a/tests/codemods/test_sonar_remove_assertion_in_pytest_raises.py
+++ b/tests/codemods/test_sonar_remove_assertion_in_pytest_raises.py
@@ -13,14 +13,14 @@ class TestRemoveAssertionInPytestRaises(BaseSASTCodemodTest):
         assert self.codemod.name == "remove-assertion-in-pytest-raises-S5915"
 
     def test_simple(self, tmpdir):
-        input_code = """\
+        input_code = """
         import pytest
         def foo():
             with pytest.raises(ZeroDivisionError):
                 1/0
                 assert True
         """
-        expected = """\
+        expected = """
         import pytest
         def foo():
             with pytest.raises(ZeroDivisionError):
@@ -33,8 +33,8 @@ class TestRemoveAssertionInPytestRaises(BaseSASTCodemodTest):
                     "rule": "python:S5915",
                     "component": f"{tmpdir / 'code.py'}",
                     "textRange": {
-                        "startLine": 5,
-                        "endLine": 5,
+                        "startLine": 6,
+                        "endLine": 6,
                         "startOffset": 8,
                         "endOffset": 19,
                     },

--- a/tests/codemods/test_sql_parameterization.py
+++ b/tests/codemods/test_sql_parameterization.py
@@ -1,6 +1,5 @@
 from core_codemods.sql_parameterization import SQLQueryParameterization
 from tests.codemods.base_codemod_test import BaseCodemodTest
-from textwrap import dedent
 
 
 class TestSQLQueryParameterization(BaseCodemodTest):
@@ -10,7 +9,7 @@ class TestSQLQueryParameterization(BaseCodemodTest):
         assert self.codemod.name == "sql-parameterization"
 
     def test_simple(self, tmpdir):
-        input_code = """\
+        input_code = """
         import sqlite3
 
         name = input()
@@ -18,7 +17,7 @@ class TestSQLQueryParameterization(BaseCodemodTest):
         cursor = connection.cursor()
         cursor.execute("SELECT * from USERS WHERE name ='" + name + "'")
         """
-        expected = """\
+        expected = """
         import sqlite3
 
         name = input()
@@ -26,10 +25,10 @@ class TestSQLQueryParameterization(BaseCodemodTest):
         cursor = connection.cursor()
         cursor.execute("SELECT * from USERS WHERE name =?", (name, ))
         """
-        self.run_and_assert(tmpdir, dedent(input_code), dedent(expected))
+        self.run_and_assert(tmpdir, input_code, expected)
 
     def test_multiple(self, tmpdir):
-        input_code = """\
+        input_code = """
         import sqlite3
 
         name = input()
@@ -38,7 +37,7 @@ class TestSQLQueryParameterization(BaseCodemodTest):
         cursor = connection.cursor()
         cursor.execute("SELECT * from USERS WHERE name ='" + name + r"' AND phone ='" + phone + "'" )
         """
-        expected = """\
+        expected = """
         import sqlite3
 
         name = input()
@@ -47,10 +46,10 @@ class TestSQLQueryParameterization(BaseCodemodTest):
         cursor = connection.cursor()
         cursor.execute("SELECT * from USERS WHERE name =?" + r" AND phone =?",  (name, phone, ))
         """
-        self.run_and_assert(tmpdir, dedent(input_code), dedent(expected))
+        self.run_and_assert(tmpdir, input_code, expected)
 
     def test_simple_with_quotes_in_middle(self, tmpdir):
-        input_code = """\
+        input_code = """
         import sqlite3
 
         name = input()
@@ -58,7 +57,7 @@ class TestSQLQueryParameterization(BaseCodemodTest):
         cursor = connection.cursor()
         cursor.execute("SELECT * from USERS WHERE name ='user_" + name + r"_system'")
         """
-        expected = """\
+        expected = """
         import sqlite3
 
         name = input()
@@ -66,10 +65,10 @@ class TestSQLQueryParameterization(BaseCodemodTest):
         cursor = connection.cursor()
         cursor.execute("SELECT * from USERS WHERE name =?", ('user_{0}{1}'.format(name, r"_system"), ))
         """
-        self.run_and_assert(tmpdir, dedent(input_code), dedent(expected))
+        self.run_and_assert(tmpdir, input_code, expected)
 
     def test_can_deal_with_multiple_variables(self, tmpdir):
-        input_code = """\
+        input_code = """
         import sqlite3
 
         def foo(self, cursor, name, phone):
@@ -80,7 +79,7 @@ class TestSQLQueryParameterization(BaseCodemodTest):
             return cursor.execute(a + b + c)
         """
 
-        expected = """\
+        expected = """
         import sqlite3
 
         def foo(self, cursor, name, phone):
@@ -90,10 +89,10 @@ class TestSQLQueryParameterization(BaseCodemodTest):
             c = " AND phone = ?"
             return cursor.execute(a + b + c, (name, phone, ))
         """
-        self.run_and_assert(tmpdir, dedent(input_code), dedent(expected))
+        self.run_and_assert(tmpdir, input_code, expected)
 
     def test_simple_if(self, tmpdir):
-        input_code = """\
+        input_code = """
         import sqlite3
 
         name = input()
@@ -101,7 +100,7 @@ class TestSQLQueryParameterization(BaseCodemodTest):
         cursor = connection.cursor()
         cursor.execute("SELECT * from USERS WHERE name ='" + ('Jenny' if True else name) + "'")
         """
-        expected = """\
+        expected = """
         import sqlite3
 
         name = input()
@@ -109,10 +108,10 @@ class TestSQLQueryParameterization(BaseCodemodTest):
         cursor = connection.cursor()
         cursor.execute("SELECT * from USERS WHERE name =?", (('Jenny' if True else name), ))
         """
-        self.run_and_assert(tmpdir, dedent(input_code), dedent(expected))
+        self.run_and_assert(tmpdir, input_code, expected)
 
     def test_multiple_escaped_quote(self, tmpdir):
-        input_code = """\
+        input_code = """
         import sqlite3
 
         name = input()
@@ -121,7 +120,7 @@ class TestSQLQueryParameterization(BaseCodemodTest):
         cursor = connection.cursor()
         cursor.execute('SELECT * from USERS WHERE name =\\'' + name + '\\' AND phone =\\'' + phone + '\\'' )
         """
-        expected = """\
+        expected = """
         import sqlite3
 
         name = input()
@@ -130,10 +129,10 @@ class TestSQLQueryParameterization(BaseCodemodTest):
         cursor = connection.cursor()
         cursor.execute('SELECT * from USERS WHERE name =?' + ' AND phone =?',  (name, phone, ))
         """
-        self.run_and_assert(tmpdir, dedent(input_code), dedent(expected))
+        self.run_and_assert(tmpdir, input_code, expected)
 
     def test_simple_concatenated_strings(self, tmpdir):
-        input_code = """\
+        input_code = """
         import sqlite3
 
         name = input()
@@ -141,7 +140,7 @@ class TestSQLQueryParameterization(BaseCodemodTest):
         cursor = connection.cursor()
         cursor.execute("SELECT * from USERS" "WHERE name ='" + name + "'")
         """
-        expected = """\
+        expected = """
         import sqlite3
 
         name = input()
@@ -149,14 +148,14 @@ class TestSQLQueryParameterization(BaseCodemodTest):
         cursor = connection.cursor()
         cursor.execute("SELECT * from USERS" "WHERE name =?", (name, ))
         """
-        self.run_and_assert(tmpdir, dedent(input_code), dedent(expected))
+        self.run_and_assert(tmpdir, input_code, expected)
 
 
 class TestSQLQueryParameterizationFormattedString(BaseCodemodTest):
     codemod = SQLQueryParameterization
 
     def test_formatted_string_simple(self, tmpdir):
-        input_code = """\
+        input_code = """
         import sqlite3
 
         name = input()
@@ -164,7 +163,7 @@ class TestSQLQueryParameterizationFormattedString(BaseCodemodTest):
         cursor = connection.cursor()
         cursor.execute(f"SELECT * from USERS WHERE name='{name}'")
         """
-        expected = """\
+        expected = """
         import sqlite3
 
         name = input()
@@ -172,10 +171,10 @@ class TestSQLQueryParameterizationFormattedString(BaseCodemodTest):
         cursor = connection.cursor()
         cursor.execute(f"SELECT * from USERS WHERE name=?", (name, ))
         """
-        self.run_and_assert(tmpdir, dedent(input_code), dedent(expected))
+        self.run_and_assert(tmpdir, input_code, expected)
 
     def test_formatted_string_quote_in_middle(self, tmpdir):
-        input_code = """\
+        input_code = """
         import sqlite3
 
         name = input()
@@ -183,7 +182,7 @@ class TestSQLQueryParameterizationFormattedString(BaseCodemodTest):
         cursor = connection.cursor()
         cursor.execute(f"SELECT * from USERS WHERE name='user_{name}_admin'")
         """
-        expected = """\
+        expected = """
         import sqlite3
 
         name = input()
@@ -191,10 +190,10 @@ class TestSQLQueryParameterizationFormattedString(BaseCodemodTest):
         cursor = connection.cursor()
         cursor.execute(f"SELECT * from USERS WHERE name=?", ('user_{0}_admin'.format(name), ))
         """
-        self.run_and_assert(tmpdir, dedent(input_code), dedent(expected))
+        self.run_and_assert(tmpdir, input_code, expected)
 
     def test_formatted_string_with_literal(self, tmpdir):
-        input_code = """\
+        input_code = """
         import sqlite3
 
         name = input()
@@ -202,7 +201,7 @@ class TestSQLQueryParameterizationFormattedString(BaseCodemodTest):
         cursor = connection.cursor()
         cursor.execute(f"SELECT * from USERS WHERE name='{name}_{1+2}'")
         """
-        expected = """\
+        expected = """
         import sqlite3
 
         name = input()
@@ -210,10 +209,10 @@ class TestSQLQueryParameterizationFormattedString(BaseCodemodTest):
         cursor = connection.cursor()
         cursor.execute(f"SELECT * from USERS WHERE name=?", ('{0}_{1}'.format(name, 1+2), ))
         """
-        self.run_and_assert(tmpdir, dedent(input_code), dedent(expected))
+        self.run_and_assert(tmpdir, input_code, expected)
 
     def test_formatted_string_nested(self, tmpdir):
-        input_code = """\
+        input_code = """
         import sqlite3
 
         name = input()
@@ -221,7 +220,7 @@ class TestSQLQueryParameterizationFormattedString(BaseCodemodTest):
         cursor = connection.cursor()
         cursor.execute(f"SELECT * from USERS WHERE name={f"'{name}'"}")
         """
-        expected = """\
+        expected = """
         import sqlite3
 
         name = input()
@@ -229,10 +228,10 @@ class TestSQLQueryParameterizationFormattedString(BaseCodemodTest):
         cursor = connection.cursor()
         cursor.execute(f"SELECT * from USERS WHERE name={f"?"}", (name, ))
         """
-        self.run_and_assert(tmpdir, dedent(input_code), dedent(expected))
+        self.run_and_assert(tmpdir, input_code, expected)
 
     def test_formatted_string_concat_mixed(self, tmpdir):
-        input_code = """\
+        input_code = """
         import sqlite3
 
         name = input()
@@ -240,7 +239,7 @@ class TestSQLQueryParameterizationFormattedString(BaseCodemodTest):
         cursor = connection.cursor()
         cursor.execute("SELECT * from USERS WHERE name='" + f"{name}_{b'123'}" "'")
         """
-        expected = """\
+        expected = """
         import sqlite3
 
         name = input()
@@ -248,10 +247,10 @@ class TestSQLQueryParameterizationFormattedString(BaseCodemodTest):
         cursor = connection.cursor()
         cursor.execute("SELECT * from USERS WHERE name=?", ('{0}_{1}'.format(name, b'123'), ))
         """
-        self.run_and_assert(tmpdir, dedent(input_code), dedent(expected))
+        self.run_and_assert(tmpdir, input_code, expected)
 
     def test_multiple_expressions_injection(self, tmpdir):
-        input_code = """\
+        input_code = """
         import sqlite3
 
         name = input()
@@ -259,7 +258,7 @@ class TestSQLQueryParameterizationFormattedString(BaseCodemodTest):
         cursor = connection.cursor()
         cursor.execute("SELECT * from USERS WHERE name ='" + name + "_username" + "'")
         """
-        expected = """\
+        expected = """
         import sqlite3
 
         name = input()
@@ -267,7 +266,7 @@ class TestSQLQueryParameterizationFormattedString(BaseCodemodTest):
         cursor = connection.cursor()
         cursor.execute("SELECT * from USERS WHERE name =?", ('{0}_username'.format(name), ))
         """
-        self.run_and_assert(tmpdir, dedent(input_code), dedent(expected))
+        self.run_and_assert(tmpdir, input_code, expected)
 
 
 class TestSQLQueryParameterizationNegative(BaseCodemodTest):
@@ -275,7 +274,7 @@ class TestSQLQueryParameterizationNegative(BaseCodemodTest):
 
     # negative tests below
     def test_no_sql_keyword(self, tmpdir):
-        input_code = """\
+        input_code = """
         import sqlite3
 
         def foo(self, cursor, name, phone):
@@ -285,50 +284,50 @@ class TestSQLQueryParameterizationNegative(BaseCodemodTest):
             c = "' AND phone = '" + phone + "'"
             return cursor.execute(a + b + c)
         """
-        self.run_and_assert(tmpdir, dedent(input_code), dedent(input_code))
+        self.run_and_assert(tmpdir, input_code, input_code)
 
     def test_wont_mess_with_byte_strings(self, tmpdir):
-        input_code = """\
+        input_code = """
         import sqlite3
 
         connection = sqlite3.connect("my_db.db")
         cursor = connection.cursor()
         cursor.execute("SELECT * from USERS WHERE " + b"name ='" + str(1234) + b"'")
         """
-        self.run_and_assert(tmpdir, dedent(input_code), dedent(input_code))
+        self.run_and_assert(tmpdir, input_code, input_code)
 
     def test_wont_parameterize_literals(self, tmpdir):
-        input_code = """\
+        input_code = """
         import sqlite3
 
         connection = sqlite3.connect("my_db.db")
         cursor = connection.cursor()
         cursor.execute("SELECT * from USERS WHERE name ='" + str(1234) + "'")
         """
-        self.run_and_assert(tmpdir, dedent(input_code), dedent(input_code))
+        self.run_and_assert(tmpdir, input_code, input_code)
 
     def test_wont_parameterize_literals_if(self, tmpdir):
-        input_code = """\
+        input_code = """
         import sqlite3
 
         connection = sqlite3.connect("my_db.db")
         cursor = connection.cursor()
         cursor.execute("SELECT * from USERS WHERE name ='" + ('Jenny' if True else 'Lorelei') + "'")
         """
-        self.run_and_assert(tmpdir, dedent(input_code), dedent(input_code))
+        self.run_and_assert(tmpdir, input_code, input_code)
 
     def test_will_ignore_escaped_quote(self, tmpdir):
-        input_code = """\
+        input_code = """
         import sqlite3
 
         connection = sqlite3.connect("my_db.db")
         cursor = connection.cursor()
         cursor.execute("SELECT * from USERS WHERE name ='Jenny\'s username'")
         """
-        self.run_and_assert(tmpdir, dedent(input_code), dedent(input_code))
+        self.run_and_assert(tmpdir, input_code, input_code)
 
     def test_already_has_parameters(self, tmpdir):
-        input_code = """\
+        input_code = """
         import sqlite3
 
         def foo(self, cursor, name, phone):
@@ -338,11 +337,11 @@ class TestSQLQueryParameterizationNegative(BaseCodemodTest):
             c = "' AND phone = ?"
             return cursor.execute(a + b + c, (phone,))
         """
-        self.run_and_assert(tmpdir, dedent(input_code), dedent(input_code))
+        self.run_and_assert(tmpdir, input_code, input_code)
 
     def test_wont_change_class_attribute(self, tmpdir):
         # query may be accesed from outside the module by importing A
-        input_code = """\
+        input_code = """
         import sqlite3
 
 
@@ -353,11 +352,11 @@ class TestSQLQueryParameterizationNegative(BaseCodemodTest):
             def foo(self, name, cursor):
                 return cursor.execute(query + name + "'")
         """
-        self.run_and_assert(tmpdir, dedent(input_code), dedent(input_code))
+        self.run_and_assert(tmpdir, input_code, input_code)
 
     def test_wont_change_module_variable(self, tmpdir):
         # query may be accesed from outside the module by importing it
-        input_code = """\
+        input_code = """
         import sqlite3
 
         query = "SELECT * from USERS WHERE name ='"
@@ -365,4 +364,4 @@ class TestSQLQueryParameterizationNegative(BaseCodemodTest):
         def foo(name, cursor):
             return cursor.execute(query + name + "'")
         """
-        self.run_and_assert(tmpdir, dedent(input_code), dedent(input_code))
+        self.run_and_assert(tmpdir, input_code, input_code)

--- a/tests/codemods/test_subprocess_shell_false.py
+++ b/tests/codemods/test_subprocess_shell_false.py
@@ -56,11 +56,11 @@ class TestSubprocessShellFalse(BaseCodemodTest):
     def test_exclude_line(self, tmpdir):
         input_code = (
             expected
-        ) = """\
+        ) = """
         import subprocess
         subprocess.run(args, shell=True)
         """
-        lines_to_exclude = [2]
+        lines_to_exclude = [3]
         self.run_and_assert(
             tmpdir,
             input_code,

--- a/tests/codemods/test_use_generator.py
+++ b/tests/codemods/test_use_generator.py
@@ -37,10 +37,10 @@ class TestUseGenerator(BaseCodemodTest):
     def test_exclude_line(self, tmpdir):
         input_code = (
             expected
-        ) = """\
+        ) = """
         x = any([i for i in range(10)])
         """
-        lines_to_exclude = [1]
+        lines_to_exclude = [2]
         self.run_and_assert(
             tmpdir,
             input_code,


### PR DESCRIPTION
## Overview
*We keep forgetting unit test base_test already dedents so this is just a cleanup*

