### PR TITLE
Support `httpx` library in requests-verify codemod

### DIFF
--- a/src/core_codemods/docs/pixee_python_requests-verify.md
+++ b/src/core_codemods/docs/pixee_python_requests-verify.md
@@ -1,7 +1,9 @@
-This codemod checks that calls to the `requests` module API use `verify=True` or a path to a CA bundle to ensure TLS certificate validation.
+This codemod checks that calls to the `requests` module API or the `httpx` library use `verify=True` or a path to a CA bundle to ensure TLS certificate validation.
 
 The [requests documentation](https://requests.readthedocs.io/en/latest/api/) warns that the `verify` flag
 > When set to False, requests will accept any TLS certificate presented by the server, and will ignore hostname mismatches and/or expired certificates, which will make your application vulnerable to man-in-the-middle (MitM) attacks. Setting verify to False may be useful during local development or testing.
+
+Similarly, setting `verify=False` when using the `httpx` library to make requests disables certificate verification.
 
 The changes from this codemod look like this:
 
@@ -11,6 +13,12 @@ The changes from this codemod look like this:
   
 - requests.get("www.google.com", ...,verify=False)
 + requests.get("www.google.com", ...,verify=True)
+...
+import httpx
+  
+- httpx.get("www.google.com", ...,verify=False)
++ httpx.get("www.google.com", ...,verify=True)
+
 ```
 
-This codemod also checks other methods in the `requests` module that accept a `verify` flag (e.g. `requests.post`, etc.)
+This codemod also checks other methods in the `requests` module and `httpx` library that accept a `verify` flag (e.g. `requests.post`, `httpx.AsyncClient`, etc.)

--- a/src/core_codemods/requests_verify.py
+++ b/src/core_codemods/requests_verify.py
@@ -14,13 +14,14 @@ class RequestsVerify(SimpleCodemod):
         review_guidance=ReviewGuidance.MERGE_AFTER_CURSORY_REVIEW,
         references=[
             Reference(url="https://requests.readthedocs.io/en/latest/api/"),
+            Reference(url="https://www.python-httpx.org/"),
             Reference(
                 url="https://owasp.org/www-community/attacks/Manipulator-in-the-middle_attack"
             ),
         ],
     )
     change_description = (
-        "Makes any calls to requests.{func} with `verify=False` to `verify=True`."
+        "Ensures requests using the `requests` or `httpx` library use `verify=True`."
     )
     detector_pattern = """
             rules:

--- a/src/core_codemods/requests_verify.py
+++ b/src/core_codemods/requests_verify.py
@@ -23,12 +23,29 @@ class RequestsVerify(SimpleCodemod):
         "Makes any calls to requests.{func} with `verify=False` to `verify=True`."
     )
     detector_pattern = """
-        rules:
-          - patterns:
-            - pattern: requests.$F(..., verify=False, ...)
-            - pattern-inside: |
-                import requests
-                ...
+            rules:
+              - pattern-either:
+                - patterns:
+                    - pattern: requests.$F(..., verify=False, ...)
+                    - pattern-inside: |
+                        import requests
+                        ...
+                - patterns:
+                    - pattern: httpx.$F(..., verify=False, ...)
+                    - pattern-inside: |
+                        import httpx
+                        ...
+                - patterns:
+                    - pattern: httpx.$CLASS(..., verify=False, ...)
+                    - pattern-inside: |
+                        import httpx
+                        ...
+                    - metavariable-pattern:
+                        metavariable: $CLASS
+                        patterns:
+                          - pattern-either:
+                            - pattern: Client
+                            - pattern: AsyncClient
         """
 
     def on_result_found(self, original_node, updated_node):

--- a/src/core_codemods/requests_verify.py
+++ b/src/core_codemods/requests_verify.py
@@ -35,17 +35,6 @@ class RequestsVerify(SimpleCodemod):
                     - pattern-inside: |
                         import httpx
                         ...
-                - patterns:
-                    - pattern: httpx.$CLASS(..., verify=False, ...)
-                    - pattern-inside: |
-                        import httpx
-                        ...
-                    - metavariable-pattern:
-                        metavariable: $CLASS
-                        patterns:
-                          - pattern-either:
-                            - pattern: Client
-                            - pattern: AsyncClient
         """
 
     def on_result_found(self, original_node, updated_node):

--- a/tests/codemods/test_request_verify.py
+++ b/tests/codemods/test_request_verify.py
@@ -2,7 +2,9 @@ import pytest
 from core_codemods.requests_verify import RequestsVerify
 from tests.codemods.base_codemod_test import BaseSemgrepCodemodTest
 
-REQUEST_FUNCS = ["get", "post", "request"]
+# todo: add stream, etc specific to httpx
+each_func = pytest.mark.parametrize("func", ["get", "post", "request"])
+each_library = pytest.mark.parametrize("library", ["requests", "httpx"])
 
 
 class TestRequestsVerify(BaseSemgrepCodemodTest):
@@ -11,93 +13,100 @@ class TestRequestsVerify(BaseSemgrepCodemodTest):
     def test_name(self):
         assert self.codemod.name == "requests-verify"
 
-    @pytest.mark.parametrize("func", REQUEST_FUNCS)
-    def test_default_verify(self, tmpdir, func):
-        input_code = f"""import requests
-
-requests.{func}("www.google.com")
-var = "hello"
-"""
+    @each_func
+    @each_library
+    def test_default_verify(self, tmpdir, library, func):
+        input_code = f"""
+        import {library}
+        {library}.{func}("www.google.com")
+        var = "hello"
+        """
         self.run_and_assert(tmpdir, input_code, input_code)
 
-    @pytest.mark.parametrize("func", REQUEST_FUNCS)
-    @pytest.mark.parametrize("verify_val", ["True", "'/some/path'"])
-    def test_verify(self, tmpdir, verify_val, func):
-        input_code = f"""import requests
-
-requests.{func}("www.google.com", verify={verify_val})
-var = "hello"
-"""
+    @each_func
+    @each_library
+    @pytest.mark.parametrize("verify_val", ["True", "'/some/palibrary, th'"])
+    def test_verify(self, tmpdir, verify_val, library, func):
+        input_code = f"""
+        import {library}
+        {library}.{func}("www.google.com", verify={verify_val})
+        var = "hello"
+        """
         self.run_and_assert(tmpdir, input_code, input_code)
 
-    @pytest.mark.parametrize("func", REQUEST_FUNCS)
-    def test_import(self, tmpdir, func):
-        input_code = f"""import requests
-
-requests.{func}("www.google.com", verify=False)
-var = "hello"
-"""
-        expected = f"""import requests
-
-requests.{func}("www.google.com", verify=True)
-var = "hello"
-"""
+    @each_func
+    @each_library
+    def test_import(self, tmpdir, library, func):
+        input_code = f"""
+        import {library}
+        {library}.{func}("www.google.com", verify=False)
+        var = "hello"
+        """
+        expected = f"""
+        import {library}
+        {library}.{func}("www.google.com", verify=True)
+        var = "hello"
+        """
         self.run_and_assert(tmpdir, input_code, expected)
 
-    @pytest.mark.parametrize("func", REQUEST_FUNCS)
-    def test_from_import(self, tmpdir, func):
-        input_code = f"""from requests import {func}
-
-{func}("www.google.com", verify=False)
-var = "hello"
-"""
-        expected = f"""from requests import {func}
-
-{func}("www.google.com", verify=True)
-var = "hello"
-"""
+    @each_func
+    @each_library
+    def test_from_import(self, tmpdir, library, func):
+        input_code = f"""
+        from {library} import {func}
+        {func}("www.google.com", verify=False)
+        var = "hello"
+        """
+        expected = f"""
+        from {library} import {func}
+        {func}("www.google.com", verify=True)
+        var = "hello"
+        """
         self.run_and_assert(tmpdir, input_code, expected)
 
-    @pytest.mark.parametrize("func", REQUEST_FUNCS)
-    def test_multifunctions(self, tmpdir, func):
-        input_code = f"""import requests
-
-requests.{func}("www.google.com", verify=False)
-requests.HTTPError()
-var = "hello"
-"""
-        expected = f"""import requests
-
-requests.{func}("www.google.com", verify=True)
-requests.HTTPError()
-var = "hello"
-"""
+    @each_func
+    @each_library
+    def test_multifunctions(self, tmpdir, library, func):
+        input_code = f"""
+        import {library}
+        {library}.{func}("www.google.com", verify=False)
+        {library}.HTTPError()
+        var = "hello"
+        """
+        expected = f"""
+        import {library}
+        {library}.{func}("www.google.com", verify=True)
+        {library}.HTTPError()
+        var = "hello"
+        """
         self.run_and_assert(tmpdir, input_code, expected)
 
-    @pytest.mark.parametrize("func", REQUEST_FUNCS)
-    def test_import_alias(self, tmpdir, func):
-        input_code = f"""import requests as req_mod
-
-req_mod.{func}("www.google.com", verify=False)
-var = "hello"
-"""
-        expected = f"""import requests as req_mod
-
-req_mod.{func}("www.google.com", verify=True)
-var = "hello"
-"""
+    @each_func
+    @each_library
+    def test_import_alias(self, tmpdir, library, func):
+        input_code = f"""
+        import {library} as req_mod
+        req_mod.{func}("www.google.com", verify=False)
+        var = "hello"
+        """
+        expected = f"""
+        import {library} as req_mod
+        req_mod.{func}("www.google.com", verify=True)
+        var = "hello"
+        """
         self.run_and_assert(tmpdir, input_code, expected)
 
-    @pytest.mark.parametrize("func", REQUEST_FUNCS)
-    def test_multiple_kwargs(self, tmpdir, func):
-        input_code = f"""import requests
-
-requests.{func}("www.google.com", headers={{"Content-Type":"text"}}, verify=False)
-var = "hello"
-"""
-        expected = f"""import requests
-
-requests.{func}("www.google.com", headers={{"Content-Type":"text"}}, verify=True)
-var = "hello"
-"""
+    @each_func
+    @each_library
+    def test_multiple_kwargs(self, tmpdir, library, func):
+        input_code = f"""
+        import {library}
+        {library}.{func}("www.google.com", headers={{"Content-Type":"text"}}, verify=False)
+        var = "hello"
+        """
+        expected = f"""
+        import {library}
+        {library}.{func}("www.google.com", headers={{"Content-Type":"text"}}, verify=True)
+        var = "hello"
+        """
         self.run_and_assert(tmpdir, input_code, expected)

--- a/tests/codemods/test_request_verify.py
+++ b/tests/codemods/test_request_verify.py
@@ -145,7 +145,7 @@ class TestHttpxSpecific(BaseSemgrepCodemodTest):
         self.run_and_assert(tmpdir, input_code, expected)
 
     def test_verify_with_sslcontext(self, tmpdir):
-        input_code = f"""
+        input_code = """
         import ssl
         import httpx
         context = ssl.create_default_context()
@@ -155,7 +155,7 @@ class TestHttpxSpecific(BaseSemgrepCodemodTest):
         self.run_and_assert(tmpdir, input_code, input_code)
 
     def test_client_verify(self, tmpdir):
-        input_code = f"""
+        input_code = """
         import httpx
         client = httpx.Client(verify=False)
         try:
@@ -163,7 +163,7 @@ class TestHttpxSpecific(BaseSemgrepCodemodTest):
         finally:
             client.close()
         """
-        expected_code = f"""
+        expected_code = """
         import httpx
         client = httpx.Client(verify=True)
         try:
@@ -174,7 +174,7 @@ class TestHttpxSpecific(BaseSemgrepCodemodTest):
         self.run_and_assert(tmpdir, input_code, expected_code)
 
     def test_client_verify_from_import(self, tmpdir):
-        input_code = f"""
+        input_code = """
         from httpx import Client
         c = Client(verify=False)
         try:
@@ -182,7 +182,7 @@ class TestHttpxSpecific(BaseSemgrepCodemodTest):
         finally:
             c.close()
         """
-        expected_code = f"""
+        expected_code = """
         from httpx import Client
         c = Client(verify=True)
         try:
@@ -193,12 +193,12 @@ class TestHttpxSpecific(BaseSemgrepCodemodTest):
         self.run_and_assert(tmpdir, input_code, expected_code)
 
     def test_client_verify_context_manager(self, tmpdir):
-        input_code = f"""
+        input_code = """
         import httpx
         with httpx.Client(verify=False) as client:
             client.get('https://example.com')
         """
-        expected_code = f"""
+        expected_code = """
         import httpx
         with httpx.Client(verify=True) as client:
             client.get('https://example.com')
@@ -206,7 +206,7 @@ class TestHttpxSpecific(BaseSemgrepCodemodTest):
         self.run_and_assert(tmpdir, input_code, expected_code)
 
     def test_async_client_verify(self, tmpdir):
-        input_code = f"""
+        input_code = """
         import httpx
         client = httpx.AsyncClient(verify=False)
         try:
@@ -214,7 +214,7 @@ class TestHttpxSpecific(BaseSemgrepCodemodTest):
         finally:
             await client.close()
         """
-        expected_code = f"""
+        expected_code = """
         import httpx
         client = httpx.AsyncClient(verify=True)
         try:
@@ -225,12 +225,12 @@ class TestHttpxSpecific(BaseSemgrepCodemodTest):
         self.run_and_assert(tmpdir, input_code, expected_code)
 
     def test_async_client_verify_context_manager(self, tmpdir):
-        input_code = f"""
+        input_code = """
         import httpx
         async with httpx.AsyncClient(verify=False) as client:
             await client.get('https://example.com')
         """
-        expected_code = f"""
+        expected_code = """
         import httpx
         async with httpx.AsyncClient(verify=True) as client:
             await client.get('https://example.com')


### PR DESCRIPTION
## Overview
*`httpx` is a requests library with an API almost identical to `requests` so we're adding it in this codemod*


