### PR TITLE
Fix CodemodCollection API

### DIFF
--- a/src/codemodder/registry.py
+++ b/src/codemodder/registry.py
@@ -24,8 +24,6 @@ class CodemodCollection:
     """A collection of codemods that all share the same origin and documentation."""
 
     origin: str
-    docs_module: str
-    semgrep_config_module: str
     codemods: list
 
 

--- a/src/core_codemods/__init__.py
+++ b/src/core_codemods/__init__.py
@@ -65,8 +65,6 @@ from .fix_async_task_instantiation import FixAsyncTaskInstantiation
 
 registry = CodemodCollection(
     origin="pixee",
-    docs_module="core_codemods.docs",
-    semgrep_config_module="core_codemods.semgrep",
     codemods=[
         AddRequestsTimeouts,
         DjangoDebugFlagOn,
@@ -125,8 +123,6 @@ registry = CodemodCollection(
 
 sonar_registry = CodemodCollection(
     origin="sonar",
-    docs_module="core_codemods.docs",
-    semgrep_config_module="core_codemods.semgrep",
     codemods=[
         SonarNumpyNanEquality,
         SonarLiteralOrNewObjectIdentity,

--- a/tests/codemods/base_codemod_test.py
+++ b/tests/codemods/base_codemod_test.py
@@ -107,8 +107,6 @@ class BaseSemgrepCodemodTest(BaseCodemodTest):
         collection = CodemodCollection(
             origin="pixee",
             codemods=[cls.codemod],
-            docs_module="core_codemods.docs",
-            semgrep_config_module="core_codemods.semgrep",
         )
         cls.registry = CodemodRegistry()
         cls.registry.add_codemod_collection(collection)

--- a/tests/codemods/test_lazy_logging.py
+++ b/tests/codemods/test_lazy_logging.py
@@ -3,7 +3,7 @@ from tests.codemods.base_codemod_test import BaseSemgrepCodemodTest
 from core_codemods.lazy_logging import LazyLogging
 
 logging_funcs = {"debug", "info", "warning", "warn", "error", "critical"}
-each_func = pytest.mark.parametrize("func", logging_funcs)
+each_func = pytest.mark.parametrize("func", sorted(logging_funcs))
 
 
 class TestLazyLoggingModulo(BaseSemgrepCodemodTest):


### PR DESCRIPTION
## Overview
*Remove unused `CodemodCollection` attributes*

## Description

* These should have been removed as part of the API refactoring in #213
* Also fixed an issue that was causing test errors when using `pytest-xdist` locally
