### PR TITLE
jwt.decode sonar codemod

### DIFF
--- a/integration_tests/test_jwt_decode_verify.py
+++ b/integration_tests/test_jwt_decode_verify.py
@@ -1,4 +1,4 @@
-from core_codemods.jwt_decode_verify import JwtDecodeVerify
+from core_codemods.jwt_decode_verify import JwtDecodeVerify, JwtDecodeVerifyTransformer
 from codemodder.codemods.test import (
     BaseIntegrationTest,
     original_and_expected_from_code_path,
@@ -24,4 +24,4 @@ class TestJwtDecodeVerify(BaseIntegrationTest):
     expected_diff = '--- \n+++ \n@@ -8,7 +8,7 @@\n \n encoded_jwt = jwt.encode(payload, SECRET_KEY, algorithm="HS256")\n \n-decoded_payload = jwt.decode(encoded_jwt, SECRET_KEY, algorithms=["HS256"], verify=False)\n-decoded_payload = jwt.decode(encoded_jwt, SECRET_KEY, algorithms=["HS256"], options={"verify_signature": False})\n+decoded_payload = jwt.decode(encoded_jwt, SECRET_KEY, algorithms=["HS256"], verify=True)\n+decoded_payload = jwt.decode(encoded_jwt, SECRET_KEY, algorithms=["HS256"], options={"verify_signature": True})\n \n var = "something"\n'
     expected_line_change = "11"
     num_changes = 2
-    change_description = JwtDecodeVerify.change_description
+    change_description = JwtDecodeVerifyTransformer.change_description

--- a/integration_tests/test_sonar_exception_without_raise.py
+++ b/integration_tests/test_sonar_exception_without_raise.py
@@ -1,7 +1,5 @@
-from core_codemods.exception_without_raise import (
-    ExceptionWithoutRaise,
-    ExceptionWithoutRaiseTransformer,
-)
+from core_codemods.exception_without_raise import ExceptionWithoutRaiseTransformer
+from core_codemods.sonar.sonar_exception_without_raise import SonarExceptionWithoutRaise
 from codemodder.codemods.test import (
     BaseIntegrationTest,
     original_and_expected_from_code_path,
@@ -9,7 +7,7 @@ from codemodder.codemods.test import (
 
 
 class TestSonarExceptionWithoutRaise(BaseIntegrationTest):
-    codemod = ExceptionWithoutRaise
+    codemod = SonarExceptionWithoutRaise
     code_path = "tests/samples/exception_without_raise.py"
     original_code, expected_new_code = original_and_expected_from_code_path(
         code_path,

--- a/integration_tests/test_sonar_jwt_decode_verify.py
+++ b/integration_tests/test_sonar_jwt_decode_verify.py
@@ -1,0 +1,32 @@
+from core_codemods.sonar.sonar_jwt_decode_verify import (
+    SonarJwtDecodeVerify,
+    JwtDecodeVerifySonarTransformer,
+)
+from codemodder.codemods.test import (
+    BaseIntegrationTest,
+    original_and_expected_from_code_path,
+)
+
+
+class TestJwtDecodeVerify(BaseIntegrationTest):
+    codemod = SonarJwtDecodeVerify
+    code_path = "tests/samples/jwt_decode_verify.py"
+    original_code, expected_new_code = original_and_expected_from_code_path(
+        code_path,
+        [
+            (
+                10,
+                """decoded_payload = jwt.decode(encoded_jwt, SECRET_KEY, algorithms=["HS256"], verify=True)\n""",
+            ),
+            (
+                11,
+                """decoded_payload = jwt.decode(encoded_jwt, SECRET_KEY, algorithms=["HS256"], options={"verify_signature": True})\n""",
+            ),
+        ],
+    )
+    sonar_issues_json = "tests/samples/sonar_issues.json"
+
+    expected_diff = '--- \n+++ \n@@ -8,7 +8,7 @@\n \n encoded_jwt = jwt.encode(payload, SECRET_KEY, algorithm="HS256")\n \n-decoded_payload = jwt.decode(encoded_jwt, SECRET_KEY, algorithms=["HS256"], verify=False)\n-decoded_payload = jwt.decode(encoded_jwt, SECRET_KEY, algorithms=["HS256"], options={"verify_signature": False})\n+decoded_payload = jwt.decode(encoded_jwt, SECRET_KEY, algorithms=["HS256"], verify=True)\n+decoded_payload = jwt.decode(encoded_jwt, SECRET_KEY, algorithms=["HS256"], options={"verify_signature": True})\n \n var = "something"\n'
+    expected_line_change = "11"
+    num_changes = 2
+    change_description = JwtDecodeVerifySonarTransformer.change_description

--- a/src/codemodder/codemods/base_visitor.py
+++ b/src/codemodder/codemods/base_visitor.py
@@ -23,7 +23,7 @@ class UtilsMixin(MetadataDependent):
     def filter_by_result(self, node):
         pos_to_match = self.node_position(node)
         if self.results is None:
-            return False
+            return True  # should be false??
         return any(result.match_location(pos_to_match, node) for result in self.results)
 
     def filter_by_path_includes_or_excludes(self, pos_to_match):

--- a/src/codemodder/codemods/base_visitor.py
+++ b/src/codemodder/codemods/base_visitor.py
@@ -23,7 +23,7 @@ class UtilsMixin(MetadataDependent):
     def filter_by_result(self, node):
         pos_to_match = self.node_position(node)
         if self.results is None:
-            return True
+            return False
         return any(result.match_location(pos_to_match, node) for result in self.results)
 
     def filter_by_path_includes_or_excludes(self, pos_to_match):

--- a/src/codemodder/codemods/base_visitor.py
+++ b/src/codemodder/codemods/base_visitor.py
@@ -23,7 +23,8 @@ class UtilsMixin(MetadataDependent):
     def filter_by_result(self, node):
         pos_to_match = self.node_position(node)
         if self.results is None:
-            return True  # should be false??
+            # Some codemods must run without results existing.
+            return True
         return any(result.match_location(pos_to_match, node) for result in self.results)
 
     def filter_by_path_includes_or_excludes(self, pos_to_match):

--- a/src/codemodder/codemods/base_visitor.py
+++ b/src/codemodder/codemods/base_visitor.py
@@ -23,7 +23,8 @@ class UtilsMixin(MetadataDependent):
     def filter_by_result(self, node):
         pos_to_match = self.node_position(node)
         if self.results is None:
-            # Some codemods must run without results existing.
+            # Returning True here means codemods without detectors (and results)
+            # will still run their transformations.
             return True
         return any(result.match_location(pos_to_match, node) for result in self.results)
 

--- a/src/codemodder/result.py
+++ b/src/codemodder/result.py
@@ -34,17 +34,28 @@ class Result(ABCDataclass):
     def match_location(self, pos: CodeRange, node: cst.CSTNode) -> bool:
         del node
         return any(
-            pos.start.line == location.start.line
+            same_line(pos, location)
             and (
                 pos.start.column
                 in ((start_column := location.start.column) - 1, start_column)
             )
-            and pos.end.line == location.end.line
             and (
                 pos.end.column in ((end_column := location.end.column) - 1, end_column)
             )
             for location in self.locations
         )
+
+
+def same_line(pos: CodeRange, location: Location) -> bool:
+    return pos.start.line == location.start.line and pos.end.line == location.end.line
+
+
+def fuzzy_column_match(pos: CodeRange, location: Location) -> bool:
+    """Checks that a result location is within the range of node's `pos` position"""
+    return (
+        pos.start.column <= location.start.column <= pos.end.column + 1
+        and pos.start.column <= location.end.column <= pos.end.column + 1
+    )
 
 
 class ResultSet(dict[str, dict[Path, list[Result]]]):

--- a/src/codemodder/scripts/generate_docs.py
+++ b/src/codemodder/scripts/generate_docs.py
@@ -287,6 +287,11 @@ METADATA = CORE_METADATA | {
         ].guidance_explained,
         need_sarif="Yes (Sonar)",
     ),
+    "jwt-decode-verify-S5659": DocMetadata(
+        importance=CORE_METADATA["jwt-decode-verify"].importance,
+        guidance_explained=CORE_METADATA["jwt-decode-verify"].guidance_explained,
+        need_sarif="Yes (Sonar)",
+    ),
 }
 
 

--- a/src/core_codemods/__init__.py
+++ b/src/core_codemods/__init__.py
@@ -63,6 +63,7 @@ from .lazy_logging import LazyLogging
 from .str_concat_in_seq_literal import StrConcatInSeqLiteral
 from .fix_async_task_instantiation import FixAsyncTaskInstantiation
 from .django_model_without_dunder_str import DjangoModelWithoutDunderStr
+from .sonar.sonar_jwt_decode_verify import SonarJwtDecodeVerify
 
 registry = CodemodCollection(
     origin="pixee",
@@ -134,5 +135,6 @@ sonar_registry = CodemodCollection(
         SonarRemoveAssertionInPytestRaises,
         SonarFlaskJsonResponseType,
         SonarDjangoJsonResponseType,
+        SonarJwtDecodeVerify,
     ],
 )

--- a/src/core_codemods/sonar/sonar_jwt_decode_verify.py
+++ b/src/core_codemods/sonar/sonar_jwt_decode_verify.py
@@ -1,0 +1,15 @@
+from codemodder.codemods.base_codemod import Reference
+from codemodder.codemods.sonar import SonarCodemod
+
+from core_codemods.numpy_nan_equality import (
+    NumpyNanEquality,
+)
+
+SonarNumpyNanEquality = SonarCodemod.from_core_codemod(
+    name="numpy-nan-equality-S6725",
+    other=NumpyNanEquality,
+    rules=["python:S6725"],
+    new_references=[
+        Reference(url="https://rules.sonarsource.com/python/type/Bug/RSPEC-6725/"),
+    ],
+)

--- a/src/core_codemods/sonar/sonar_jwt_decode_verify.py
+++ b/src/core_codemods/sonar/sonar_jwt_decode_verify.py
@@ -1,15 +1,44 @@
+import libcst as cst
 from codemodder.codemods.base_codemod import Reference
 from codemodder.codemods.sonar import SonarCodemod
-
-from core_codemods.numpy_nan_equality import (
-    NumpyNanEquality,
+from codemodder.codemods.libcst_transformer import (
+    LibcstTransformerPipeline,
 )
+from core_codemods.jwt_decode_verify import JwtDecodeVerify, JwtDecodeVerifyTransformer
 
-SonarNumpyNanEquality = SonarCodemod.from_core_codemod(
-    name="numpy-nan-equality-S6725",
-    other=NumpyNanEquality,
-    rules=["python:S6725"],
+
+class NewTransf(JwtDecodeVerifyTransformer):
+    def filter_by_result(self, node) -> bool:
+        # sonar results for this rule have a start/end column
+        # for the verify keyword, not for the decode call
+        if self.results is None:
+            return False
+        match node:
+            case cst.Call():
+                pos_to_match = self.node_position(node)
+                return any(
+                    self.match_location(pos_to_match, result) for result in self.results
+                )
+        return False
+
+    def match_location(self, pos, result):
+        for location in result.locations:
+            start_column = location.start.column
+            end_column = location.end.column
+            return (
+                pos.start.line == location.start.line
+                and pos.end.line == location.end.line
+                and pos.start.column <= start_column <= pos.end.column + 1
+                and pos.start.column <= end_column <= pos.end.column + 1
+            )
+
+
+SonarJwtDecodeVerify = SonarCodemod.from_core_codemod(
+    name="jwt-decode-verify-S5659",
+    other=JwtDecodeVerify,
+    rules=["python:S5659"],
     new_references=[
-        Reference(url="https://rules.sonarsource.com/python/type/Bug/RSPEC-6725/"),
+        Reference(url="https://rules.sonarsource.com/python/RSPEC-5659/"),
     ],
+    transformer=LibcstTransformerPipeline(NewTransf),
 )

--- a/src/core_codemods/sonar/sonar_jwt_decode_verify.py
+++ b/src/core_codemods/sonar/sonar_jwt_decode_verify.py
@@ -8,10 +8,13 @@ from codemodder.codemods.libcst_transformer import (
 from core_codemods.jwt_decode_verify import JwtDecodeVerify, JwtDecodeVerifyTransformer
 
 
-class NewTransf(JwtDecodeVerifyTransformer):
+class JwtDecodeVerifySonarTransformer(JwtDecodeVerifyTransformer):
     def filter_by_result(self, node) -> bool:
-        # sonar results for this rule have a start/end column
-        # for the verify keyword, not for the decode call
+        """
+        Special case result-matching for this rule because the sonar
+        results returned have a start/end column for the verify keyword
+        within the `decode` call, not for the entire call like semgrep returns.
+        """
         if self.results is None:
             return False
         match node:
@@ -36,5 +39,5 @@ SonarJwtDecodeVerify = SonarCodemod.from_core_codemod(
     new_references=[
         Reference(url="https://rules.sonarsource.com/python/RSPEC-5659/"),
     ],
-    transformer=LibcstTransformerPipeline(NewTransf),
+    transformer=LibcstTransformerPipeline(JwtDecodeVerifySonarTransformer),
 )

--- a/src/core_codemods/sonar/sonar_jwt_decode_verify.py
+++ b/src/core_codemods/sonar/sonar_jwt_decode_verify.py
@@ -15,13 +15,12 @@ class JwtDecodeVerifySonarTransformer(JwtDecodeVerifyTransformer):
         results returned have a start/end column for the verify keyword
         within the `decode` call, not for the entire call like semgrep returns.
         """
-        if self.results is None:
-            return False
         match node:
             case cst.Call():
                 pos_to_match = self.node_position(node)
                 return any(
-                    self.match_location(pos_to_match, result) for result in self.results
+                    self.match_location(pos_to_match, result)
+                    for result in self.results or []
                 )
         return False
 

--- a/src/core_codemods/sonar/sonar_jwt_decode_verify.py
+++ b/src/core_codemods/sonar/sonar_jwt_decode_verify.py
@@ -1,5 +1,6 @@
 import libcst as cst
 from codemodder.codemods.base_codemod import Reference
+from codemodder.result import same_line, fuzzy_column_match
 from codemodder.codemods.sonar import SonarCodemod
 from codemodder.codemods.libcst_transformer import (
     LibcstTransformerPipeline,
@@ -22,15 +23,10 @@ class NewTransf(JwtDecodeVerifyTransformer):
         return False
 
     def match_location(self, pos, result):
-        for location in result.locations:
-            start_column = location.start.column
-            end_column = location.end.column
-            return (
-                pos.start.line == location.start.line
-                and pos.end.line == location.end.line
-                and pos.start.column <= start_column <= pos.end.column + 1
-                and pos.start.column <= end_column <= pos.end.column + 1
-            )
+        return any(
+            same_line(pos, location) and fuzzy_column_match(pos, location)
+            for location in result.locations
+        )
 
 
 SonarJwtDecodeVerify = SonarCodemod.from_core_codemod(

--- a/tests/codemods/test_sonar_jwt_decode_verify.py
+++ b/tests/codemods/test_sonar_jwt_decode_verify.py
@@ -22,6 +22,7 @@ class TestSonarJwtDecodeVerify(BaseSASTCodemodTest):
 
         encoded_jwt = jwt.encode(payload, SECRET_KEY, algorithm="HS256")
         decoded_payload = jwt.decode(encoded_jwt, SECRET_KEY, algorithms=["HS256"], verify=False)
+        decoded_payload = jwt.decode(encoded_jwt, SECRET_KEY, algorithms=["HS256"], options={"verify_signature": False})
         """
         expected = """
         import jwt
@@ -34,6 +35,7 @@ class TestSonarJwtDecodeVerify(BaseSASTCodemodTest):
 
         encoded_jwt = jwt.encode(payload, SECRET_KEY, algorithm="HS256")
         decoded_payload = jwt.decode(encoded_jwt, SECRET_KEY, algorithms=["HS256"], verify=True)
+        decoded_payload = jwt.decode(encoded_jwt, SECRET_KEY, algorithms=["HS256"], options={"verify_signature": True})
         """
         issues = {
             "issues": [
@@ -47,7 +49,20 @@ class TestSonarJwtDecodeVerify(BaseSASTCodemodTest):
                         "startOffset": 76,
                         "endOffset": 88,
                     },
-                }
+                },
+                {
+                    "rule": "python:S5659",
+                    "status": "OPEN",
+                    "component": f"{tmpdir / 'code.py'}",
+                    "textRange": {
+                        "startLine": 12,
+                        "endLine": 12,
+                        "startOffset": 84,
+                        "endOffset": 111,
+                    },
+                },
             ]
         }
-        self.run_and_assert(tmpdir, input_code, expected, results=json.dumps(issues))
+        self.run_and_assert(
+            tmpdir, input_code, expected, results=json.dumps(issues), num_changes=2
+        )

--- a/tests/codemods/test_sonar_jwt_decode_verify.py
+++ b/tests/codemods/test_sonar_jwt_decode_verify.py
@@ -1,0 +1,53 @@
+import json
+from core_codemods.sonar.sonar_jwt_decode_verify import SonarJwtDecodeVerify
+from codemodder.codemods.test import BaseSASTCodemodTest
+
+
+class TestSonarJwtDecodeVerify(BaseSASTCodemodTest):
+    codemod = SonarJwtDecodeVerify
+    tool = "sonar"
+
+    def test_name(self):
+        assert self.codemod.name == "jwt-decode-verify-S5659"
+
+    def test_simple(self, tmpdir):
+        input_code = """
+        import jwt
+
+        SECRET_KEY = "mysecretkey"
+        payload = {
+            "user_id": 123,
+            "username": "john",
+        }
+
+        encoded_jwt = jwt.encode(payload, SECRET_KEY, algorithm="HS256")
+        decoded_payload = jwt.decode(encoded_jwt, SECRET_KEY, algorithms=["HS256"], verify=False)
+        """
+        expected = """
+        import jwt
+
+        SECRET_KEY = "mysecretkey"
+        payload = {
+            "user_id": 123,
+            "username": "john",
+        }
+
+        encoded_jwt = jwt.encode(payload, SECRET_KEY, algorithm="HS256")
+        decoded_payload = jwt.decode(encoded_jwt, SECRET_KEY, algorithms=["HS256"], verify=True)
+        """
+        issues = {
+            "issues": [
+                {
+                    "rule": "python:S5659",
+                    "status": "OPEN",
+                    "component": f"{tmpdir / 'code.py'}",
+                    "textRange": {
+                        "startLine": 11,
+                        "endLine": 11,
+                        "startOffset": 76,
+                        "endOffset": 88,
+                    },
+                }
+            ]
+        }
+        self.run_and_assert(tmpdir, input_code, expected, results=json.dumps(issues))


### PR DESCRIPTION
## Overview
*Add codemod support for the sonar rule for jwt.decode*

## Description

* The challenge with this codemod is matching sonar results column to `decode` call node column. Sonar returns column start/end for `....verify=False` or `...."verify_signature": True` while the semgrep node we care about is `jwt.decode` which contains these verify keywords. To get the codemod to run, I had to implement a  codemod specific `match_location` that I called `fuzzy`. 

## Additional Details
* some minor cleanup. /documentation

Closes #298