### PR TITLE
Fix harden-pyyaml to handle bad default

### DIFF
--- a/src/core_codemods/docs/pixee_python_harden-pyyaml.md
+++ b/src/core_codemods/docs/pixee_python_harden-pyyaml.md
@@ -1,13 +1,13 @@
-This codemod hardens all [`yaml.load()`](https://pyyaml.org/wiki/PyYAMLDocumentation) calls against attacks that could result from deserializing untrusted data.
+The default loaders in PyYAML are not safe to use with untrusted data. They potentially make your application vulnerable to arbitrary code execution attacks. If you open a YAML file from an untrusted source, and the file is loaded with the default loader, an attacker could execute arbitrary code on your machine.
 
-The fix uses a safety check that already exists in the `yaml` module, replacing unsafe loader class with `SafeLoader`.
-The changes from this codemod look like this:
+This codemod hardens all [`yaml.load()`](https://pyyaml.org/wiki/PyYAMLDocumentation) calls against such attacks by replacing the default loader with `yaml.SafeLoader`. This is the recommended loader for loading untrusted data. For most use cases it functions as a drop-in replacement for the default loader.
 
+Calling `yaml.load()` without an explicit loader argument is equivalent to calling it with `Loader=yaml.Loader`, which is unsafe. This usage [has been deprecated](https://github.com/yaml/pyyaml/wiki/PyYAML-yaml.load(input\)-Deprecation) since PyYAML 5.1. This codemod will add an explicit `SafeLoader` argument to all `yaml.load()` calls that don't use an explicit loader.
+
+The changes from this codemod look like the following:
 ```diff
   import yaml
   data = b'!!python/object/apply:subprocess.Popen \\n- ls'
 - deserialized_data = yaml.load(data, yaml.Loader)
 + deserialized_data = yaml.load(data, Loader=yaml.SafeLoader)
 ```
-The codemod will also catch if you pass in the loader argument as a kwarg and if you use any loader other than `SafeLoader`,
-including `FullLoader` and `UnsafeLoader`.

--- a/tests/codemods/test_harden_pyyaml.py
+++ b/tests/codemods/test_harden_pyyaml.py
@@ -86,6 +86,19 @@ deserialized_data = yam.load(data, Loader=yam.SafeLoader)
 
         self.run_and_assert(tmpdir, input_code, expected)
 
+    def test_default_loader_unsafe(self, tmpdir):
+        input_code = """
+        import yaml
+
+        yaml.load(data)
+        """
+        expected = """
+        import yaml
+
+        yaml.load(data, Loader=yaml.SafeLoader)
+        """
+        self.run_and_assert(tmpdir, input_code, expected)
+
 
 class TestHardenPyyamlClassInherit(BaseSemgrepCodemodTest):
     codemod = HardenPyyaml


### PR DESCRIPTION
## Overview
*Update `harden-pyyaml` to fix cases where no loader is explicitly provided*