### PR TITLE
New codemod to replace `hasattr(obj, "__call__")` with `callable`

### DIFF
--- a/integration_tests/test_fix_hasattr_call.py
+++ b/integration_tests/test_fix_hasattr_call.py
@@ -1,0 +1,32 @@
+from codemodder.codemods.test import (
+    BaseIntegrationTest,
+    original_and_expected_from_code_path,
+)
+from core_codemods.fix_hasattr_call import TransformFixHasattrCall
+
+
+class TestTransformFixHasattrCall(BaseIntegrationTest):
+    codemod = TransformFixHasattrCall
+    code_path = "tests/samples/fix_hasattr_call.py"
+    original_code, expected_new_code = original_and_expected_from_code_path(
+        code_path,
+        [
+            (4, """callable(obj)\n"""),
+        ],
+    )
+
+    # fmt: off
+    expected_diff =(
+    """--- \n"""
+    """+++ \n"""
+    """@@ -2,4 +2,4 @@\n"""
+    """     pass\n"""
+    """ \n"""
+    """ obj = Test()\n"""
+    """-hasattr(obj, "__call__")\n"""
+    """+callable(obj)\n"""
+    )
+    # fmt: on
+
+    expected_line_change = "5"
+    change_description = TransformFixHasattrCall.change_description

--- a/src/codemodder/scripts/generate_docs.py
+++ b/src/codemodder/scripts/generate_docs.py
@@ -365,3 +365,6 @@ def main():
         codemod_doc_name = f"{codemod.id.replace(':', '_').replace('/', '_')}.md"
         with open(parent_dir / codemod_doc_name, "w", encoding="utf-8") as f:
             f.write(doc)
+
+
+# Update METADATA above

--- a/src/codemodder/scripts/generate_docs.py
+++ b/src/codemodder/scripts/generate_docs.py
@@ -239,6 +239,10 @@ If you want to allow those protocols, change the incoming PR to look more like t
         importance="Low",
         guidance_explained="This codemod is a great starting point for models with few fields. We encourage you to write custom `__str__` methods that best suit your Django application.",
     ),
+    "fix-hasattr-call": DocMetadata(
+        importance="Low",
+        guidance_explained="We believe this change is safe because using `callable` is a more reliable way to check if an object is a callable.",
+    ),
 }
 
 METADATA = CORE_METADATA | {
@@ -365,6 +369,3 @@ def main():
         codemod_doc_name = f"{codemod.id.replace(':', '_').replace('/', '_')}.md"
         with open(parent_dir / codemod_doc_name, "w", encoding="utf-8") as f:
             f.write(doc)
-
-
-# Update METADATA above

--- a/src/core_codemods/__init__.py
+++ b/src/core_codemods/__init__.py
@@ -15,6 +15,7 @@ from .fix_async_task_instantiation import FixAsyncTaskInstantiation
 from .fix_deprecated_abstractproperty import FixDeprecatedAbstractproperty
 from .fix_deprecated_logging_warn import FixDeprecatedLoggingWarn
 from .fix_empty_sequence_comparison import FixEmptySequenceComparison
+from .fix_hasattr_call import TransformFixHasattrCall
 from .fix_mutable_params import FixMutableParams
 from .flask_enable_csrf_protection import FlaskEnableCSRFProtection
 from .flask_json_response_type import FlaskJsonResponseType
@@ -121,6 +122,7 @@ registry = CodemodCollection(
         StrConcatInSeqLiteral,
         FixAsyncTaskInstantiation,
         DjangoModelWithoutDunderStr,
+        TransformFixHasattrCall,
     ],
 )
 

--- a/src/core_codemods/docs/pixee_python_fix-hasattr-call.md
+++ b/src/core_codemods/docs/pixee_python_fix-hasattr-call.md
@@ -1,0 +1,11 @@
+This codemod fixes cases where `hasattr` is used to check if an object is a callable. You likely want to use `callable` instead. This is because using `hasattr` will return different results in some cases, such as when the class implements a `__getattr__` method. 
+
+Our changes look something like this:
+```diff
+ class Test:
+     pass
+
+ obj = Test()
+- hasattr(obj, "__call__")
++ callable(obj)
+```

--- a/src/core_codemods/fix_hasattr_call.py
+++ b/src/core_codemods/fix_hasattr_call.py
@@ -1,19 +1,16 @@
 import libcst as cst
-from core_codemods.api import (
-    Metadata,
-    Reference,
-    ReviewGuidance,
-    SimpleCodemod,
-)
+
+from core_codemods.api import Metadata, Reference, ReviewGuidance, SimpleCodemod
 
 
 class TransformFixHasattrCall(SimpleCodemod):
     metadata = Metadata(
         name="fix-hasattr-call",
-        summary="todo",
-        review_guidance=ReviewGuidance.MERGE_AFTER_CURSORY_REVIEW,
+        summary="Use `callable` builtin to check for callables",
+        review_guidance=ReviewGuidance.MERGE_WITHOUT_REVIEW,
         references=[
-            Reference(url="todo"),
+            Reference(url="https://docs.python.org/3/library/functions.html#callable"),
+            Reference(url="https://docs.python.org/3/library/functions.html#hasattr"),
         ],
     )
     detector_pattern = """

--- a/src/core_codemods/fix_hasattr_call.py
+++ b/src/core_codemods/fix_hasattr_call.py
@@ -1,0 +1,32 @@
+import libcst as cst
+from core_codemods.api import (
+    Metadata,
+    Reference,
+    ReviewGuidance,
+    SimpleCodemod,
+)
+
+
+class TransformFixHasattrCall(SimpleCodemod):
+    metadata = Metadata(
+        name="fix-hasattr-call",
+        summary="todo",
+        review_guidance=ReviewGuidance.MERGE_AFTER_CURSORY_REVIEW,
+        references=[
+            Reference(url="todo"),
+        ],
+    )
+    detector_pattern = """
+        - patterns:
+          - pattern: hasattr(..., "__call__")
+          - pattern-not: $MODULE.hasattr(...)
+        """
+
+    change_description = "Replace `hasattr` function call with `callable`"
+
+    def on_result_found(self, original_node, updated_node):
+        del original_node
+        return updated_node.with_changes(
+            func=updated_node.func.with_changes(value="callable"),
+            args=[updated_node.args[0].with_changes(comma=cst.MaybeSentinel.DEFAULT)],
+        )

--- a/tests/codemods/test_fix_hasattr_call.py
+++ b/tests/codemods/test_fix_hasattr_call.py
@@ -1,0 +1,79 @@
+from codemodder.codemods.test import BaseSemgrepCodemodTest
+from core_codemods.fix_hasattr_call import TransformFixHasattrCall
+
+
+class TestTransformFixHasattrCall(BaseSemgrepCodemodTest):
+    codemod = TransformFixHasattrCall
+
+    def test_name(self):
+        assert self.codemod.name == "fix-hasattr-call"
+
+    def test_combine(self, tmpdir):
+        input_code = """
+        class Test:
+            pass
+
+        hasattr(Test(), "__call__")
+        hasattr("hi", '__call__')
+        
+        assert hasattr(1, '__call__')
+        obj = Test()
+        var = hasattr(obj, "__call__")
+        
+        if hasattr(obj, "__call__"):
+            print(1)
+        """
+        expected = """
+        class Test:
+            pass
+
+        callable(Test())
+        callable("hi")
+        
+        assert callable(1)
+        obj = Test()
+        var = callable(obj)
+        
+        if callable(obj):
+            print(1)
+        """
+        self.run_and_assert(tmpdir, input_code, expected, num_changes=5)
+
+    def test_other_hasattr(self, tmpdir):
+        code = """
+        from myscript import hasattr
+        
+        class Test:
+            pass
+
+        hasattr(Test(), "__call__")
+        hasattr("hi", '__call__')
+        """
+        self.run_and_assert(tmpdir, code, code)
+
+    def test_other_attr(self, tmpdir):
+        code = """
+        class Test:
+            pass
+
+        hasattr(Test(), "__repr__")
+        hasattr("hi", '__repr__')
+        """
+        self.run_and_assert(tmpdir, code, code)
+
+    def test_exclude_line(self, tmpdir):
+        input_code = (
+            expected
+        ) = """
+        class Test:
+            pass
+        obj = Test()
+        hasattr(obj, "__call__")
+        """
+        lines_to_exclude = [5]
+        self.run_and_assert(
+            tmpdir,
+            input_code,
+            expected,
+            lines_to_exclude=lines_to_exclude,
+        )

--- a/tests/samples/fix_hasattr_call.py
+++ b/tests/samples/fix_hasattr_call.py
@@ -1,0 +1,5 @@
+class Test:
+    pass
+
+obj = Test()
+hasattr(obj, "__call__")


### PR DESCRIPTION
## Overview
*Using `callable` is the recommended and reliable way to check if something is a callable*


Closes #290 