### PR TITLE
Codemodder can handle non-existent requested codemods

### DIFF
--- a/src/codemodder/registry.py
+++ b/src/codemodder/registry.py
@@ -28,7 +28,11 @@ class CodemodCollection:
 
 
 class TupledKeysDict(dict):
-    # todo: document
+    """
+    Dict whose keys are a two-item tuple so it's possible to
+    get or remove a dict item based on either item in the tuple.
+    """
+
     def get(self, key):
         for key_tuple, value in self.items():
             if key in key_tuple:
@@ -75,12 +79,6 @@ class CodemodRegistry:
     ) -> list[BaseCodemod]:
         codemod_include = codemod_include or []
         codemod_exclude = codemod_exclude or DEFAULT_EXCLUDED_CODEMODS
-        # base_list = [
-        #     codemod
-        #     for codemod in self.codemods
-        #     if (sast_only and codemod.origin != "pixee")
-        #     or (not sast_only and codemod.origin == "pixee")
-        # ]
 
         base_codemods = TupledKeysDict(
             {
@@ -91,11 +89,8 @@ class CodemodRegistry:
             }
         )
         if codemod_exclude and not codemod_include:
-            # other approach: instead of iterating over all base_list, iterate over
-            # exclude list and return base_list filtered
             for name in codemod_exclude:
                 try:
-                    # if this name to exclude exists, pop it from the dict.
                     base_codemods.get(name)
                     base_codemods.pop(name)
                 except KeyError:
@@ -103,17 +98,7 @@ class CodemodRegistry:
                         f"Requested codemod to exclude'{name}' does not exist."
                     )
             return list(base_codemods.values())
-            # excluded_codemods = []
-            # for codemod in base_list:
-            #     if codemod.name not in codemod_exclude and codemod.id not in codemod_exclude:
-            #         matched_codemods.append(codemod)
-            #     else:
-            #         excluded_codemods.append(codemod)
-            # names = ["a", "b"]
-            # logger.warning(f"Requested codemod to exclude'{name}' does not exist.")
-            # return matched_codemods
 
-        # todo: make list comp, other function
         matched_codemods = []
         for name in codemod_include:
             try:

--- a/tests/codemods/test_include_exclude.py
+++ b/tests/codemods/test_include_exclude.py
@@ -63,12 +63,12 @@ class TestMatchCodemods:
     )
     def test_exclude(self, input_str):
         excludes = input_str.split(",")
-        # todo: change behavior depending on issue
-        assert self.registry.match_codemods(None, excludes) == [
+        res = [
             c
             for c in self.registry.codemods
-            if c.name not in excludes or c.id not in excludes
+            if c.id in self.all_ids and c.name not in excludes and c.id not in excludes
         ]
+        assert self.registry.match_codemods(None, excludes) == res
 
     def test_bad_codemod_include_no_match(self):
         assert self.registry.match_codemods(["doesntexist"], None) == []

--- a/tests/codemods/test_include_exclude.py
+++ b/tests/codemods/test_include_exclude.py
@@ -35,12 +35,13 @@ class TestMatchCodemods:
         ) == {self.codemod_map["secure-random"]}
 
     @pytest.mark.parametrize(
-        "input_str", ["secure-random", "secure-random,url-sandbox"]
+        "input_str",
+        ["secure-random", "pixee:python/secure-random", "secure-random,url-sandbox"],
     )
     def test_include(self, input_str):
         includes = input_str.split(",")
         assert self.registry.match_codemods(includes, None) == [
-            self.codemod_map[name] for name in includes
+            self.codemod_map[name.replace("pixee:python/", "")] for name in includes
         ]
 
     @pytest.mark.parametrize(
@@ -56,15 +57,17 @@ class TestMatchCodemods:
         "input_str",
         [
             "secure-random",
+            "pixee:python/secure-random",
             "secure-random,url-sandbox",
         ],
     )
     def test_exclude(self, input_str):
         excludes = input_str.split(",")
+        # todo: change behavior depending on issue
         assert self.registry.match_codemods(None, excludes) == [
             c
             for c in self.registry.codemods
-            if c.name not in excludes and c.id in self.all_ids
+            if c.name not in excludes or c.id not in excludes
         ]
 
     def test_bad_codemod_include_no_match(self):
@@ -86,5 +89,3 @@ class TestMatchCodemods:
             for c in self.registry.codemods
             if c.name not in "secure-random" and c.id in self.all_ids
         ]
-
-    # todo: test name or id


### PR DESCRIPTION
## Overview
*Codemodder now does not stop with an error if you pass in an unknown codemod for include or exclude*

## Description

* Behavior up to this point in codmodder is that argparse would check if any of the codemod names you pass in are not know. If any were not known, it would just stop without running any codemods that are known.
* To correctly handle this new behavior of continuing on if you requested known codemods, I moved all the logic out of the argparse cli section and put it in a more appropriate place, in `match_codemods` which already does all the include/exclude check logic.
Now codemodder output will look like this
```
codemodder tests/samples/ --output here.txt --codemod-include=secured

[startup]
codemodder: python/0.84.1.dev25+g7f5d2ca.d20240313
command: codemodder tests/samples/ --output here.txt --codemod-include=secured
Requested codemod to include'secured' does not exist.
...
...
```

closes #346
