### PR TITLE
remove todo comments that are already handled

### DIFF
--- a/src/core_codemods/django_receiver_on_top.py
+++ b/src/core_codemods/django_receiver_on_top.py
@@ -19,8 +19,6 @@ class DjangoReceiverOnTopTransformer(LibcstResultTransformer, NameResolutionMixi
     ) -> Union[
         cst.BaseStatement, cst.FlattenSentinel[cst.BaseStatement], cst.RemovalSentinel
     ]:
-        # TODO: add filter by include or exclude that works for nodes
-        # that that have different start/end numbers.
         maybe_receiver_with_index = None
         for i, decorator in enumerate(original_node.decorators):
             if self.find_base_name(decorator.decorator) == "django.dispatch.receiver":

--- a/src/core_codemods/remove_assertion_in_pytest_raises.py
+++ b/src/core_codemods/remove_assertion_in_pytest_raises.py
@@ -93,10 +93,6 @@ class RemoveAssertionInPytestRaisesTransformer(
     ) -> Union[
         cst.BaseStatement, cst.FlattenSentinel[cst.BaseStatement], cst.RemovalSentinel
     ]:
-        # TODO: add filter by include or exclude that works for nodes
-        # that that have different start/end numbers.
-
-        # Are all items pytest.raises?
         if not self._all_pytest_raises(original_node):
             return updated_node
 


### PR DESCRIPTION
## Overview
*I originally thought these two codemods were not handling for node selection because of the TODO, but if you read the codemod correctly `node_is_selected` is called on the right nodes*
