### PR TITLE
New codemod to add missing `self`/`cls`

### DIFF
--- a/integration_tests/test_fix_missing_self_or_cls.py
+++ b/integration_tests/test_fix_missing_self_or_cls.py
@@ -1,0 +1,44 @@
+from codemodder.codemods.test import (
+    BaseIntegrationTest,
+    original_and_expected_from_code_path,
+)
+from core_codemods.fix_missing_self_or_cls import FixMissingSelfOrCls
+
+
+class TestFixMissingSelfOrCls(BaseIntegrationTest):
+    codemod = FixMissingSelfOrCls
+    code_path = "tests/samples/fix_missing_self_or_cls.py"
+    original_code, expected_new_code = original_and_expected_from_code_path(
+        code_path,
+        [
+            (
+                1,
+                """    def instance_method(self):\n""",
+            ),
+            (
+                5,
+                """    def class_method(cls):\n""",
+            ),
+        ],
+    )
+
+    # fmt: off
+    expected_diff = (
+    """--- \n"""
+    """+++ \n"""
+    """@@ -1,7 +1,7 @@\n"""
+    """ class MyClass:\n"""
+    """-    def instance_method():\n"""
+    """+    def instance_method(self):\n"""
+    """         print("instance_method")\n"""
+    """ \n"""
+    """     @classmethod\n"""
+    """-    def class_method():\n"""
+    """+    def class_method(cls):\n"""
+    """         print("class_method")\n"""
+    )
+    # fmt: on
+
+    expected_line_change = "2"
+    change_description = FixMissingSelfOrCls.change_description
+    num_changes = 2

--- a/integration_tests/test_sonar_fix_missing_self_or_cls.py
+++ b/integration_tests/test_sonar_fix_missing_self_or_cls.py
@@ -2,14 +2,12 @@ from codemodder.codemods.test import (
     BaseIntegrationTest,
     original_and_expected_from_code_path,
 )
-from core_codemods.fix_missing_self_or_cls import (
-    FixMissingSelfOrCls,
-    FixMissingSelfOrClsTransformer,
-)
+from core_codemods.fix_missing_self_or_cls import FixMissingSelfOrClsTransformer
+from core_codemods.sonar.sonar_fix_missing_self_or_cls import SonarFixMissingSelfOrCls
 
 
-class TestFixMissingSelfOrCls(BaseIntegrationTest):
-    codemod = FixMissingSelfOrCls
+class TestSonarFixMissingSelfOrCls(BaseIntegrationTest):
+    codemod = SonarFixMissingSelfOrCls
     code_path = "tests/samples/fix_missing_self_or_cls.py"
     original_code, expected_new_code = original_and_expected_from_code_path(
         code_path,
@@ -24,7 +22,7 @@ class TestFixMissingSelfOrCls(BaseIntegrationTest):
             ),
         ],
     )
-
+    sonar_issues_json = "tests/samples/sonar_issues.json"
     # fmt: off
     expected_diff = (
     """--- \n"""

--- a/src/codemodder/codemods/utils_mixin.py
+++ b/src/codemodder/codemods/utils_mixin.py
@@ -277,6 +277,18 @@ class NameResolutionMixin(MetadataDependent):
             return matchers.matches(node.func, matchers.Name())
         return False
 
+    def is_staticmethod(self, node: cst.FunctionDef) -> bool:
+        for decorator in node.decorators:
+            if self.find_base_name(decorator.decorator) == "builtins.staticmethod":
+                return True
+        return False
+
+    def is_classmethod(self, node: cst.FunctionDef) -> bool:
+        for decorator in node.decorators:
+            if self.find_base_name(decorator.decorator) == "builtins.classmethod":
+                return True
+        return False
+
     def find_accesses(self, node) -> Collection[Access]:
         if scope := self.get_metadata(ScopeProvider, node, None):
             return scope.accesses[node]

--- a/src/codemodder/codemods/utils_mixin.py
+++ b/src/codemodder/codemods/utils_mixin.py
@@ -449,10 +449,10 @@ class AncestorPatternsMixin(MetadataDependent):
 
     def path_to_root(self, node: cst.CSTNode) -> list[cst.CSTNode]:
         """
-        Returns node's path to root. Includes self.
+        Returns node's path to `node` (excludes `node`).
         """
         path = []
-        maybe_parent = node
+        maybe_parent = self.get_parent(node)
         while maybe_parent:
             path.append(maybe_parent)
             maybe_parent = self.get_parent(maybe_parent)

--- a/src/codemodder/scripts/generate_docs.py
+++ b/src/codemodder/scripts/generate_docs.py
@@ -309,6 +309,11 @@ METADATA = CORE_METADATA | {
         guidance_explained=CORE_METADATA["jwt-decode-verify"].guidance_explained,
         need_sarif="Yes (Sonar)",
     ),
+    "fix-missing-self-or-cls-S5719": DocMetadata(
+        importance=CORE_METADATA["fix-missing-self-or-cls"].importance,
+        guidance_explained=CORE_METADATA["fix-missing-self-or-cls"].guidance_explained,
+        need_sarif="Yes (Sonar)",
+    ),
 }
 
 

--- a/src/codemodder/scripts/generate_docs.py
+++ b/src/codemodder/scripts/generate_docs.py
@@ -251,6 +251,10 @@ If you want to allow those protocols, change the incoming PR to look more like t
         importance="Medium",
         guidance_explained="This change is safe and will prevent runtime `ValueError`.",
     ),
+    "fix-missing-self-or-cls": DocMetadata(
+        importance="Medium",
+        guidance_explained="This change is safe and will prevent errors when calling on these instance or class methods..",
+    ),
 }
 
 METADATA = CORE_METADATA | {

--- a/src/core_codemods/__init__.py
+++ b/src/core_codemods/__init__.py
@@ -49,6 +49,7 @@ from .sonar.sonar_django_json_response_type import SonarDjangoJsonResponseType
 from .sonar.sonar_django_receiver_on_top import SonarDjangoReceiverOnTop
 from .sonar.sonar_exception_without_raise import SonarExceptionWithoutRaise
 from .sonar.sonar_fix_assert_tuple import SonarFixAssertTuple
+from .sonar.sonar_fix_missing_self_or_cls import SonarFixMissingSelfOrCls
 from .sonar.sonar_flask_json_response_type import SonarFlaskJsonResponseType
 from .sonar.sonar_jwt_decode_verify import SonarJwtDecodeVerify
 from .sonar.sonar_literal_or_new_object_identity import SonarLiteralOrNewObjectIdentity
@@ -144,5 +145,6 @@ sonar_registry = CodemodCollection(
         SonarFlaskJsonResponseType,
         SonarDjangoJsonResponseType,
         SonarJwtDecodeVerify,
+        SonarFixMissingSelfOrCls,
     ],
 )

--- a/src/core_codemods/__init__.py
+++ b/src/core_codemods/__init__.py
@@ -17,6 +17,7 @@ from .fix_deprecated_abstractproperty import FixDeprecatedAbstractproperty
 from .fix_deprecated_logging_warn import FixDeprecatedLoggingWarn
 from .fix_empty_sequence_comparison import FixEmptySequenceComparison
 from .fix_hasattr_call import TransformFixHasattrCall
+from .fix_missing_self_or_cls import FixMissingSelfOrCls
 from .fix_mutable_params import FixMutableParams
 from .flask_enable_csrf_protection import FlaskEnableCSRFProtection
 from .flask_json_response_type import FlaskJsonResponseType
@@ -127,6 +128,7 @@ registry = CodemodCollection(
         DjangoModelWithoutDunderStr,
         TransformFixHasattrCall,
         FixDataclassDefaults,
+        FixMissingSelfOrCls,
     ],
 )
 

--- a/src/core_codemods/docs/pixee_python_fix-missing-self-or-cls.md
+++ b/src/core_codemods/docs/pixee_python_fix-missing-self-or-cls.md
@@ -1,0 +1,15 @@
+Python instance methods must be defined with `self` as the first argument. Likewise, class methods must have `cls` as the first argument. This codemod will add these arguments the method/class method has no arguments defined.
+
+Our changes look something like this:
+
+```diff
+ class MyClass:
+-    def instance_method():
++    def instance_method(self):
+         print("instance_method")
+
+     @classmethod
+-    def class_method():
++    def class_method(cls):
+         print("class_method")
+```

--- a/src/core_codemods/docs/pixee_python_fix-missing-self-or-cls.md
+++ b/src/core_codemods/docs/pixee_python_fix-missing-self-or-cls.md
@@ -1,4 +1,4 @@
-Python instance methods must be defined with `self` as the first argument. Likewise, class methods must have `cls` as the first argument. This codemod will add these arguments the method/class method has no arguments defined.
+Python instance methods must be defined with `self` as the first argument. Likewise, class methods must have `cls` as the first argument. This codemod will add these arguments when the method/class method has no arguments defined.
 
 Our changes look something like this:
 

--- a/src/core_codemods/fix_missing_self_or_cls.py
+++ b/src/core_codemods/fix_missing_self_or_cls.py
@@ -4,51 +4,50 @@ from codemodder.codemods.libcst_transformer import (
     LibcstResultTransformer,
     LibcstTransformerPipeline,
 )
-from codemodder.codemods.utils_mixin import NameResolutionMixin
+from codemodder.codemods.utils_mixin import NameAndAncestorResolutionMixin
 from core_codemods.api import Metadata, ReviewGuidance
 from core_codemods.api.core_codemod import CoreCodemod
 
 
-class FixMissingSelfOrClsTransformer(LibcstResultTransformer, NameResolutionMixin):
+class FixMissingSelfOrClsTransformer(
+    LibcstResultTransformer, NameAndAncestorResolutionMixin
+):
     change_description = "Add `self` or `cls` parameter to instance or class method."
-
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
-        self.current_class_name = None
-
-    def visit_ClassDef(self, node: cst.ClassDef) -> bool:
-        self.current_class_name = node.name.value
-        return True
-
-    def leave_ClassDef(
-        self, original_node: cst.ClassDef, updated_node: cst.ClassDef
-    ) -> cst.ClassDef:
-        self.current_class_name = None
-        return updated_node
 
     def leave_FunctionDef(
         self, original_node: cst.FunctionDef, updated_node: cst.FunctionDef
     ) -> cst.FunctionDef:
-        if self.current_class_name:
-            if original_node.decorators:
-                if self.is_staticmethod(original_node):
-                    return updated_node
-                if self.is_classmethod(original_node):
-                    if self.has_no_args(original_node):
-                        self.report_change(original_node)
-                        return updated_node.with_changes(
-                            params=updated_node.params.with_changes(
-                                params=[cst.Param(name=cst.Name("cls"))]
-                            )
-                        )
-            else:
+        # TODO: add filter by include or exclude that works for nodes
+        # that that have different start/end numbers.
+
+        if not self.find_immediate_class_def(original_node):
+            # If `original_node` is not inside a class, nothing to do.
+            return original_node
+
+        if self.find_immediate_function_def(original_node):
+            # If `original_node` is inside a class but also nested within a function/method
+            # We won't touch it.
+            return original_node
+
+        if original_node.decorators:
+            if self.is_staticmethod(original_node):
+                return updated_node
+            if self.is_classmethod(original_node):
                 if self.has_no_args(original_node):
                     self.report_change(original_node)
                     return updated_node.with_changes(
                         params=updated_node.params.with_changes(
-                            params=[cst.Param(name=self._pick_arg_name(original_node))]
+                            params=[cst.Param(name=cst.Name("cls"))]
                         )
                     )
+        else:
+            if self.has_no_args(original_node):
+                self.report_change(original_node)
+                return updated_node.with_changes(
+                    params=updated_node.params.with_changes(
+                        params=[cst.Param(name=self._pick_arg_name(original_node))]
+                    )
+                )
         return updated_node
 
     def _pick_arg_name(self, node: cst.FunctionDef) -> cst.Name:
@@ -79,7 +78,7 @@ class FixMissingSelfOrClsTransformer(LibcstResultTransformer, NameResolutionMixi
 FixMissingSelfOrCls = CoreCodemod(
     metadata=Metadata(
         name="fix-missing-self-or-cls",
-        review_guidance=ReviewGuidance.MERGE_WITHOUT_REVIEW,
+        review_guidance=ReviewGuidance.MERGE_AFTER_CURSORY_REVIEW,
         summary="Add Missing Positional Parameter for Instance and Class Methods",
         references=[],
     ),

--- a/src/core_codemods/fix_missing_self_or_cls.py
+++ b/src/core_codemods/fix_missing_self_or_cls.py
@@ -1,17 +1,15 @@
 import libcst as cst
 
+from codemodder.codemods.libcst_transformer import (
+    LibcstResultTransformer,
+    LibcstTransformerPipeline,
+)
 from codemodder.codemods.utils_mixin import NameResolutionMixin
-from core_codemods.api import Metadata, ReviewGuidance, SimpleCodemod
+from core_codemods.api import Metadata, ReviewGuidance
+from core_codemods.api.core_codemod import CoreCodemod
 
 
-class FixMissingSelfOrCls(SimpleCodemod, NameResolutionMixin):
-    metadata = Metadata(
-        name="fix-missing-self-or-cls",
-        review_guidance=ReviewGuidance.MERGE_WITHOUT_REVIEW,
-        summary="Fix Missing Positional Parameter for Instance and Class Methods",
-        references=[],
-    )
-
+class FixMissingSelfOrClsTransformer(LibcstResultTransformer, NameResolutionMixin):
     change_description = "Add `self` or `cls` parameter to instance or class method."
 
     def __init__(self, *args, **kwargs):
@@ -76,3 +74,15 @@ class FixMissingSelfOrCls(SimpleCodemod, NameResolutionMixin):
                 node.params.posonly_params,
             )
         )
+
+
+FixMissingSelfOrCls = CoreCodemod(
+    metadata=Metadata(
+        name="fix-missing-self-or-cls",
+        review_guidance=ReviewGuidance.MERGE_WITHOUT_REVIEW,
+        summary="Fix Missing Positional Parameter for Instance and Class Methods",
+        references=[],
+    ),
+    transformer=LibcstTransformerPipeline(FixMissingSelfOrClsTransformer),
+    detector=None,
+)

--- a/src/core_codemods/fix_missing_self_or_cls.py
+++ b/src/core_codemods/fix_missing_self_or_cls.py
@@ -7,12 +7,12 @@ from core_codemods.api import Metadata, ReviewGuidance, SimpleCodemod
 class FixMissingSelfOrCls(SimpleCodemod, NameResolutionMixin):
     metadata = Metadata(
         name="fix-missing-self-or-cls",
-        review_guidance=ReviewGuidance.MERGE_AFTER_CURSORY_REVIEW,
-        summary="todo",
+        review_guidance=ReviewGuidance.MERGE_WITHOUT_REVIEW,
+        summary="Fix Missing Positional Parameter for Instance and Class Methods",
         references=[],
     )
 
-    change_description = "todo"
+    change_description = "Add `self` or `cls` parameter to instance or class method."
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)

--- a/src/core_codemods/fix_missing_self_or_cls.py
+++ b/src/core_codemods/fix_missing_self_or_cls.py
@@ -1,0 +1,78 @@
+import libcst as cst
+
+from codemodder.codemods.utils_mixin import NameResolutionMixin
+from core_codemods.api import Metadata, ReviewGuidance, SimpleCodemod
+
+
+class FixMissingSelfOrCls(SimpleCodemod, NameResolutionMixin):
+    metadata = Metadata(
+        name="fix-missing-self-or-cls",
+        review_guidance=ReviewGuidance.MERGE_AFTER_CURSORY_REVIEW,
+        summary="todo",
+        references=[],
+    )
+
+    change_description = "todo"
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.current_class_name = None
+
+    def visit_ClassDef(self, node: cst.ClassDef) -> bool:
+        self.current_class_name = node.name.value
+        return True
+
+    def leave_ClassDef(
+        self, original_node: cst.ClassDef, updated_node: cst.ClassDef
+    ) -> cst.ClassDef:
+        self.current_class_name = None
+        return updated_node
+
+    def leave_FunctionDef(
+        self, original_node: cst.FunctionDef, updated_node: cst.FunctionDef
+    ) -> cst.FunctionDef:
+        if self.current_class_name:
+            if original_node.decorators:
+                if self.is_staticmethod(original_node):
+                    return updated_node
+                if self.is_classmethod(original_node):
+                    if self.has_no_args(original_node):
+                        self.report_change(original_node)
+                        return updated_node.with_changes(
+                            params=updated_node.params.with_changes(
+                                params=[cst.Param(name=cst.Name("cls"))]
+                            )
+                        )
+            else:
+                if self.has_no_args(original_node):
+                    self.report_change(original_node)
+                    return updated_node.with_changes(
+                        params=updated_node.params.with_changes(
+                            params=[cst.Param(name=self._pick_arg_name(original_node))]
+                        )
+                    )
+        return updated_node
+
+    def _pick_arg_name(self, node: cst.FunctionDef) -> cst.Name:
+        match node.name:
+            case cst.Name(value="__new__") | cst.Name(value="__init_subclass__"):
+                new_name = "cls"
+            case _:
+                new_name = "self"
+        return cst.Name(value=new_name)
+
+    def has_no_args(self, node: cst.FunctionDef) -> bool:
+        converted_star_arg = (
+            None
+            if node.params.star_arg is cst.MaybeSentinel.DEFAULT
+            else node.params.star_arg
+        )
+        return not any(
+            (
+                node.params.params,
+                converted_star_arg,
+                node.params.kwonly_params,
+                node.params.star_kwarg,
+                node.params.posonly_params,
+            )
+        )

--- a/src/core_codemods/fix_missing_self_or_cls.py
+++ b/src/core_codemods/fix_missing_self_or_cls.py
@@ -80,7 +80,7 @@ FixMissingSelfOrCls = CoreCodemod(
     metadata=Metadata(
         name="fix-missing-self-or-cls",
         review_guidance=ReviewGuidance.MERGE_WITHOUT_REVIEW,
-        summary="Fix Missing Positional Parameter for Instance and Class Methods",
+        summary="Add Missing Positional Parameter for Instance and Class Methods",
         references=[],
     ),
     transformer=LibcstTransformerPipeline(FixMissingSelfOrClsTransformer),

--- a/src/core_codemods/sonar/sonar_fix_missing_self_or_cls.py
+++ b/src/core_codemods/sonar/sonar_fix_missing_self_or_cls.py
@@ -1,0 +1,12 @@
+from codemodder.codemods.base_codemod import Reference
+from codemodder.codemods.sonar import SonarCodemod
+from core_codemods.fix_missing_self_or_cls import FixMissingSelfOrCls
+
+SonarNumpyNanEquality = SonarCodemod.from_core_codemod(
+    name="fix-missing-self-or-cls-S5719",
+    other=FixMissingSelfOrCls,
+    rules=["python:S5719"],
+    new_references=[
+        Reference(url="https://rules.sonarsource.com/python/RSPEC-5719/"),
+    ],
+)

--- a/src/core_codemods/sonar/sonar_fix_missing_self_or_cls.py
+++ b/src/core_codemods/sonar/sonar_fix_missing_self_or_cls.py
@@ -1,12 +1,10 @@
-from codemodder.codemods.base_codemod import Reference
 from codemodder.codemods.sonar import SonarCodemod
 from core_codemods.fix_missing_self_or_cls import FixMissingSelfOrCls
 
 SonarFixMissingSelfOrCls = SonarCodemod.from_core_codemod(
     name="fix-missing-self-or-cls-S5719",
     other=FixMissingSelfOrCls,
-    rules=["python:S5719"],
-    new_references=[
-        Reference(url="https://rules.sonarsource.com/python/RSPEC-5719/"),
-    ],
+    rule_id="python:S5719",
+    rule_name="Instance and class methods should have at least one positional parameter",
+    rule_url="https://rules.sonarsource.com/python/RSPEC-5719/",
 )

--- a/src/core_codemods/sonar/sonar_fix_missing_self_or_cls.py
+++ b/src/core_codemods/sonar/sonar_fix_missing_self_or_cls.py
@@ -2,7 +2,7 @@ from codemodder.codemods.base_codemod import Reference
 from codemodder.codemods.sonar import SonarCodemod
 from core_codemods.fix_missing_self_or_cls import FixMissingSelfOrCls
 
-SonarNumpyNanEquality = SonarCodemod.from_core_codemod(
+SonarFixMissingSelfOrCls = SonarCodemod.from_core_codemod(
     name="fix-missing-self-or-cls-S5719",
     other=FixMissingSelfOrCls,
     rules=["python:S5719"],

--- a/tests/codemods/test_fix_missing_self_or_cls.py
+++ b/tests/codemods/test_fix_missing_self_or_cls.py
@@ -41,6 +41,41 @@ class TestFixMissingSelfOrCls(BaseCodemodTest):
         """
         self.run_and_assert(tmpdir, input_code, expected, num_changes=4)
 
+    def test_change_not_nested(self, tmpdir):
+        input_code = """
+        class A:
+            def method():
+                def inner():
+                    pass
+
+            @classmethod
+            def clsmethod():
+                def other_inner():
+                    pass
+        
+        def wrapper():
+            class B:
+                def method():
+                    pass                    
+        """
+        expected = """
+        class A:
+            def method(self):
+                def inner():
+                    pass
+
+            @classmethod
+            def clsmethod(cls):
+                def other_inner():
+                    pass
+
+        def wrapper():
+            class B:
+                def method():
+                    pass                    
+        """
+        self.run_and_assert(tmpdir, input_code, expected, num_changes=2)
+
     @pytest.mark.parametrize(
         "code",
         [
@@ -56,7 +91,7 @@ class TestFixMissingSelfOrCls(BaseCodemodTest):
                 @classmethod
                 def clsmethod(cls, arg):
                     pass
-                    
+
                 @staticmethod
                 def my_static():
                     pass
@@ -67,6 +102,12 @@ class TestFixMissingSelfOrCls(BaseCodemodTest):
                     pass
                 def __init_subclass__(**kwargs):
                     pass
+            """,
+            """
+            class A():
+              def f(self):
+                def g():
+                  pass
             """,
         ],
     )
@@ -94,17 +135,3 @@ class TestFixMissingSelfOrCls(BaseCodemodTest):
                pass
            """
         self.run_and_assert(tmpdir, input_code, input_code)
-
-    # def test_exclude_line(self, tmpdir):
-    #     input_code = (
-    #         expected
-    #     ) = """
-    #     assert (1, 2)
-    #     """
-    #     lines_to_exclude = [2]
-    #     self.run_and_assert(
-    #         tmpdir,
-    #         input_code,
-    #         expected,
-    #         lines_to_exclude=lines_to_exclude,
-    #     )

--- a/tests/codemods/test_fix_missing_self_or_cls.py
+++ b/tests/codemods/test_fix_missing_self_or_cls.py
@@ -1,0 +1,110 @@
+import pytest
+
+from codemodder.codemods.test import BaseCodemodTest
+from core_codemods.fix_missing_self_or_cls import FixMissingSelfOrCls
+
+
+class TestFixMissingSelfOrCls(BaseCodemodTest):
+    codemod = FixMissingSelfOrCls
+
+    def test_name(self):
+        assert self.codemod.name == "fix-missing-self-or-cls"
+
+    def test_change(self, tmpdir):
+        input_code = """
+        class A:
+            def method():
+                pass
+            
+            @classmethod
+            def clsmethod():
+                pass
+
+            def __new__():
+                pass
+            def __init_subclass__():
+                pass
+        """
+        expected = """
+        class A:
+            def method(self):
+                pass
+            
+            @classmethod
+            def clsmethod(cls):
+                pass
+
+            def __new__(cls):
+                pass
+            def __init_subclass__(cls):
+                pass
+        """
+        self.run_and_assert(tmpdir, input_code, expected, num_changes=4)
+
+    @pytest.mark.parametrize(
+        "code",
+        [
+            """
+            def my_function():
+                pass
+            """,
+            """
+            class A:
+                def method(self, arg):
+                    pass
+
+                @classmethod
+                def clsmethod(cls, arg):
+                    pass
+                    
+                @staticmethod
+                def my_static():
+                    pass
+            """,
+            """
+            class MyBaseClass:
+                def __new__(*args, **kwargs):
+                    pass
+                def __init_subclass__(**kwargs):
+                    pass
+            """,
+        ],
+    )
+    def test_no_change(self, tmpdir, code):
+        self.run_and_assert(tmpdir, code, code)
+
+    def test_with_args_no_change(self, tmpdir):
+        input_code = """
+        class A:
+            def method(one, two):
+               pass
+
+            def method(*args, two=2):
+               pass
+               
+            def method(**kwargs):
+               pass
+                                  
+            @classmethod
+            def clsmethod(one, two):
+               pass
+        
+            @classmethod
+            def kls(**kwargs):
+               pass
+           """
+        self.run_and_assert(tmpdir, input_code, input_code)
+
+    # def test_exclude_line(self, tmpdir):
+    #     input_code = (
+    #         expected
+    #     ) = """
+    #     assert (1, 2)
+    #     """
+    #     lines_to_exclude = [2]
+    #     self.run_and_assert(
+    #         tmpdir,
+    #         input_code,
+    #         expected,
+    #         lines_to_exclude=lines_to_exclude,
+    #     )

--- a/tests/codemods/test_sonar_fix_missing_self_or_cls.py
+++ b/tests/codemods/test_sonar_fix_missing_self_or_cls.py
@@ -1,0 +1,65 @@
+import json
+
+from codemodder.codemods.test import BaseSASTCodemodTest
+from core_codemods.sonar.sonar_fix_missing_self_or_cls import SonarFixMissingSelfOrCls
+
+
+class TestSonarFixMissingSelfOrCls(BaseSASTCodemodTest):
+    codemod = SonarFixMissingSelfOrCls
+    tool = "sonar"
+
+    def test_name(self):
+        assert self.codemod.name == "fix-missing-self-or-cls-S5719"
+
+    def test_simple(self, tmpdir):
+        input_code = """
+        class A:
+            def method():
+                pass
+            
+            @classmethod
+            def clsmethod():
+                pass
+        """
+        expected_output = """
+        class A:
+            def method(self):
+                pass
+            
+            @classmethod
+            def clsmethod(cls):
+                pass
+        """
+        issues = {
+            "issues": [
+                {
+                    "rule": "python:S5719",
+                    "status": "OPEN",
+                    "component": "code.py",
+                    "textRange": {
+                        "startLine": 2,
+                        "endLine": 2,
+                        "startOffset": 4,
+                        "endOffset": 25,
+                    },
+                },
+                {
+                    "rule": "python:S5719",
+                    "status": "OPEN",
+                    "component": "code.py",
+                    "textRange": {
+                        "startLine": 6,
+                        "endLine": 6,
+                        "startOffset": 4,
+                        "endOffset": 22,
+                    },
+                },
+            ]
+        }
+        self.run_and_assert(
+            tmpdir,
+            input_code,
+            expected_output,
+            results=json.dumps(issues),
+            num_changes=2,
+        )

--- a/tests/samples/fix_missing_self_or_cls.py
+++ b/tests/samples/fix_missing_self_or_cls.py
@@ -1,0 +1,7 @@
+class MyClass:
+    def instance_method():
+        print("instance_method")
+
+    @classmethod
+    def class_method():
+        print("class_method")

--- a/tests/test_ancestorpatterns_mixin.py
+++ b/tests/test_ancestorpatterns_mixin.py
@@ -46,7 +46,7 @@ class TestNameResolutionMixin:
                 node = stmt.body[0]
 
                 path = self.path_to_root(node)
-                assert len(path) == 3
+                assert len(path) == 2
                 return tree
 
         input_code = dedent(


### PR DESCRIPTION
## Overview
*A codemod that checks if instance/class methods without any args need self/cls*

## Description

* This codemod follows [the sonar rule](https://rules.sonarsource.com/python/RSPEC-5719/) exactly, without adding any other features other than the edge cases for `__new__` and `__init_subclass__` sonar mentions
* However, while working on this I thought about additional steps we could take, either in this codemod or as a separate codemod:
1. As is, we're only checking methods/class methods with no args at all. However, what about those which have args but none are `self` / `cls`?
2.  As is, when a method has no args, we just add `self`. However, another valid change would be to make it a `@staticmethod`. For example:
```
def A(): 
	print("instance_method")
	# `self` is never used in the method, we could make this a staticmethod

def B(): 
	self.hi = 1
        # `self` is used, so this should have `self` as an arg
```

Right now we handle both cases the same: just add `self`. However, we could decide to handle for case `A` by checking if `self` is ever used. Could be a bit tricky. It is less risky to just add `self` than it is to incorrectly assume `self` is never used and making it a staticmethod.


Closes #297