### PR TITLE
up integration test time for actions

### DIFF
--- a/.github/workflows/integration_test.yml
+++ b/.github/workflows/integration_test.yml
@@ -19,7 +19,7 @@ jobs:
   test:
     name: Run pytest
     runs-on: ubuntu-20.04
-    timeout-minutes: 10
+    timeout-minutes: 15
     strategy:
       matrix:
         python-version: ['3.10',  '3.11', '3.12']


### PR DESCRIPTION
We're hitting the 10min limit consistently now with all the codemods we've added