### PR TITLE
Use system monitoring for faster coverage on Py3.12

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ COV_FLAGS = --cov-fail-under=94 --cov=codemodder --cov=core_codemods
 XDIST_FLAGS = --numprocesses auto
 
 test:
-	${PYTEST} ${COV_FLAGS} tests ${XDIST_FLAGS}
+	COVERAGE_CORE=sysmon ${PYTEST} ${COV_FLAGS} tests ${XDIST_FLAGS}
 
 integration-test:
 	${PYTEST} integration_tests


### PR DESCRIPTION
## Summary
*Enable low-impact system monitoring for `coverage` in Python 3.12*

## Details
~This is a bit of a long shot but it might (partially) address #338.~

**UPDATE**: This took the Python 3.12 unit tests from ~20 mins to ~4 mins. It had no impact on the other Python versions (as expected).

Closes #338.