### PR TITLE
Update docs for `use-walrus-if`

### DIFF
--- a/src/core_codemods/docs/pixee_python_use-walrus-if.md
+++ b/src/core_codemods/docs/pixee_python_use-walrus-if.md
@@ -10,5 +10,3 @@ The changes from this codemod look like this:
 + if (x := foo()) is not None:
       print(x)
 ```
-
-The walrus operator is only supported in Python 3.8 and later.


### PR DESCRIPTION
## Overview
*Update docs for `use-walrus-if`*

## Description

* The callout for Python 3.8 is no longer necessary since that is the oldest supported version of Python (this codemod was written when Python 3.7) was still around