### PR TITLE
change requests timeout codemod semgrep pattern

### DIFF
--- a/src/core_codemods/add_requests_timeouts.py
+++ b/src/core_codemods/add_requests_timeouts.py
@@ -40,20 +40,20 @@ AddRequestsTimeouts = CoreCodemod(
             - pattern-inside: |
                 import requests
                 ...
-            - pattern: $CALL(...)
-            - pattern-not: $CALL(..., timeout=$TIMEOUT, ...)
+            - pattern: requests.$CALL(...)
+            - pattern-not: requests.$CALL(..., timeout=$TIMEOUT, ...)
             - metavariable-pattern:
                 metavariable: $CALL
                 patterns:
                   - pattern-either:
-                    - pattern: requests.get
-                    - pattern: requests.post
-                    - pattern: requests.put
-                    - pattern: requests.delete
-                    - pattern: requests.head
-                    - pattern: requests.options
-                    - pattern: requests.patch
-                    - pattern: requests.request
+                    - pattern: get
+                    - pattern: post
+                    - pattern: put
+                    - pattern: delete
+                    - pattern: head
+                    - pattern: options
+                    - pattern: patch
+                    - pattern: request
         """
     ),
     transformer=LibcstTransformerPipeline(TransformAddRequestsTimeouts),

--- a/tests/codemods/test_add_requests_timeouts.py
+++ b/tests/codemods/test_add_requests_timeouts.py
@@ -84,3 +84,15 @@ class TestAddRequestsTimeouts(BaseSemgrepCodemodTest):
             demands.get("https://example.com")
         """
         self.run_and_assert(tmpdir, original, original)
+
+    def test_chaining(self, tmpdir):
+        # See issue https://github.com/pixee/codemodder-python/issues/244
+        original = """
+        import requests
+        requests.get("https://example.com").json()
+        """
+        expected = f"""
+        import requests
+        requests.get("https://example.com", timeout={TIMEOUT}).json()
+        """
+        self.run_and_assert(tmpdir, original, expected)


### PR DESCRIPTION
## Overview
*change semgrep rule for codemod to not match chained functions*

Closes #244 

More context:  the only other codemod that suffers from this is the `bad-lock-with-statement`. The issue there is the way we're using metavariable-pattern and focus-variable makes this fix not as easy.