### PR TITLE
chore: add pre-commit downstream workflows

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -10,6 +10,7 @@ on:
       - main
       - develop
   merge_group:
+  workflow_call:
 
 concurrency:
   group: (${{ github.workflow }}-${{ github.event.inputs.branch || github.event.pull_request.head.ref }})

--- a/.github/workflows/pre-commit-autoupdate.yml
+++ b/.github/workflows/pre-commit-autoupdate.yml
@@ -6,6 +6,7 @@ on:
     - cron: "0 0 * * *"
   # on demand
   workflow_dispatch:
+  push:
 
 jobs:
   auto-update:

--- a/.github/workflows/pre-commit-autoupdate.yml
+++ b/.github/workflows/pre-commit-autoupdate.yml
@@ -35,11 +35,12 @@ jobs:
           branch: update/pre-commit-hooks
           title: Update pre-commit hooks
           commit-message: "chore: update pre-commit hooks"
-          body: Update versions of pre-commit hooks to latest version.
+          body:
+            Update versions of pre-commit hooks to latest version.
             # output is called pull-request-operation
       - name: Set outputs
         id: check-diff
-        if: | 
+        if: |
           steps.pr-create.outputs.pull-request-number &&
           (steps.pr-create.outputs.pull-request-operation == 'created' ||
           steps.pr-create.outputs.pull-request-operation == 'updated')
@@ -47,15 +48,12 @@ jobs:
 
   lint-workflow:
     name: Run lint
-    uses: ./.github/workflows/lint.yml
-    if: ${{ needs.auto-update.outputs.diff }}
-    runs-on: ubuntu-latest
     needs: auto-update
-
+    if: ${{ needs.auto-update.outputs.diff }}
+    uses: ./.github/workflows/lint.yml
 
   test-workflow:
     name: run tests on diff
-    uses: ./.github/workflows/test.yml
-    if: ${{ needs.auto-update.outputs.diff }}
-    runs-on: ubuntu-latest
     needs: auto-update
+    if: ${{ needs.auto-update.outputs.diff }}
+    uses: ./.github/workflows/test.yml

--- a/.github/workflows/pre-commit-autoupdate.yml
+++ b/.github/workflows/pre-commit-autoupdate.yml
@@ -14,6 +14,17 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
       - uses: browniebroke/pre-commit-autoupdate-action@main
+      - name: Check for changes
+        id: git-check
+        run: |
+          git diff --exit-code || echo "::set-output name=modified::true"
+        continue-on-error: true
+      - name: lint on diff
+        if: steps.git-check.outputs.modified == 'true'
+        uses: ./github/workflows/lint.yml
+      - name: run tests on diff
+        if: steps.git-check.outputs.modified == 'true'
+        uses: ./github/workflows/test.yml
       - uses: peter-evans/create-pull-request@v6
         with:
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/pre-commit-autoupdate.yml
+++ b/.github/workflows/pre-commit-autoupdate.yml
@@ -22,10 +22,10 @@ jobs:
         continue-on-error: true
       - name: lint on diff
         if: steps.git-check.outputs.modified == 'true'
-        uses: ./github/workflows/lint.yml
+        uses: ./.github/workflows/lint.yml
       - name: run tests on diff
         if: steps.git-check.outputs.modified == 'true'
-        uses: ./github/workflows/test.yml
+        uses: ./.github/workflows/test.yml
       - uses: peter-evans/create-pull-request@v6
         with:
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/pre-commit-autoupdate.yml
+++ b/.github/workflows/pre-commit-autoupdate.yml
@@ -17,17 +17,6 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
       - uses: browniebroke/pre-commit-autoupdate-action@main
-      # - name: Check for changes
-      #   id: git-check
-      #   run: |
-      #     git diff --exit-code || echo "::set-output name=modified::true"
-      #   continue-on-error: true
-      # - name: lint on diff
-      #   if: steps.git-check.outputs.modified == 'true'
-      #   uses: ./.github/workflows/lint.yml
-      # - name: run tests on diff
-      #   if: steps.git-check.outputs.modified == 'true'
-      #   uses: ./.github/workflows/test.yml
       - uses: peter-evans/create-pull-request@v6
         id: pr-create
         with:
@@ -37,14 +26,17 @@ jobs:
           commit-message: "chore: update pre-commit hooks"
           body:
             Update versions of pre-commit hooks to latest version.
-            # output is called pull-request-operation
       - name: Set outputs
         id: check-diff
         if: |
-          steps.pr-create.outputs.pull-request-number &&
           (steps.pr-create.outputs.pull-request-operation == 'created' ||
-          steps.pr-create.outputs.pull-request-operation == 'updated')
-        run: echo "diff=true" >> "$GITHUB_OUTPUT"
+          steps.pr-create.outputs.pull-request-operation == 'updated') &&
+          steps.pr-create.outputs.pull-request-number
+        run: |
+          echo "diff=true" >> "$GITHUB_OUTPUT"
+          echo "PR status: ${{ steps.pr-create.outputs.pull-request-operation }}"
+          echo "PR number: ${{ steps.pr-create.outputs.pull-request-number }}"
+          echo "Running workflows for ${{ steps.pr-create.outputs.pull-request-url }}"
 
   lint-workflow:
     name: Run lint

--- a/.github/workflows/pre-commit-autoupdate.yml
+++ b/.github/workflows/pre-commit-autoupdate.yml
@@ -6,7 +6,6 @@ on:
     - cron: "0 0 * * *"
   # on demand
   workflow_dispatch:
-  push:
 
 jobs:
   auto-update:
@@ -24,8 +23,7 @@ jobs:
           branch: update/pre-commit-hooks
           title: Update pre-commit hooks
           commit-message: "chore: update pre-commit hooks"
-          body:
-            Update versions of pre-commit hooks to latest version.
+          body: Update versions of pre-commit hooks to latest version.
       - name: Set outputs
         id: check-diff
         if: |

--- a/.github/workflows/pre-commit-autoupdate.yml
+++ b/.github/workflows/pre-commit-autoupdate.yml
@@ -11,25 +11,51 @@ on:
 jobs:
   auto-update:
     runs-on: ubuntu-latest
+    outputs:
+      diff: ${{ steps.check-diff.outputs.diff }}
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
       - uses: browniebroke/pre-commit-autoupdate-action@main
-      - name: Check for changes
-        id: git-check
-        run: |
-          git diff --exit-code || echo "::set-output name=modified::true"
-        continue-on-error: true
-      - name: lint on diff
-        if: steps.git-check.outputs.modified == 'true'
-        uses: ./.github/workflows/lint.yml
-      - name: run tests on diff
-        if: steps.git-check.outputs.modified == 'true'
-        uses: ./.github/workflows/test.yml
+      # - name: Check for changes
+      #   id: git-check
+      #   run: |
+      #     git diff --exit-code || echo "::set-output name=modified::true"
+      #   continue-on-error: true
+      # - name: lint on diff
+      #   if: steps.git-check.outputs.modified == 'true'
+      #   uses: ./.github/workflows/lint.yml
+      # - name: run tests on diff
+      #   if: steps.git-check.outputs.modified == 'true'
+      #   uses: ./.github/workflows/test.yml
       - uses: peter-evans/create-pull-request@v6
+        id: pr-create
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           branch: update/pre-commit-hooks
           title: Update pre-commit hooks
           commit-message: "chore: update pre-commit hooks"
           body: Update versions of pre-commit hooks to latest version.
+            # output is called pull-request-operation
+      - name: Set outputs
+        id: check-diff
+        if: | 
+          steps.pr-create.outputs.pull-request-number &&
+          (steps.pr-create.outputs.pull-request-operation == 'created' ||
+          steps.pr-create.outputs.pull-request-operation == 'updated')
+        run: echo "diff=true" >> "$GITHUB_OUTPUT"
+
+  lint-workflow:
+    name: Run lint
+    uses: ./.github/workflows/lint.yml
+    if: ${{ needs.auto-update.outputs.diff }}
+    runs-on: ubuntu-latest
+    needs: auto-update
+
+
+  test-workflow:
+    name: run tests on diff
+    uses: ./.github/workflows/test.yml
+    if: ${{ needs.auto-update.outputs.diff }}
+    runs-on: ubuntu-latest
+    needs: auto-update

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,6 +14,7 @@ on:
       - develop
       - "[0-9]+.[0-9]+.x"
   merge_group:
+  workflow_call:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}


### PR DESCRIPTION
## Overview
- If there's a `pre-commit` update:
    - "require" and run the [`lint`](./github/workflows/lint.yml) and [`test`](./github/workflows/test.yml) workflows, avoiding any direct recursive calls to GH actions

## Description

Based on our [previous conversation](https://github.com/pixee/codemodder-python/pull/356#issuecomment-1995675603) I looked at how to get this running with dependabot, but I quickly realized it wouldn't work as expected. 

It would only run when a `pip` dependency changed, so effectively it wouldn't run the specific code that the current GH action [runs](https://github.com/browniebroke/pre-commit-autoupdate-action/blob/1e32b32e531346c631e93007c766971301367ec9/action.yml#L11-L14) with a daily frequency.

Also, using `dependabot` with `pre-commit` is very low on the GH team's [priority](https://github.com/dependabot/dependabot-core/issues/1524). 

So I decided to "unfurl" the needed downstream actions as direct dependencies on the "pre-commit" job, by "requiring" them and conditionally running linting and testing if there's a `pre-commit` update. This works because we can see if the pr was [created or updated](https://github.com/peter-evans/create-pull-request?tab=readme-ov-file#action-behaviour) in the outputs of the create-pr action. 

### PROOF:
You can see the [successful run](https://github.com/maxArturo/codemodder-python/actions/runs/8326875669) and then the lint/test actions being triggered afterwards.

## Additional Details
The one thing to keep in mind is if you want something else to conditionally run based on `pre-commit update`, you have to add it here as a direct downstream dependency. That's it!


