### PR TITLE
Revert to push-based workflow for releases

### DIFF
--- a/.github/workflows/deploy_to_pypi.yml
+++ b/.github/workflows/deploy_to_pypi.yml
@@ -1,10 +1,7 @@
 name: Deploy to PyPI
 
 on:
-  workflow_run:
-    workflows: ["Unit Tests"]
-    types:
-      - completed
+  push:
     tags:
       - "[0-9]+.[0-9]+.[0-9]+"
 


### PR DESCRIPTION
## Overview
*Revert to push-based workflow for release*

## Description

* I was hoping we could gate the release workflow on successful completion of the unit tests
* Unfortunately the `workflow_run` trigger does not allow filtering based on tags, so we can't do this right now
* I opened a discussion item here: https://github.com/orgs/community/discussions/111043
* Closes #334