### PR TITLE
Enhance `fix-deprecated-abstractproperty` codemod

### DIFF
--- a/integration_tests/test_fix_deprecated_abstractproperty.py
+++ b/integration_tests/test_fix_deprecated_abstractproperty.py
@@ -24,29 +24,42 @@ class TestFixDeprecatedAbstractproperty(BaseIntegrationTest):
         def foo(self):
             pass
 
+        @classmethod
+        @abc.abstractmethod
+        def hello(cls):
+            pass
+            
         @abstractmethod
         def bar(self):
             pass
     """
     )
 
-    expected_diff = """\
---- 
-+++ 
-@@ -1,8 +1,10 @@
--from abc import abstractproperty as ap, abstractmethod
-+from abc import abstractmethod
-+import abc
- 
- 
- class A:
--    @ap
-+    @property
-+    @abc.abstractmethod
-     def foo(self):
-         pass
- 
-"""
-
+    # fmt: off
+    expected_diff =(
+    """--- \n"""
+    """+++ \n"""
+    """@@ -1,12 +1,15 @@\n"""
+    """-from abc import abstractproperty as ap, abstractclassmethod, abstractmethod\n"""
+    """+from abc import abstractmethod\n"""
+    """+import abc\n"""
+    """ \n"""
+    """ \n"""
+    """ class A:\n"""
+    """-    @ap\n"""
+    """+    @property\n"""
+    """+    @abc.abstractmethod\n"""
+    """     def foo(self):\n"""
+    """         pass\n"""
+    """ \n"""
+    """-    @abstractclassmethod\n"""
+    """+    @classmethod\n"""
+    """+    @abc.abstractmethod\n"""
+    """     def hello(cls):\n"""
+    """         pass\n"""
+    """ \n"""
+    )
+    # fmt: on
     expected_line_change = "5"
-    change_description = FixDeprecatedAbstractproperty.DESCRIPTION
+    num_changes = 2
+    change_description = FixDeprecatedAbstractproperty.change_description

--- a/integration_tests/test_fix_deprecated_abstractproperty.py
+++ b/integration_tests/test_fix_deprecated_abstractproperty.py
@@ -28,7 +28,12 @@ class TestFixDeprecatedAbstractproperty(BaseIntegrationTest):
         @abc.abstractmethod
         def hello(cls):
             pass
-            
+
+        @staticmethod
+        @abc.abstractmethod
+        def goodbye():
+            pass
+                        
         @abstractmethod
         def bar(self):
             pass
@@ -39,8 +44,8 @@ class TestFixDeprecatedAbstractproperty(BaseIntegrationTest):
     expected_diff =(
     """--- \n"""
     """+++ \n"""
-    """@@ -1,12 +1,15 @@\n"""
-    """-from abc import abstractproperty as ap, abstractclassmethod, abstractmethod\n"""
+    """@@ -1,16 +1,20 @@\n"""
+    """-from abc import abstractproperty as ap, abstractclassmethod, abstractstaticmethod, abstractmethod\n"""
     """+from abc import abstractmethod\n"""
     """+import abc\n"""
     """ \n"""
@@ -58,8 +63,14 @@ class TestFixDeprecatedAbstractproperty(BaseIntegrationTest):
     """     def hello(cls):\n"""
     """         pass\n"""
     """ \n"""
+    """-    @abstractstaticmethod\n"""
+    """+    @staticmethod\n"""
+    """+    @abc.abstractmethod\n"""
+    """     def goodbye():\n"""
+    """         pass\n"""
+    """ \n"""
     )
     # fmt: on
     expected_line_change = "5"
-    num_changes = 2
+    num_changes = 3
     change_description = FixDeprecatedAbstractproperty.change_description

--- a/src/core_codemods/docs/pixee_python_fix-deprecated-abstractproperty.md
+++ b/src/core_codemods/docs/pixee_python_fix-deprecated-abstractproperty.md
@@ -1,4 +1,4 @@
-The `@abstractproperty` decorator from `abc` has been [deprecated](https://docs.python.org/3/library/abc.html#abc.abstractproperty) since Python 3.3. This is because it's possible to use `@property` in combination with `@abstractmethod`. 
+The `@abstractproperty`, `@abstractclassmethod`, and `@abstractstaticmethod` decorators from `abc` has been [deprecated](https://docs.python.org/3/library/abc.html) since Python 3.3. This is because it's possible to use `@property`, `@classmethod`, and `@staticmethod`  in combination with `@abstractmethod`. 
 
 Our changes look like the following:
 ```diff
@@ -11,3 +11,5 @@ Our changes look like the following:
     def bar():
         ...
 ```
+
+and similarly for `@abstractclassmethod` and `@abstractstaticmethod`.

--- a/src/core_codemods/fix_deprecated_abstractproperty.py
+++ b/src/core_codemods/fix_deprecated_abstractproperty.py
@@ -7,7 +7,7 @@ from core_codemods.api import Metadata, Reference, ReviewGuidance, SimpleCodemod
 class FixDeprecatedAbstractproperty(SimpleCodemod, NameResolutionMixin):
     metadata = Metadata(
         name="fix-deprecated-abstractproperty",
-        summary="Replace deprecated abstractproperty or abstractclassmethod",
+        summary="Replace Deprecated `abstractproperty` or `abstractclassmethod` Decorators",
         review_guidance=ReviewGuidance.MERGE_WITHOUT_REVIEW,
         references=[
             Reference(
@@ -18,9 +18,7 @@ class FixDeprecatedAbstractproperty(SimpleCodemod, NameResolutionMixin):
             ),
         ],
     )
-    change_description = (
-        "Replace deprecated abstractproperty with property and abstractmethod"
-    )
+    change_description = "Replace deprecated `abc` module decorator."
 
     def leave_Decorator(
         self, original_node: cst.Decorator, updated_node: cst.Decorator
@@ -36,7 +34,7 @@ class FixDeprecatedAbstractproperty(SimpleCodemod, NameResolutionMixin):
         ):
             self.add_needed_import("abc")
             self.remove_unused_import(original_node)
-            self.add_change(original_node, self.DESCRIPTION)
+            self.report_change(original_node)
             new_decorator = cst.Name(
                 value=(
                     "property" if base_name == "abc.abstractproperty" else "classmethod"

--- a/tests/codemods/test_fix_deprecated_abstractproperty.py
+++ b/tests/codemods/test_fix_deprecated_abstractproperty.py
@@ -7,6 +7,7 @@ property_or_class = pytest.mark.parametrize(
     [
         ("abstractproperty", "self", "property"),
         ("abstractclassmethod", "cls", "classmethod"),
+        ("abstractstaticmethod", "arg", "staticmethod"),
     ],
 )
 

--- a/tests/codemods/test_fix_deprecated_abstractproperty.py
+++ b/tests/codemods/test_fix_deprecated_abstractproperty.py
@@ -1,4 +1,5 @@
 import pytest
+
 from codemodder.codemods.test import BaseCodemodTest
 from core_codemods.fix_deprecated_abstractproperty import FixDeprecatedAbstractproperty
 

--- a/tests/codemods/test_fix_deprecated_abstractproperty.py
+++ b/tests/codemods/test_fix_deprecated_abstractproperty.py
@@ -1,138 +1,150 @@
+import pytest
 from codemodder.codemods.test import BaseCodemodTest
 from core_codemods.fix_deprecated_abstractproperty import FixDeprecatedAbstractproperty
 
+property_or_class = pytest.mark.parametrize(
+    "deprecated_func, arg_name, new_func",
+    [
+        ("abstractproperty", "self", "property"),
+        # ("abstractclassmethod", "cls", "classmethod"),
+    ],
+)
 
+
+@property_or_class
 class TestFixDeprecatedAbstractproperty(BaseCodemodTest):
     codemod = FixDeprecatedAbstractproperty
 
-    def test_import(self, tmpdir):
-        original_code = """
+    def test_import(self, tmpdir, deprecated_func, arg_name, new_func):
+        original_code = f"""
         import abc
 
         class A:
-            @abc.abstractproperty
-            def foo(self):
+            @abc.{deprecated_func}
+            def foo({arg_name}):
                 pass
         """
-        new_code = """
+        new_code = f"""
         import abc
 
         class A:
-            @property
+            @{new_func}
             @abc.abstractmethod
-            def foo(self):
+            def foo({arg_name}):
                 pass
         """
         self.run_and_assert(tmpdir, original_code, new_code)
 
-    def test_import_from(self, tmpdir):
-        original_code = """
-        from abc import abstractproperty
+    def test_import_from(self, tmpdir, deprecated_func, arg_name, new_func):
+        original_code = f"""
+        from abc import {deprecated_func}
 
         class A:
             @abstractproperty
-            def foo(self):
+            def foo({arg_name}):
                 pass
         """
-        new_code = """
+        new_code = f"""
         import abc
 
         class A:
-            @property
+            @{new_func}
             @abc.abstractmethod
-            def foo(self):
+            def foo({arg_name}):
                 pass
         """
         self.run_and_assert(tmpdir, original_code, new_code)
 
-    def test_import_alias(self, tmpdir):
-        original_code = """
-        from abc import abstractproperty as ap
+    def test_import_alias(self, tmpdir, deprecated_func, arg_name, new_func):
+        original_code = f"""
+        from abc import {deprecated_func} as ap
 
         class A:
             @ap
-            def foo(self):
+            def foo({arg_name}):
                 pass
         """
-        new_code = """
+        new_code = f"""
         import abc
 
         class A:
-            @property
+            @{new_func}
             @abc.abstractmethod
-            def foo(self):
+            def foo({arg_name}):
                 pass
         """
         self.run_and_assert(tmpdir, original_code, new_code)
 
-    def test_different_abstractproperty(self, tmpdir):
+    def test_different_abstract(self, tmpdir, deprecated_func, arg_name, new_func):
         new_code = (
             original_code
-        ) = """
-        from xyz import abstractproperty
+        ) = f"""
+        from xyz import {deprecated_func}
 
         class A:
-            @abstractproperty
-            def foo(self):
+            @{deprecated_func}
+            def foo({arg_name}):
                 pass
 
-            @property
-            def bar(self):
+            @{new_func}
+            def bar({arg_name}):
                 pass
         """
         self.run_and_assert(tmpdir, original_code, new_code)
 
-    def test_preserve_decorator_order(self, tmpdir):
-        original_code = """
+    def test_preserve_decorator_order(
+        self, tmpdir, deprecated_func, arg_name, new_func
+    ):
+        original_code = f"""
         import abc
 
         class A:
             @whatever
-            @abc.abstractproperty
-            def foo(self):
+            @abc.{deprecated_func}
+            def foo({arg_name}):
                 pass
         """
-        new_code = """
+        new_code = f"""
         import abc
 
         class A:
             @whatever
-            @property
+            @{new_func}
             @abc.abstractmethod
-            def foo(self):
+            def foo({arg_name}):
                 pass
         """
         self.run_and_assert(tmpdir, original_code, new_code)
 
-    def test_preserve_comments(self, tmpdir):
-        original_code = """
+    def test_preserve_comments(self, tmpdir, deprecated_func, arg_name, new_func):
+        original_code = f"""
         import abc
 
         class A:
-            @abc.abstractproperty # comment
-            def foo(self):
+            @abc.{deprecated_func} # comment
+            def foo({arg_name}):
                 pass
         """
-        new_code = """
+        new_code = f"""
         import abc
 
         class A:
-            @property # comment
+            @{new_func} # comment
             @abc.abstractmethod
-            def foo(self):
+            def foo({arg_name}):
                 pass
         """
         self.run_and_assert(tmpdir, original_code, new_code)
 
-    def test_exclude_line(self, tmpdir):
+    def test_exclude_line(self, tmpdir, deprecated_func, arg_name, new_func):
         input_code = (
             expected
-        ) = """
+        ) = f"""
         import abc
 
         class A:
-            @abc.abstractproperty
-            def foo(self):
+            @abc.{deprecated_func}
+            def foo({arg_name}):
                 pass
         """
         lines_to_exclude = [5]

--- a/tests/codemods/test_fix_deprecated_abstractproperty.py
+++ b/tests/codemods/test_fix_deprecated_abstractproperty.py
@@ -6,7 +6,7 @@ property_or_class = pytest.mark.parametrize(
     "deprecated_func, arg_name, new_func",
     [
         ("abstractproperty", "self", "property"),
-        # ("abstractclassmethod", "cls", "classmethod"),
+        ("abstractclassmethod", "cls", "classmethod"),
     ],
 )
 
@@ -40,7 +40,7 @@ class TestFixDeprecatedAbstractproperty(BaseCodemodTest):
         from abc import {deprecated_func}
 
         class A:
-            @abstractproperty
+            @{deprecated_func}
             def foo({arg_name}):
                 pass
         """

--- a/tests/samples/deprecated_abstractproperty.py
+++ b/tests/samples/deprecated_abstractproperty.py
@@ -1,9 +1,13 @@
-from abc import abstractproperty as ap, abstractmethod
+from abc import abstractproperty as ap, abstractclassmethod, abstractmethod
 
 
 class A:
     @ap
     def foo(self):
+        pass
+
+    @abstractclassmethod
+    def hello(cls):
         pass
 
     @abstractmethod

--- a/tests/samples/deprecated_abstractproperty.py
+++ b/tests/samples/deprecated_abstractproperty.py
@@ -1,4 +1,4 @@
-from abc import abstractproperty as ap, abstractclassmethod, abstractmethod
+from abc import abstractproperty as ap, abstractclassmethod, abstractstaticmethod, abstractmethod
 
 
 class A:
@@ -8,6 +8,10 @@ class A:
 
     @abstractclassmethod
     def hello(cls):
+        pass
+
+    @abstractstaticmethod
+    def goodbye():
         pass
 
     @abstractmethod


### PR DESCRIPTION
## Overview
*This codemod now accounts for staticmethod and classmethod deprecated properties*

## Description

* See original issue for discussion regarding the now overloaded name for this codemod.


Closes #312 
