### PR TITLE
chore: add ssh repo deploy key option to automated PRs

### DIFF
--- a/.github/workflows/pre-commit-autoupdate.yml
+++ b/.github/workflows/pre-commit-autoupdate.yml
@@ -12,11 +12,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          ssh-key: ${{ secrets.SSH_REPO_DEPLOY_KEY }}
       - uses: actions/setup-python@v5
       - uses: browniebroke/pre-commit-autoupdate-action@main
       - uses: peter-evans/create-pull-request@v6
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.SSH_REPO_DEPLOY_KEY }}
           branch: update/pre-commit-hooks
           title: Update pre-commit hooks
           commit-message: "chore: update pre-commit hooks"


### PR DESCRIPTION
## Overview
Closes https://github.com/pixee/codemodder-python/issues/322

## Description

Per the [docs](https://github.com/peter-evans/create-pull-request/blob/main/docs/concepts-guidelines.md#triggering-further-workflow-runs) of `peter-evans/create-pull-request` GH action (and github in general) triggering an automated PR doesn't cascade down into other GH actions, which makes sense for sanity reasons. 

The proposed [workaround](https://github.com/peter-evans/create-pull-request/blob/main/docs/concepts-guidelines.md#push-using-ssh-deploy-keys) is to create a repo-scoped SSH [deploy key](https://docs.github.com/en/authentication/connecting-to-github-with-ssh/managing-deploy-keys#deploy-keys) and use that in the GH action instead. 

This PR adds a proposed secret var, `SSH_REPO_DEPLOY_KEY`, which must be added in the settings of the repo *BEFORE* this PR is merged. 

## Additional Details
See warning above: the ssh deploy repo-scoped `SSH_REPO_DEPLOY_KEY` ⚠️ must ⚠️  be added before this is merged.

Additionally, note that with this workaround only the `on: push` workflows will be triggered. This should be good enough for the lint/testing workflows.