### PR TITLE
do not log positive files to analyze if no codemods ran

### DIFF
--- a/src/codemodder/codemodder.py
+++ b/src/codemodder/codemodder.py
@@ -222,7 +222,9 @@ def run(original_args) -> int:
         )
         codetf.write_report(argv.output)
 
-    log_report(context, argv, elapsed_ms, files_to_analyze)
+    log_report(
+        context, argv, elapsed_ms, [] if not codemods_to_run else files_to_analyze
+    )
     return 0
 
 

--- a/tests/test_codemodder.py
+++ b/tests/test_codemodder.py
@@ -160,6 +160,8 @@ class TestCodemodIncludeExclude:
         write_report.assert_called_once()
 
         assert any("no codemods to run" in x[0][0] for x in info_logger.call_args_list)
+        assert any(x[0] == ("scanned: %s files", 0) for x in info_logger.call_args_list)
+
         assert any(
             f"Requested codemod to include'{bad_codemod}' does not exist." in x[0][0]
             for x in warning_logger.call_args_list


### PR DESCRIPTION
Closes #391

codemodder output goes from
```
....
[scanning]
no codemods to run

[report]
scanned: 63 files
failed: 0 files (0 unique)
changed: 0 files (0 unique)
...
```

to now:

```
....
[scanning]
no codemods to run

[report]
scanned: 0 files
failed: 0 files (0 unique)
changed: 0 files (0 unique)
...
```