### PR TITLE
Fix metadata key error

### DIFF
--- a/integration_tests/test_unnecessary_f_str.py
+++ b/integration_tests/test_unnecessary_f_str.py
@@ -1,5 +1,3 @@
-import pytest
-
 from codemodder.codemods.test import (
     BaseIntegrationTest,
     original_and_expected_from_code_path,
@@ -10,9 +8,6 @@ from core_codemods.remove_unnecessary_f_str import (
 )
 
 
-@pytest.mark.skipif(
-    True, reason="May fail if it runs after test_sql_parameterization. See Issue #378."
-)
 class TestFStr(BaseIntegrationTest):
     codemod = RemoveUnnecessaryFStr
     code_path = "tests/samples/unnecessary_f_str.py"

--- a/src/core_codemods/__init__.py
+++ b/src/core_codemods/__init__.py
@@ -37,8 +37,7 @@ from .remove_assertion_in_pytest_raises import RemoveAssertionInPytestRaises
 from .remove_debug_breakpoint import RemoveDebugBreakpoint
 from .remove_future_imports import RemoveFutureImports
 from .remove_module_global import RemoveModuleGlobal
-
-# from .remove_unnecessary_f_str import RemoveUnnecessaryFStr
+from .remove_unnecessary_f_str import RemoveUnnecessaryFStr
 from .remove_unused_imports import RemoveUnusedImports
 from .replace_flask_send_file import ReplaceFlaskSendFile
 from .requests_verify import RequestsVerify
@@ -89,7 +88,7 @@ registry = CodemodCollection(
         OrderImports,
         ProcessSandbox,
         RemoveFutureImports,
-        # RemoveUnnecessaryFStr, # Temporarely disabled due to potential error. See Issue #378.
+        RemoveUnnecessaryFStr,
         RemoveUnusedImports,
         RequestsVerify,
         SecureFlaskCookie,

--- a/src/core_codemods/remove_unnecessary_f_str.py
+++ b/src/core_codemods/remove_unnecessary_f_str.py
@@ -1,6 +1,7 @@
+from typing import cast
+
 import libcst as cst
 import libcst.matchers as m
-from libcst.codemod import CodemodContext
 from libcst.codemod.commands.unnecessary_format_string import UnnecessaryFormatString
 
 from codemodder.codemods.libcst_transformer import (
@@ -11,17 +12,8 @@ from core_codemods.api import Metadata, Reference, ReviewGuidance
 from core_codemods.api.core_codemod import CoreCodemod
 
 
-class RemoveUnnecessaryFStrTransform(LibcstResultTransformer, UnnecessaryFormatString):
-
+class RemoveUnnecessaryFStrTransform(LibcstResultTransformer):
     change_description = "Remove unnecessary f-string"
-
-    def __init__(
-        self, codemod_context: CodemodContext, *codemod_args, **codemod_kwargs
-    ):
-        UnnecessaryFormatString.__init__(self, codemod_context)
-        LibcstResultTransformer.__init__(
-            self, codemod_context, *codemod_args, **codemod_kwargs
-        )
 
     @m.leave(m.FormattedString(parts=(m.FormattedStringText(),)))
     def _check_formatted_string(
@@ -34,7 +26,9 @@ class RemoveUnnecessaryFStrTransform(LibcstResultTransformer, UnnecessaryFormatS
         ):
             return updated_node
 
-        transformed_node = super()._check_formatted_string(_original_node, updated_node)
+        transformed_node = UnnecessaryFormatString._check_formatted_string(
+            cast(UnnecessaryFormatString, self), _original_node, updated_node
+        )
         if not _original_node.deep_equals(transformed_node):
             self.report_change(_original_node)
         return transformed_node

--- a/tests/codemods/test_remove_unnecessary_f_str.py
+++ b/tests/codemods/test_remove_unnecessary_f_str.py
@@ -1,5 +1,3 @@
-import pytest
-
 from codemodder.codemods.test import BaseCodemodTest
 from core_codemods.remove_unnecessary_f_str import RemoveUnnecessaryFStr
 
@@ -7,9 +5,6 @@ from core_codemods.remove_unnecessary_f_str import RemoveUnnecessaryFStr
 class TestFStr(BaseCodemodTest):
     codemod = RemoveUnnecessaryFStr
 
-    @pytest.mark.skip(
-        reason="May fail if it runs after the test_sql_parameterization. See Issue #378."
-    )
     def test_no_change(self, tmpdir):
         before = r"""
         good: str = "good"
@@ -23,9 +18,6 @@ class TestFStr(BaseCodemodTest):
         """
         self.run_and_assert(tmpdir, before, before)
 
-    @pytest.mark.skip(
-        reason="May fail if it runs after the test_sql_parameterization. See Issue #378."
-    )
     def test_change(self, tmpdir):
         before = r"""
         bad: str = f"bad" + "bad"
@@ -39,9 +31,6 @@ class TestFStr(BaseCodemodTest):
         """
         self.run_and_assert(tmpdir, before, after, num_changes=3)
 
-    @pytest.mark.skip(
-        reason="May fail if it runs after the test_sql_parameterization. See Issue #378."
-    )
     def test_exclude_line(self, tmpdir):
         input_code = (
             expected


### PR DESCRIPTION
## Overview
*Fix metadata key error with `RemoveUnnecessaryFStr codemod*

## Description

* Fixes #378 
* I believe this is due to an issue with multiple inheritance when multiple LibCST transforms are parents of the same codemod class
* LibCST is doing some ~funny~ clever stuff with caching the metadata dependencies, and multiple inheritance seems to break some assumptions
* I'm not sure why this only manifested recently but this change seems to resolve the issue
