### PR TITLE
Updates to enable SAST remediation support

### DIFF
--- a/src/codemodder/codemodder.py
+++ b/src/codemodder/codemodder.py
@@ -19,6 +19,7 @@ from codemodder.project_analysis.file_parsers.package_store import PackageStore
 from codemodder.project_analysis.python_repo_manager import PythonRepoManager
 from codemodder.report.codetf_reporter import report_default
 from codemodder.result import ResultSet
+from codemodder.sarifs import detect_sarif_tools
 from codemodder.semgrep import run as run_semgrep
 
 
@@ -156,8 +157,12 @@ def run(original_args) -> int:
     logger.info("codemodder: python/%s", __version__)
     logger.info("command: %s %s", Path(sys.argv[0]).name, " ".join(original_args))
 
-    tool_result_files_map = {"sonar": argv.sonar_issues_json}
-    # TODO find the tool name in the --sarif files here and populate the dict
+    # TODO: sonar files should be _parsed_ here as well
+    # TODO: this should be dict[str, list[Path]]
+    tool_result_files_map: dict[str, list[str]] = detect_sarif_tools(
+        [Path(name) for name in argv.sarif or []]
+    )
+    tool_result_files_map["sonar"] = argv.sonar_issues_json
 
     repo_manager = PythonRepoManager(Path(argv.directory))
     context = CodemodExecutionContext(

--- a/src/codemodder/codemods/base_codemod.py
+++ b/src/codemodder/codemods/base_codemod.py
@@ -188,7 +188,7 @@ class BaseCodemod(metaclass=ABCMeta):
             findings_for_rule = []
             for rule in rules:
                 findings_for_rule.extend(
-                    results.results_for_rule_and_file(rule, filename)
+                    results.results_for_rule_and_file(context, rule, filename)
                 )
 
         file_context = FileContext(
@@ -198,6 +198,8 @@ class BaseCodemod(metaclass=ABCMeta):
             line_include,
             findings_for_rule,
         )
+
+        # TODO: for SAST tools we should preemtively filter out files that are not part of the result set
 
         if change_set := self.transformer.apply(
             context, file_context, findings_for_rule

--- a/src/codemodder/codemods/base_visitor.py
+++ b/src/codemodder/codemods/base_visitor.py
@@ -52,7 +52,6 @@ class UtilsMixin(MetadataDependent):
 
 
 class BaseTransformer(VisitorBasedCodemodCommand, UtilsMixin):
-
     def __init__(
         self,
         context,
@@ -65,7 +64,6 @@ class BaseTransformer(VisitorBasedCodemodCommand, UtilsMixin):
 
 
 class BaseVisitor(ContextAwareVisitor, UtilsMixin):
-
     def __init__(
         self,
         context,


### PR DESCRIPTION
## Overview
*Updates to support new SAST remediation codemods*

## Description

* These changes were necessary in order to support some new SAST remediation codemods
* It introduces a plugin infrastructure for detecting the tool provider encoded in SARIF files
* Previously SARIF files were not being handled at all but this change makes them available via the `CodemodExecutionContext`
* Fixed the location filtering logic which was previously ignoring all but the first location
* Made the `CodemodExecutionContext` available to the `ResultSet` API so that detectors can make use of additional contextual information (e.g. base directory path) where necessary