### PR TITLE
Support sonar hotspots and secure-random sonar hotspot rule

### DIFF
--- a/integration_tests/test_secure_random.py
+++ b/integration_tests/test_secure_random.py
@@ -1,5 +1,5 @@
 from codemodder.codemods.test import BaseIntegrationTest
-from core_codemods.secure_random import SecureRandom
+from core_codemods.secure_random import SecureRandom, SecureRandomTransformer
 
 
 class TestSecureRandom(BaseIntegrationTest):
@@ -26,4 +26,4 @@ class TestSecureRandom(BaseIntegrationTest):
         """ var = "hello"\n""")
     # fmt: on
     expected_line_change = "2"
-    change_description = SecureRandom.change_description
+    change_description = SecureRandomTransformer.change_description

--- a/integration_tests/test_sonar_secure_random.py
+++ b/integration_tests/test_sonar_secure_random.py
@@ -1,0 +1,33 @@
+from codemodder.codemods.test import SonarIntegrationTest
+from core_codemods.django_json_response_type import DjangoJsonResponseTypeTransformer
+from core_codemods.sonar.sonar_django_json_response_type import (
+    SonarDjangoJsonResponseType,
+)
+
+
+class TestSonarDjangoJsonResponseType(SonarIntegrationTest):
+    codemod = SonarDjangoJsonResponseType
+    code_path = "tests/samples/django_json_response_type.py"
+    replacement_lines = [
+        (
+            6,
+            """    return HttpResponse(json_response, content_type="application/json")\n""",
+        ),
+    ]
+
+    # fmt: off
+    expected_diff = (
+    """--- \n"""
+    """+++ \n"""
+    """@@ -3,4 +3,4 @@\n"""
+    """ \n"""
+    """ def foo(request):\n"""
+    """     json_response = json.dumps({ "user_input": request.GET.get("input") })\n"""
+    """-    return HttpResponse(json_response)\n"""
+    """+    return HttpResponse(json_response, content_type="application/json")\n"""
+    )
+    # fmt: on
+
+    expected_line_change = "6"
+    change_description = DjangoJsonResponseTypeTransformer.change_description
+    num_changed_files = 1

--- a/integration_tests/test_sonar_secure_random.py
+++ b/integration_tests/test_sonar_secure_random.py
@@ -1,33 +1,29 @@
 from codemodder.codemods.test import SonarIntegrationTest
-from core_codemods.django_json_response_type import DjangoJsonResponseTypeTransformer
-from core_codemods.sonar.sonar_django_json_response_type import (
-    SonarDjangoJsonResponseType,
-)
+from core_codemods.secure_random import SecureRandomTransformer
+from core_codemods.sonar.sonar_secure_random import SonarSecureRandom
 
 
 class TestSonarDjangoJsonResponseType(SonarIntegrationTest):
-    codemod = SonarDjangoJsonResponseType
-    code_path = "tests/samples/django_json_response_type.py"
+    codemod = SonarSecureRandom
+    code_path = "tests/samples/secure_random.py"
     replacement_lines = [
-        (
-            6,
-            """    return HttpResponse(json_response, content_type="application/json")\n""",
-        ),
+        (1, """import secrets\n"""),
+        (3, """secrets.SystemRandom().random()\n"""),
+        (4, """secrets.SystemRandom().getrandbits(1)\n"""),
     ]
-
     # fmt: off
     expected_diff = (
-    """--- \n"""
-    """+++ \n"""
-    """@@ -3,4 +3,4 @@\n"""
-    """ \n"""
-    """ def foo(request):\n"""
-    """     json_response = json.dumps({ "user_input": request.GET.get("input") })\n"""
-    """-    return HttpResponse(json_response)\n"""
-    """+    return HttpResponse(json_response, content_type="application/json")\n"""
-    )
+        """--- \n"""
+        """+++ \n"""
+        """@@ -1,4 +1,4 @@\n"""
+        """-import random\n"""
+        """+import secrets\n"""
+        """ \n"""
+        """-random.random()\n"""
+        """-random.getrandbits(1)\n"""
+        """+secrets.SystemRandom().random()\n"""
+        """+secrets.SystemRandom().getrandbits(1)\n""")
     # fmt: on
-
-    expected_line_change = "6"
-    change_description = DjangoJsonResponseTypeTransformer.change_description
-    num_changed_files = 1
+    expected_line_change = "3"
+    change_description = SecureRandomTransformer.change_description
+    num_changes = 2

--- a/src/codemodder/codemodder.py
+++ b/src/codemodder/codemodder.py
@@ -4,7 +4,7 @@ import logging
 import os
 import sys
 from pathlib import Path
-from typing import Sequence
+from typing import DefaultDict, Sequence
 
 from codemodder import __version__, registry
 from codemodder.cli import parse_args
@@ -158,10 +158,20 @@ def run(original_args) -> int:
 
     # TODO: sonar files should be _parsed_ here as well
     # TODO: this should be dict[str, list[Path]]
-    tool_result_files_map: dict[str, list[str]] = detect_sarif_tools(
+
+    tool_result_files_map: DefaultDict[str, list[str]] = detect_sarif_tools(
         [Path(name) for name in argv.sarif or []]
     )
-    tool_result_files_map["sonar"] = argv.sonar_issues_json
+    (
+        tool_result_files_map["sonar"].extend(argv.sonar_issues_json)
+        if argv.sonar_issues_json
+        else None
+    )
+    (
+        tool_result_files_map["sonar"].extend(argv.sonar_hotspots_json)
+        if argv.sonar_hotspots_json
+        else None
+    )
 
     repo_manager = PythonRepoManager(Path(argv.directory))
     context = CodemodExecutionContext(

--- a/src/codemodder/codemods/sonar.py
+++ b/src/codemodder/codemods/sonar.py
@@ -54,12 +54,6 @@ class SonarCodemod(SASTCodemod):
 class SonarDetector(BaseDetector):
     _lazy_cache = None
 
-    def _process_sonar_findings(self, sonar_json_files: list[str]) -> SonarResultSet:
-        combined_result_set = SonarResultSet()
-        for file in sonar_json_files or []:
-            combined_result_set |= SonarResultSet.from_json(file)
-        return combined_result_set
-
     def apply(
         self,
         codemod_id: str,
@@ -67,7 +61,14 @@ class SonarDetector(BaseDetector):
         files_to_analyze: list[Path],
     ) -> ResultSet:
         if not self._lazy_cache:
-            self._lazy_cache = self._process_sonar_findings(
+            self._lazy_cache = process_sonar_findings(
                 context.tool_result_files_map.get("sonar", [])
             )
         return self._lazy_cache
+
+
+def process_sonar_findings(sonar_json_files: list[str]) -> SonarResultSet:
+    combined_result_set = SonarResultSet()
+    for file in sonar_json_files or []:
+        combined_result_set |= SonarResultSet.from_json(file)
+    return combined_result_set

--- a/src/codemodder/sarifs.py
+++ b/src/codemodder/sarifs.py
@@ -1,8 +1,9 @@
 import json
 from abc import ABCMeta, abstractmethod
+from collections import defaultdict
 from importlib.metadata import entry_points
 from pathlib import Path
-from typing import Optional
+from typing import DefaultDict, Optional
 
 from typing_extensions import Self
 
@@ -18,8 +19,8 @@ class AbstractSarifToolDetector(metaclass=ABCMeta):
         pass
 
 
-def detect_sarif_tools(filenames: list[Path]) -> dict[str, list[str]]:
-    results: dict[str, list[str]] = {}
+def detect_sarif_tools(filenames: list[Path]) -> DefaultDict[str, list[str]]:
+    results: DefaultDict[str, list[str]] = defaultdict(list)
 
     logger.debug("loading registered SARIF tool detectors")
     detectors = {
@@ -33,7 +34,7 @@ def detect_sarif_tools(filenames: list[Path]) -> dict[str, list[str]]:
                 try:
                     if det.detect(run):
                         logger.debug("detected %s sarif: %s", name, fname)
-                        results.setdefault(name, []).append(str(fname))
+                        results[name].append(str(fname))
                 except (KeyError, AttributeError, ValueError):
                     continue
 

--- a/src/codemodder/scripts/generate_docs.py
+++ b/src/codemodder/scripts/generate_docs.py
@@ -319,6 +319,11 @@ METADATA = CORE_METADATA | {
         guidance_explained=CORE_METADATA["secure-tempfile"].guidance_explained,
         need_sarif="Yes (Sonar)",
     ),
+    "secure-random-S2245": DocMetadata(
+        importance=CORE_METADATA["secure-random"].importance,
+        guidance_explained=CORE_METADATA["secure-random"].guidance_explained,
+        need_sarif="Yes (Sonar)",
+    ),
 }
 
 

--- a/src/codemodder/sonar_results.py
+++ b/src/codemodder/sonar_results.py
@@ -24,8 +24,8 @@ class SonarResult(Result):
 
     @classmethod
     def from_result(cls, result) -> Self:
-        rule_id = result.get("rule", None)
-        if not rule_id:
+        # Sonar issues have `rule` as key while hotspots call it `ruleKey`
+        if not (rule_id := result.get("rule", None) or result.get("ruleKey", None)):
             raise ValueError("Could not extract rule id from sarif result.")
 
         locations: list[Location] = [SonarLocation.from_result(result)]

--- a/src/codemodder/sonar_results.py
+++ b/src/codemodder/sonar_results.py
@@ -52,7 +52,7 @@ class SonarResultSet(ResultSet):
 
             result_set = cls()
             for result in data.get("issues") or [] + data.get("hotspots") or []:
-                if result["status"].lower() == "open":
+                if result["status"].lower() in ("open", "to_review"):
                     result_set.add_result(SonarResult.from_result(result))
 
             return result_set

--- a/src/codemodder/sonar_results.py
+++ b/src/codemodder/sonar_results.py
@@ -12,23 +12,23 @@ from codemodder.result import LineInfo, Location, Result, ResultSet
 
 class SonarLocation(Location):
     @classmethod
-    def from_issue(cls, issue) -> Self:
-        location = issue.get("textRange")
+    def from_result(cls, result) -> Self:
+        location = result.get("textRange")
         start = LineInfo(location.get("startLine"), location.get("startOffset"), "")
         end = LineInfo(location.get("endLine"), location.get("endOffset"), "")
-        file = Path(issue.get("component").split(":")[-1])
+        file = Path(result.get("component").split(":")[-1])
         return cls(file=file, start=start, end=end)
 
 
 class SonarResult(Result):
 
     @classmethod
-    def from_issue(cls, issue) -> Self:
-        rule_id = issue.get("rule", None)
+    def from_result(cls, result) -> Self:
+        rule_id = result.get("rule", None)
         if not rule_id:
             raise ValueError("Could not extract rule id from sarif result.")
 
-        locations: list[Location] = [SonarLocation.from_issue(issue)]
+        locations: list[Location] = [SonarLocation.from_result(result)]
         return cls(rule_id=rule_id, locations=locations)
 
     def match_location(self, pos, node):
@@ -51,9 +51,9 @@ class SonarResultSet(ResultSet):
                 data = json.load(file)
 
             result_set = cls()
-            for issue in data.get("issues"):
-                if issue["status"].lower() == "open":
-                    result_set.add_result(SonarResult.from_issue(issue))
+            for result in data.get("issues") or [] + data.get("hotspots") or []:
+                if result["status"].lower() == "open":
+                    result_set.add_result(SonarResult.from_result(result))
 
             return result_set
         except Exception:

--- a/src/core_codemods/__init__.py
+++ b/src/core_codemods/__init__.py
@@ -57,6 +57,7 @@ from .sonar.sonar_numpy_nan_equality import SonarNumpyNanEquality
 from .sonar.sonar_remove_assertion_in_pytest_raises import (
     SonarRemoveAssertionInPytestRaises,
 )
+from .sonar.sonar_secure_random import SonarSecureRandom
 from .sonar.sonar_tempfile_mktemp import SonarTempfileMktemp
 from .sql_parameterization import SQLQueryParameterization
 from .str_concat_in_seq_literal import StrConcatInSeqLiteral
@@ -148,5 +149,6 @@ sonar_registry = CodemodCollection(
         SonarJwtDecodeVerify,
         SonarFixMissingSelfOrCls,
         SonarTempfileMktemp,
+        SonarSecureRandom,
     ],
 )

--- a/src/core_codemods/secure_random.py
+++ b/src/core_codemods/secure_random.py
@@ -1,7 +1,8 @@
+from codemodder.codemods.utils_mixin import NameResolutionMixin
 from core_codemods.api import Metadata, Reference, ReviewGuidance, SimpleCodemod
 
 
-class SecureRandom(SimpleCodemod):
+class SecureRandom(SimpleCodemod, NameResolutionMixin):
     metadata = Metadata(
         name="secure-random",
         review_guidance=ReviewGuidance.MERGE_AFTER_CURSORY_REVIEW,
@@ -32,4 +33,7 @@ class SecureRandom(SimpleCodemod):
     def on_result_found(self, original_node, updated_node):
         self.remove_unused_import(original_node)
         self.add_needed_import("secrets")
+
+        if self.find_base_name(original_node.func) == "random.choice":
+            return self.update_call_target(updated_node, "secrets")
         return self.update_call_target(updated_node, "secrets.SystemRandom()")

--- a/src/core_codemods/secure_random.py
+++ b/src/core_codemods/secure_random.py
@@ -1,31 +1,13 @@
+from codemodder.codemods.libcst_transformer import (
+    LibcstResultTransformer,
+    LibcstTransformerPipeline,
+)
+from codemodder.codemods.semgrep import SemgrepRuleDetector
 from codemodder.codemods.utils_mixin import NameResolutionMixin
-from core_codemods.api import Metadata, Reference, ReviewGuidance, SimpleCodemod
+from core_codemods.api import CoreCodemod, Metadata, Reference, ReviewGuidance
 
 
-class SecureRandom(SimpleCodemod, NameResolutionMixin):
-    metadata = Metadata(
-        name="secure-random",
-        review_guidance=ReviewGuidance.MERGE_AFTER_CURSORY_REVIEW,
-        summary="Secure Source of Randomness",
-        references=[
-            Reference(
-                url="https://owasp.org/www-community/vulnerabilities/Insecure_Randomness",
-            ),
-            Reference(
-                url="https://docs.python.org/3/library/random.html",
-            ),
-        ],
-    )
-
-    detector_pattern = """
-        - patterns:
-          - pattern: random.$F(...)
-          - pattern-not: random.SystemRandom()
-          - pattern-inside: |
-              import random
-              ...
-    """
-
+class SecureRandomTransformer(LibcstResultTransformer, NameResolutionMixin):
     change_description = (
         "Replace random.{func} with more secure secrets library functions."
     )
@@ -37,3 +19,31 @@ class SecureRandom(SimpleCodemod, NameResolutionMixin):
         if self.find_base_name(original_node.func) == "random.choice":
             return self.update_call_target(updated_node, "secrets")
         return self.update_call_target(updated_node, "secrets.SystemRandom()")
+
+
+SecureRandom = CoreCodemod(
+    metadata=Metadata(
+        name="secure-random",
+        review_guidance=ReviewGuidance.MERGE_AFTER_CURSORY_REVIEW,
+        summary="Secure Source of Randomness",
+        references=[
+            Reference(
+                url="https://owasp.org/www-community/vulnerabilities/Insecure_Randomness",
+            ),
+            Reference(
+                url="https://docs.python.org/3/library/random.html",
+            ),
+        ],
+    ),
+    detector=SemgrepRuleDetector(
+        """
+            - patterns:
+              - pattern: random.$F(...)
+              - pattern-not: random.SystemRandom()
+              - pattern-inside: |
+                  import random
+                  ...
+        """
+    ),
+    transformer=LibcstTransformerPipeline(SecureRandomTransformer),
+)

--- a/src/core_codemods/sonar/sonar_secure_random.py
+++ b/src/core_codemods/sonar/sonar_secure_random.py
@@ -1,0 +1,10 @@
+from codemodder.codemods.sonar import SonarCodemod
+from core_codemods.secure_random import SecureRandom
+
+SonarSecureRandom = SonarCodemod.from_core_codemod(
+    name="secure-random-S2245",
+    other=SecureRandom,
+    rule_id="python:S2245",
+    rule_name="Using pseudorandom number generators (PRNGs) is security-sensitive",
+    rule_url="https://rules.sonarsource.com/python/type/Security%20Hotspot/RSPEC-2245/",
+)

--- a/tests/codemods/test_secure_random.py
+++ b/tests/codemods/test_secure_random.py
@@ -214,8 +214,22 @@ class TestSecureRandom(BaseSemgrepCodemodTest):
         import secrets
 
         secrets.SystemRandom().sample(["a", "b"], 1)
-        secrets.SystemRandom().choice(["a", "b"])
+        secrets.choice(["a", "b"])
         secrets.SystemRandom().choices(["a", "b"])
         """
 
         self.run_and_assert(tmpdir, input_code, expected_output, num_changes=3)
+
+    def test_from_import_choice(self, tmpdir):
+        input_code = """
+        from random import choice
+
+        choice(["a", "b"])
+        """
+        expected_output = """
+        import secrets
+
+        secrets.choice(["a", "b"])
+        """
+
+        self.run_and_assert(tmpdir, input_code, expected_output, num_changes=1)

--- a/tests/codemods/test_secure_random.py
+++ b/tests/codemods/test_secure_random.py
@@ -15,16 +15,18 @@ class TestSecureRandom(BaseSemgrepCodemodTest):
         import random
 
         random.random()
+        random.getrandbits(1)
         var = "hello"
         """
         expected_output = """
         import secrets
 
         secrets.SystemRandom().random()
+        secrets.SystemRandom().getrandbits(1)
         var = "hello"
         """
 
-        self.run_and_assert(tmpdir, input_code, expected_output)
+        self.run_and_assert(tmpdir, input_code, expected_output, num_changes=2)
 
     def test_from_random(self, tmpdir):
         input_code = """
@@ -199,3 +201,21 @@ class TestSecureRandom(BaseSemgrepCodemodTest):
         rand = domran.SystemRandom()
         """
         self.run_and_assert(tmpdir, input_code, input_code)
+
+    def test_sampling(self, tmpdir):
+        input_code = """
+        import random
+
+        random.sample(["a", "b"], 1)
+        random.choice(["a", "b"])
+        random.choices(["a", "b"])
+        """
+        expected_output = """
+        import secrets
+
+        secrets.SystemRandom().sample(["a", "b"], 1)
+        secrets.SystemRandom().choice(["a", "b"])
+        secrets.SystemRandom().choices(["a", "b"])
+        """
+
+        self.run_and_assert(tmpdir, input_code, expected_output, num_changes=3)

--- a/tests/codemods/test_sonar_secure_random.py
+++ b/tests/codemods/test_sonar_secure_random.py
@@ -1,0 +1,57 @@
+import json
+
+from codemodder.codemods.test import BaseSASTCodemodTest
+from core_codemods.sonar.sonar_secure_random import SonarSecureRandom
+
+
+class TestSonarSecureRandom(BaseSASTCodemodTest):
+    codemod = SonarSecureRandom
+    tool = "sonar"
+
+    def test_name(self):
+        assert self.codemod.name == "secure-random-S2245"
+
+    def test_simple(self, tmpdir):
+        input_code = """
+        import random
+
+        random.getrandbits(1)
+        random.randint(0, 9)
+        random.random()
+        random.sample(["a", "b"], 1)
+        random.choice(["a", "b"])
+        random.choices(["a", "b"])
+        """
+        expected_output = """
+        import secrets
+
+        secrets.SystemRandom().getrandbits(1)
+        secrets.SystemRandom().randint(0, 9)
+        secrets.SystemRandom().random()
+        secrets.SystemRandom().sample(["a", "b"], 1)
+        secrets.choice(["a", "b"])
+        secrets.SystemRandom().choices(["a", "b"])
+        """
+        # todo: not issues, notspots
+        issues = {
+            "issues": [
+                {
+                    "rule": "python:S5905",
+                    "status": "OPEN",
+                    "component": "code.py",
+                    "textRange": {
+                        "startLine": 2,
+                        "endLine": 2,
+                        "startOffset": 8,
+                        "endOffset": 15,
+                    },
+                }
+            ]
+        }
+        self.run_and_assert(
+            tmpdir,
+            input_code,
+            expected_output,
+            results=json.dumps(issues),
+            num_changes=3,
+        )

--- a/tests/codemods/test_sonar_secure_random.py
+++ b/tests/codemods/test_sonar_secure_random.py
@@ -18,9 +18,6 @@ class TestSonarSecureRandom(BaseSASTCodemodTest):
         random.getrandbits(1)
         random.randint(0, 9)
         random.random()
-        random.sample(["a", "b"], 1)
-        random.choice(["a", "b"])
-        random.choices(["a", "b"])
         """
         expected_output = """
         import secrets
@@ -28,30 +25,48 @@ class TestSonarSecureRandom(BaseSASTCodemodTest):
         secrets.SystemRandom().getrandbits(1)
         secrets.SystemRandom().randint(0, 9)
         secrets.SystemRandom().random()
-        secrets.SystemRandom().sample(["a", "b"], 1)
-        secrets.choice(["a", "b"])
-        secrets.SystemRandom().choices(["a", "b"])
         """
-        # todo: not issues, notspots
-        issues = {
-            "issues": [
+        hotspots = {
+            "hotspots": [
                 {
-                    "rule": "python:S5905",
+                    "rule": "python:S2245",
                     "status": "OPEN",
                     "component": "code.py",
                     "textRange": {
-                        "startLine": 2,
-                        "endLine": 2,
-                        "startOffset": 8,
+                        "startLine": 4,
+                        "endLine": 4,
+                        "startOffset": 0,
+                        "endOffset": 21,
+                    },
+                },
+                {
+                    "rule": "python:S2245",
+                    "status": "OPEN",
+                    "component": "code.py",
+                    "textRange": {
+                        "startLine": 5,
+                        "endLine": 5,
+                        "startOffset": 0,
+                        "endOffset": 20,
+                    },
+                },
+                {
+                    "rule": "python:S2245",
+                    "status": "OPEN",
+                    "component": "code.py",
+                    "textRange": {
+                        "startLine": 6,
+                        "endLine": 6,
+                        "startOffset": 0,
                         "endOffset": 15,
                     },
-                }
+                },
             ]
         }
         self.run_and_assert(
             tmpdir,
             input_code,
             expected_output,
-            results=json.dumps(issues),
+            results=json.dumps(hotspots),
             num_changes=3,
         )

--- a/tests/samples/secure_random.py
+++ b/tests/samples/secure_random.py
@@ -1,0 +1,4 @@
+import random
+
+random.random()
+random.getrandbits(1)

--- a/tests/samples/sonar_hotspots.json
+++ b/tests/samples/sonar_hotspots.json
@@ -1,0 +1,68 @@
+{
+  "paging": {
+    "pageIndex": 1,
+    "pageSize": 100,
+    "total": 2
+  },
+  "hotspots": [
+    {
+      "key": "AY6fXn2rzaaymEtIucTd",
+      "component": "pixee_codemodder-python:secure_random.py",
+      "project": "pixee_codemodder-python",
+      "securityCategory": "weak-cryptography",
+      "vulnerabilityProbability": "MEDIUM",
+      "status": "TO_REVIEW",
+      "line": 3,
+      "message": "Make sure that using this pseudorandom number generator is safe here.",
+      "assignee": "AY02ClhIe4Bh2XgBg3RU",
+      "creationDate": "2024-04-02T17:11:46+0200",
+      "updateDate": "2024-04-02T17:12:18+0200",
+      "textRange": {
+        "startLine": 3,
+        "endLine": 3,
+        "startOffset": 0,
+        "endOffset": 15
+      },
+      "flows": [],
+      "ruleKey": "python:S2245"
+    },
+    {
+      "key": "AY6fXn2rzaaymEtIucTe",
+      "component": "pixee_codemodder-python:secure_random.py",
+      "project": "pixee_codemodder-python",
+      "securityCategory": "weak-cryptography",
+      "vulnerabilityProbability": "MEDIUM",
+      "status": "TO_REVIEW",
+      "line": 4,
+      "message": "Make sure that using this pseudorandom number generator is safe here.",
+      "assignee": "AY02ClhIe4Bh2XgBg3RU",
+      "creationDate": "2024-04-02T17:11:46+0200",
+      "updateDate": "2024-04-02T17:12:18+0200",
+      "textRange": {
+        "startLine": 4,
+        "endLine": 4,
+        "startOffset": 0,
+        "endOffset": 21
+      },
+      "flows": [],
+      "ruleKey": "python:S2245"
+    }
+  ],
+  "components": [
+    {
+      "organization": "pixee",
+      "key": "pixee_codemodder-python",
+      "qualifier": "TRK",
+      "name": "codemodder-python",
+      "longName": "codemodder-python"
+    },
+    {
+      "organization": "pixee",
+      "key": "pixee_codemodder-python:secure_random.py",
+      "qualifier": "FIL",
+      "name": "secure_random.py",
+      "longName": "secure_random.py",
+      "path": "secure_random.py"
+    }
+  ]
+}


### PR DESCRIPTION
## Overview
*Add support for sonar hotspots and the first sonar hotspot, secure-random*

## Description

* Secure random is the first sonar hotspots (a category separate from issues) that we support. While we have a CLI arg separately for a file for hotspots, internally these can be processed pretty much the same way with just some minor tweaking to existing code

Closes #376