### PR TITLE
Implement prototype codemods for DefectDojo remediation

### DIFF
--- a/integration_tests/test_harden_pyyaml.py
+++ b/integration_tests/test_harden_pyyaml.py
@@ -1,7 +1,7 @@
 import yaml
 
 from codemodder.codemods.test import BaseIntegrationTest
-from core_codemods.harden_pyyaml import HardenPyyaml
+from core_codemods.harden_pyyaml import HardenPyyaml, HardenPyyamlTransformer
 
 
 class TestHardenPyyaml(BaseIntegrationTest):
@@ -17,6 +17,6 @@ class TestHardenPyyaml(BaseIntegrationTest):
     ]
     expected_diff = '--- \n+++ \n@@ -1,4 +1,4 @@\n import yaml\n \n data = b"!!python/object/apply:subprocess.Popen \\\\n- ls"\n-deserialized_data = yaml.load(data, Loader=yaml.Loader)\n+deserialized_data = yaml.load(data, Loader=yaml.SafeLoader)\n'
     expected_line_change = "4"
-    change_description = HardenPyyaml.change_description
+    change_description = HardenPyyamlTransformer.change_description
     # expected exception because the yaml.SafeLoader protects against unsafe code
     allowed_exceptions = (yaml.constructor.ConstructorError,)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -81,6 +81,7 @@ all = [
 [project.entry-points.codemods]
 core = "core_codemods:registry"
 sonar = "core_codemods:sonar_registry"
+defectdojo = "core_codemods:defectdojo_registry"
 
 [tool.setuptools]
 

--- a/src/codemodder/codemodder.py
+++ b/src/codemodder/codemodder.py
@@ -156,22 +156,13 @@ def run(original_args) -> int:
     logger.info("codemodder: python/%s", __version__)
     logger.info("command: %s %s", Path(sys.argv[0]).name, " ".join(original_args))
 
-    # TODO: sonar files should be _parsed_ here as well
     # TODO: this should be dict[str, list[Path]]
-
     tool_result_files_map: DefaultDict[str, list[str]] = detect_sarif_tools(
         [Path(name) for name in argv.sarif or []]
     )
-    (
-        tool_result_files_map["sonar"].extend(argv.sonar_issues_json)
-        if argv.sonar_issues_json
-        else None
-    )
-    (
-        tool_result_files_map["sonar"].extend(argv.sonar_hotspots_json)
-        if argv.sonar_hotspots_json
-        else None
-    )
+    tool_result_files_map["sonar"].extend(argv.sonar_issues_json or [])
+    tool_result_files_map["sonar"].extend(argv.sonar_hotspots_json or [])
+    tool_result_files_map["defectdojo"] = argv.defectdojo_findings_json
 
     repo_manager = PythonRepoManager(Path(argv.directory))
     context = CodemodExecutionContext(

--- a/src/codemodder/codemodder.py
+++ b/src/codemodder/codemodder.py
@@ -162,7 +162,7 @@ def run(original_args) -> int:
     )
     tool_result_files_map["sonar"].extend(argv.sonar_issues_json or [])
     tool_result_files_map["sonar"].extend(argv.sonar_hotspots_json or [])
-    tool_result_files_map["defectdojo"] = argv.defectdojo_findings_json
+    tool_result_files_map["defectdojo"] = argv.defectdojo_findings_json or []
 
     repo_manager = PythonRepoManager(Path(argv.directory))
     context = CodemodExecutionContext(

--- a/src/codemodder/codemods/libcst_transformer.py
+++ b/src/codemodder/codemods/libcst_transformer.py
@@ -118,10 +118,13 @@ class LibcstResultTransformer(BaseTransformer):
     def add_dependency(self, dependency: Dependency):
         self.file_context.add_dependency(dependency)
 
-    def report_change(self, original_node):
+    def report_change(self, original_node, description: str | None = None):
         line_number = self.lineno_for_node(original_node)
         self.file_context.codemod_changes.append(
-            Change(lineNumber=line_number, description=self.change_description)
+            Change(
+                lineNumber=line_number,
+                description=description or self.change_description,
+            )
         )
 
     def remove_unused_import(self, original_node):

--- a/src/codemodder/codemods/test/utils.py
+++ b/src/codemodder/codemods/test/utils.py
@@ -146,9 +146,7 @@ class BaseSASTCodemodTest(BaseCodemodTest):
         tmp_file_path.write_text(dedent(input_code))
 
         tmp_results_file_path = Path(tmpdir) / "sast_results"
-
-        with open(tmp_results_file_path, "w", encoding="utf-8") as results_file:
-            results_file.write(results)
+        tmp_results_file_path.write_text(results)
 
         files_to_check = files or [tmp_file_path]
 

--- a/src/codemodder/result.py
+++ b/src/codemodder/result.py
@@ -16,8 +16,8 @@ if TYPE_CHECKING:
 @dataclass
 class LineInfo:
     line: int
-    column: int
-    snippet: str | None
+    column: int = -1
+    snippet: str | None = None
 
 
 @dataclass

--- a/src/codemodder/scripts/generate_docs.py
+++ b/src/codemodder/scripts/generate_docs.py
@@ -334,6 +334,11 @@ METADATA = CORE_METADATA | {
         guidance_explained="Our change provides the most secure way to create cookies in Django. However, it's possible you have configured your Django application configurations to use secure cookies. In these cases, using the default parameters for `set_cookie` is safe.",
         need_sarif="Yes (DefectDojo)",
     ),
+    "avoid-insecure-deserialization": DocMetadata(
+        importance="High",
+        guidance_explained="This change is generally safe and will prevent deserialization vulnerabilities.",
+        need_sarif="Yes (DefectDojo)",
+    ),
 }
 
 

--- a/src/codemodder/scripts/generate_docs.py
+++ b/src/codemodder/scripts/generate_docs.py
@@ -329,6 +329,11 @@ METADATA = CORE_METADATA | {
         guidance_explained=CORE_METADATA["enable-jinja2-autoescape"].guidance_explained,
         need_sarif="Yes (Sonar)",
     ),
+    "django-secure-set-cookie": DocMetadata(
+        importance="Medium",
+        guidance_explained="Our change provides the most secure way to create cookies in Django. However, it's possible you have configured your Django application configurations to use secure cookies. In these cases, using the default parameters for `set_cookie` is safe.",
+        need_sarif="Yes (DefectDojo)",
+    ),
 }
 
 

--- a/src/codemodder/sonar_results.py
+++ b/src/codemodder/sonar_results.py
@@ -1,5 +1,6 @@
 import json
 from dataclasses import replace
+from functools import cache
 from pathlib import Path
 
 import libcst as cst
@@ -45,6 +46,7 @@ class SonarResult(Result):
 
 class SonarResultSet(ResultSet):
     @classmethod
+    @cache
     def from_json(cls, json_file: str | Path) -> Self:
         try:
             with open(json_file, "r", encoding="utf-8") as file:

--- a/src/core_codemods/__init__.py
+++ b/src/core_codemods/__init__.py
@@ -2,6 +2,9 @@ from codemodder.registry import CodemodCollection
 
 from .add_requests_timeouts import AddRequestsTimeouts
 from .combine_startswith_endswith import CombineStartswithEndswith
+from .defectdojo.semgrep.avoid_insecure_deserialization import (
+    AvoidInsecureDeserialization,
+)
 from .defectdojo.semgrep.django_secure_set_cookie import DjangoSecureSetCookie
 from .django_debug_flag_on import DjangoDebugFlagOn
 from .django_json_response_type import DjangoJsonResponseType
@@ -159,6 +162,7 @@ sonar_registry = CodemodCollection(
 defectdojo_registry = CodemodCollection(
     origin="defectdojo",
     codemods=[
+        AvoidInsecureDeserialization,
         DjangoSecureSetCookie,
     ],
 )

--- a/src/core_codemods/__init__.py
+++ b/src/core_codemods/__init__.py
@@ -2,6 +2,7 @@ from codemodder.registry import CodemodCollection
 
 from .add_requests_timeouts import AddRequestsTimeouts
 from .combine_startswith_endswith import CombineStartswithEndswith
+from .defectdojo.semgrep.django_secure_set_cookie import DjangoSecureSetCookie
 from .django_debug_flag_on import DjangoDebugFlagOn
 from .django_json_response_type import DjangoJsonResponseType
 from .django_model_without_dunder_str import DjangoModelWithoutDunderStr
@@ -152,5 +153,12 @@ sonar_registry = CodemodCollection(
         SonarTempfileMktemp,
         SonarSecureRandom,
         SonarEnableJinja2Autoescape,
+    ],
+)
+
+defectdojo_registry = CodemodCollection(
+    origin="defectdojo",
+    codemods=[
+        DjangoSecureSetCookie,
     ],
 )

--- a/src/core_codemods/api/__init__.py
+++ b/src/core_codemods/api/__init__.py
@@ -1,4 +1,4 @@
 # ruff: noqa: F401
 from codemodder.codemods.api import Metadata, Reference, ReviewGuidance
 
-from .core_codemod import CoreCodemod, ImportModifierCodemod, SimpleCodemod
+from .core_codemod import CoreCodemod, ImportModifierCodemod, SASTCodemod, SimpleCodemod

--- a/src/core_codemods/defectdojo/api.py
+++ b/src/core_codemods/defectdojo/api.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from functools import cache
 from pathlib import Path
 from typing import cast
 
@@ -21,11 +22,18 @@ class DefectDojoDetector(BaseDetector):
         context: CodemodExecutionContext,
         files_to_analyze: list[Path],
     ) -> ResultSet:
-        result_set = DefectDojoResultSet()
-        for filename in context.tool_result_files_map.get("defectdojo", []):
-            result_set |= DefectDojoResultSet.from_json(filename)
+        del codemod_id
+        del files_to_analyze
+        result_files = tuple(context.tool_result_files_map.get("defectdojo", ()))
+        return _process_results(result_files)
 
-        return result_set
+
+@cache
+def _process_results(result_files: tuple[str]) -> ResultSet:
+    result_set = DefectDojoResultSet()
+    for filename in result_files:
+        result_set |= DefectDojoResultSet.from_json(filename)
+    return result_set
 
 
 class DefectDojoCodemod(SASTCodemod):

--- a/src/core_codemods/defectdojo/api.py
+++ b/src/core_codemods/defectdojo/api.py
@@ -1,0 +1,24 @@
+from pathlib import Path
+
+from codemodder.codemods.base_detector import BaseDetector
+from codemodder.context import CodemodExecutionContext
+from codemodder.result import ResultSet
+from core_codemods.api import SASTCodemod
+
+from .results import DefectDojoResultSet
+
+
+class DefectDojoDetector(BaseDetector):
+    def apply(
+        self,
+        codemod_id: str,
+        context: CodemodExecutionContext,
+        files_to_analyze: list[Path],
+    ) -> ResultSet:
+        return DefectDojoResultSet()
+
+
+class DefectDojoCodemod(SASTCodemod):
+    @property
+    def origin(self):
+        return "defectdojo"

--- a/src/core_codemods/defectdojo/api.py
+++ b/src/core_codemods/defectdojo/api.py
@@ -1,9 +1,15 @@
-from pathlib import Path
+from __future__ import annotations
 
+from pathlib import Path
+from typing import cast
+
+from typing_extensions import override
+
+from codemodder.codemods.api import Metadata, Reference, ToolMetadata
 from codemodder.codemods.base_detector import BaseDetector
 from codemodder.context import CodemodExecutionContext
 from codemodder.result import ResultSet
-from core_codemods.api import SASTCodemod
+from core_codemods.api import CoreCodemod, SASTCodemod
 
 from .results import DefectDojoResultSet
 
@@ -15,10 +21,58 @@ class DefectDojoDetector(BaseDetector):
         context: CodemodExecutionContext,
         files_to_analyze: list[Path],
     ) -> ResultSet:
-        return DefectDojoResultSet()
+        result_set = DefectDojoResultSet()
+        for filename in context.tool_result_files_map.get("defectdojo", []):
+            result_set |= DefectDojoResultSet.from_json(filename)
+
+        return result_set
 
 
 class DefectDojoCodemod(SASTCodemod):
     @property
     def origin(self):
         return "defectdojo"
+
+    @classmethod
+    def from_core_codemod(
+        cls,
+        name: str,
+        other: CoreCodemod,
+        rule_id: str,
+        rule_name: str,
+        rule_url: str,
+    ) -> DefectDojoCodemod:
+        return DefectDojoCodemod(
+            metadata=Metadata(
+                name=name,
+                summary="DefectDojo: " + other.summary,
+                review_guidance=other._metadata.review_guidance,
+                references=(
+                    other.references + [Reference(url=rule_url, description=rule_name)]
+                ),
+                description=f"This codemod acts upon the following DefectDojo rules: {rule_id}.\n\n"
+                + other.description,
+                tool=ToolMetadata(
+                    name="DefectDojo",
+                    rule_id=rule_id,
+                    rule_name=rule_name,
+                    rule_url=rule_url,
+                ),
+            ),
+            transformer=other.transformer,
+            detector=DefectDojoDetector(),
+            requested_rules=[rule_id],
+        )
+
+    @override
+    def apply(
+        self,
+        context: CodemodExecutionContext,
+        files_to_analyze: list[Path],
+    ) -> None:
+        self._apply(
+            context,
+            files_to_analyze,
+            # We know this has a tool because we created it with `from_core_codemod`
+            [cast(ToolMetadata, self._metadata.tool).rule_id],
+        )

--- a/src/core_codemods/defectdojo/results.py
+++ b/src/core_codemods/defectdojo/results.py
@@ -1,0 +1,41 @@
+import json
+from functools import cache
+from pathlib import Path
+
+from typing_extensions import Self
+
+from codemodder.result import LineInfo, Location, Result, ResultSet
+
+
+class DefectDojoLocation(Location):
+    @classmethod
+    def from_finding(cls, finding: dict) -> Self:
+        return cls(
+            file=Path(finding["file_path"]),
+            # TODO: parse snippet from "description" field?
+            start=LineInfo(finding["line"]),
+            end=LineInfo(finding["line"]),
+        )
+
+
+class DefectDojoResult(Result):
+    @classmethod
+    def from_finding(cls, finding: dict) -> Self:
+        return cls(
+            rule_id=finding["title"],
+            locations=[DefectDojoLocation.from_finding(finding)],
+        )
+
+
+class DefectDojoResultSet(ResultSet):
+    @cache
+    @classmethod
+    def from_json(cls, json_file: str | Path) -> Self:
+        with open(json_file, "r", encoding="utf-8") as file:
+            data = json.load(file)
+
+        result_set = cls()
+        for finding in data.get("results"):
+            result_set.add_result(DefectDojoResult.from_finding(finding))
+
+        return result_set

--- a/src/core_codemods/defectdojo/semgrep/avoid_insecure_deserialization.py
+++ b/src/core_codemods/defectdojo/semgrep/avoid_insecure_deserialization.py
@@ -1,0 +1,52 @@
+import libcst as cst
+
+from codemodder.codemods.api import Metadata, ReviewGuidance, ToolMetadata
+from codemodder.codemods.libcst_transformer import (
+    LibcstResultTransformer,
+    LibcstTransformerPipeline,
+)
+from codemodder.codemods.utils_mixin import NameResolutionMixin
+from core_codemods.defectdojo.api import DefectDojoCodemod, DefectDojoDetector
+from core_codemods.harden_pickle_load import HardenPickleLoad
+from core_codemods.harden_pyyaml import CodemodProtocol, HardenPyyamlCallMixin
+
+
+class AvoidInsecureDeserializationTransformer(
+    LibcstResultTransformer,
+    NameResolutionMixin,
+    HardenPyyamlCallMixin,
+    CodemodProtocol,
+):
+    def leave_Call(
+        self, original_node: cst.Call, updated_node: cst.Call
+    ) -> cst.Call | None:
+        if (
+            self.node_is_selected(original_node)
+            and self.find_base_name(original_node) == "yaml.load"
+        ):
+            self.report_change(
+                original_node, description="Use SafeLoader in pyyaml.load calls"
+            )
+            return self.update_call(original_node, updated_node)
+
+        return updated_node
+
+
+AvoidInsecureDeserialization = DefectDojoCodemod(
+    metadata=Metadata(
+        name="avoid-insecure-deserialization",
+        summary="Harden potentially insecure deserialization operations",
+        review_guidance=ReviewGuidance.MERGE_AFTER_CURSORY_REVIEW,
+        tool=ToolMetadata(
+            name="DefectDojo",
+            rule_id="python.django.security.audit.avoid-insecure-deserialization.avoid-insecure-deserialization",
+            rule_name="avoid-insecure-deserialization",
+            rule_url="https://semgrep.dev/playground/r/python.django.security.audit.avoid-insecure-deserialization.avoid-insecure-deserialization",
+        ),
+        references=[],
+    ),
+    transformer=LibcstTransformerPipeline(
+        AvoidInsecureDeserializationTransformer, HardenPickleLoad
+    ),
+    detector=DefectDojoDetector(),
+)

--- a/src/core_codemods/defectdojo/semgrep/django_secure_set_cookie.py
+++ b/src/core_codemods/defectdojo/semgrep/django_secure_set_cookie.py
@@ -1,0 +1,52 @@
+import libcst as cst
+
+from codemodder.codemods.api import Metadata, ReviewGuidance, ToolMetadata
+from codemodder.codemods.libcst_transformer import (
+    LibcstResultTransformer,
+    LibcstTransformerPipeline,
+)
+from codemodder.codemods.utils_mixin import NameResolutionMixin
+from core_codemods.defectdojo.api import DefectDojoCodemod, DefectDojoDetector
+from core_codemods.secure_cookie_mixin import SecureCookieMixin
+
+
+class DjangoSecureSetCookieTransformer(
+    LibcstResultTransformer,
+    NameResolutionMixin,
+    SecureCookieMixin,
+):
+    change_description = (
+        "Call `set_cookie` with `secure=True`, `httponly=True`, and `samesite='Lax'."
+    )
+
+    def leave_Call(self, original_node: cst.Call, updated_node: cst.Call) -> cst.Call:
+        if self.node_is_selected(original_node):
+            if (name := self.find_base_name(original_node.func)) and name.endswith(
+                "set_cookie"
+            ):
+                new_args = self.replace_args(
+                    original_node,
+                    self._choose_new_args(original_node),
+                )
+                self.report_change(original_node)
+                return self.update_arg_target(updated_node, new_args)
+
+        return updated_node
+
+
+DjangoSecureSetCookie = DefectDojoCodemod(
+    metadata=Metadata(
+        name="django-secure-set-cookie",
+        summary="Use Safe Parameters in Django Response `set_cookie` Call",
+        review_guidance=ReviewGuidance.MERGE_AFTER_CURSORY_REVIEW,
+        tool=ToolMetadata(
+            name="DefectDojo",
+            rule_id="python.django.security.audit.secure-cookies.django-secure-set-cookie",
+            rule_name="django-secure-set-cookie",
+            rule_url="https://semgrep.dev/playground/r/python.django.security.audit.secure-cookies.django-secure-set-cookie",
+        ),
+        references=[],
+    ),
+    transformer=LibcstTransformerPipeline(DjangoSecureSetCookieTransformer),
+    detector=DefectDojoDetector(),
+)

--- a/src/core_codemods/docs/defectdojo_python_avoid-insecure-deserialization.md
+++ b/src/core_codemods/docs/defectdojo_python_avoid-insecure-deserialization.md
@@ -1,0 +1,36 @@
+Use of insecure deserialization can potentially lead to arbitrary code execution. This codemod addresses this issue with two different serialization providers:
+* `yaml` (via [PyYAML](https://pyyaml.org/wiki/PyYAMLDocumentation))
+* `pickle` (via the standard library [pickle](https://docs.python.org/3/library/pickle.html) module)
+
+Each is described in more detail below.
+
+## PyYAML
+
+The default loaders in PyYAML are not safe to use with untrusted data. They potentially make your application vulnerable to arbitrary code execution attacks. If you open a YAML file from an untrusted source, and the file is loaded with the default loader, an attacker could execute arbitrary code on your machine.
+
+Calling `yaml.load()` without an explicit loader argument is equivalent to calling it with `Loader=yaml.Loader`, which is unsafe. This usage [has been deprecated](https://github.com/yaml/pyyaml/wiki/PyYAML-yaml.load(input\)-Deprecation) since PyYAML 5.1. This codemod will add an explicit `SafeLoader` argument to all `yaml.load()` calls that don't use an explicit loader.
+
+The changes from this codemod look like the following:
+```diff
+  import yaml
+  data = b'!!python/object/apply:subprocess.Popen \\n- ls'
+- deserialized_data = yaml.load(data, yaml.Loader)
++ deserialized_data = yaml.load(data, Loader=yaml.SafeLoader)
+```
+
+## Pickle
+
+Python's `pickle` module is notoriouly insecure. While it is very useful for serializing and deserializing Python objects, it is not safe to use `pickle` to load data from untrusted sources. This is because `pickle` can execute arbitrary code when loading data. This can be exploited by an attacker to execute arbitrary code on your system. Unlike `yaml` there is no concept of a "safe" loader in `pickle`. Therefore, it is recommended to avoid `pickle` and to use a different serialization format such as `json` or `yaml` when working with untrusted data.
+
+However, if you must use `pickle` to load data from an untrusted source, we recommend using the open-source `fickling` library. `fickling` is a drop-in replacement for `pickle` that validates the data before loading it and checks for the possibility of code execution. This makes it much safer (although still not entirely safe) to use `pickle` to load data from untrusted sources.
+
+This codemod replaces calls to `pickle.load` with `fickling.load` in Python code. It also adds an import statement for `fickling` if it is not already present. 
+
+The changes look like the following:
+```diff
+- import pickle
++ import fickling
+ 
+- data = pickle.load(file)
++ data = fickling.load(file)
+```

--- a/src/core_codemods/docs/defectdojo_python_django-secure-set-cookie.md
+++ b/src/core_codemods/docs/defectdojo_python_django-secure-set-cookie.md
@@ -1,0 +1,13 @@
+This codemod sets the most secure parameters when Django applications call `set_cookie` on a response object. Without these parameters, your Django
+application cookies may be vulnerable to being intercepted and used to gain access to sensitive data.
+
+The changes from this codemod look like this:
+
+```diff
+ from django.shortcuts import render
+ def index(request):
+   resp = render(request, 'index.html')
+ - resp.set_cookie('custom_cookie', 'value')
+ + resp.set_cookie('custom_cookie', 'value', secure=True, httponly=True, samesite='Lax')
+   return resp
+```

--- a/src/core_codemods/secure_cookie_mixin.py
+++ b/src/core_codemods/secure_cookie_mixin.py
@@ -1,0 +1,27 @@
+from libcst import matchers
+
+from codemodder.codemods.libcst_transformer import NewArg
+
+
+class SecureCookieMixin:
+    def _choose_new_args(self, original_node):
+        new_args = [
+            NewArg(name="secure", value="True", add_if_missing=True),
+            NewArg(name="httponly", value="True", add_if_missing=True),
+        ]
+
+        samesite = matchers.Arg(
+            keyword=matchers.Name(value="samesite"),
+            value=matchers.SimpleString(value="'Strict'"),
+        )
+
+        # samesite=Strict is OK because it's more restrictive than Lax.
+        strict_samesite_defined = any(
+            matchers.matches(arg, samesite) for arg in original_node.args
+        )
+        if not strict_samesite_defined:
+            new_args.append(
+                NewArg(name="samesite", value="'Lax'", add_if_missing=True),
+            )
+
+        return new_args

--- a/tests/codemods/defectdojo/semgrep/test_avoid_insecure_deserialization.py
+++ b/tests/codemods/defectdojo/semgrep/test_avoid_insecure_deserialization.py
@@ -1,0 +1,110 @@
+import json
+
+import mock
+
+from codemodder.codemods.test import BaseSASTCodemodTest
+from codemodder.dependency import Fickling
+from core_codemods.defectdojo.semgrep.avoid_insecure_deserialization import (
+    AvoidInsecureDeserialization,
+)
+
+RULE_ID = "python.django.security.audit.avoid-insecure-deserialization.avoid-insecure-deserialization"
+
+
+class TestDjangoAvoidInsecureDeserialization(BaseSASTCodemodTest):
+    codemod = AvoidInsecureDeserialization
+    tool = "defectdojo"
+
+    def test_name(self):
+        assert self.codemod._metadata.name == "avoid-insecure-deserialization"
+
+    def test_yaml_load(self, tmpdir):
+        input_code = """
+        import yaml
+
+        result = yaml.load("data")
+        """
+        expected = """
+        import yaml
+
+        result = yaml.load("data", Loader=yaml.SafeLoader)
+        """
+
+        findings = {
+            "results": [
+                {
+                    "title": RULE_ID,
+                    "file_path": "code.py",
+                    "line": 4,
+                },
+            ]
+        }
+
+        self.run_and_assert(tmpdir, input_code, expected, results=json.dumps(findings))
+
+    @mock.patch("codemodder.codemods.api.FileContext.add_dependency")
+    def test_pickle_load(self, adds_dependency, tmpdir):
+        input_code = """
+        import pickle
+
+        result = pickle.load("data")
+        """
+        expected = """
+        import fickling
+
+        result = fickling.load("data")
+        """
+
+        findings = {
+            "results": [
+                {
+                    "title": RULE_ID,
+                    "file_path": "code.py",
+                    "line": 4,
+                },
+            ]
+        }
+
+        self.run_and_assert(tmpdir, input_code, expected, results=json.dumps(findings))
+        adds_dependency.assert_called_once_with(Fickling)
+
+    @mock.patch("codemodder.codemods.api.FileContext.add_dependency")
+    def test_pickle_and_yaml(self, adds_dependency, tmpdir):
+        input_code = """
+        import pickle
+        import yaml
+
+        result = pickle.load("data")
+        result = yaml.load("data")
+        """
+        expected = """
+        import yaml
+        import fickling
+
+        result = fickling.load("data")
+        result = yaml.load("data", Loader=yaml.SafeLoader)
+        """
+
+        findings = {
+            "results": [
+                {
+                    "title": RULE_ID,
+                    "file_path": "code.py",
+                    "line": 5,
+                },
+                {
+                    "title": RULE_ID,
+                    "file_path": "code.py",
+                    "line": 6,
+                },
+            ]
+        }
+
+        self.run_and_assert(
+            tmpdir,
+            input_code,
+            expected,
+            results=json.dumps(findings),
+            num_changes=2,
+        )
+        adds_dependency.assert_called_once_with(Fickling)

--- a/tests/codemods/defectdojo/semgrep/test_django_secure_set_cookie.py
+++ b/tests/codemods/defectdojo/semgrep/test_django_secure_set_cookie.py
@@ -1,0 +1,34 @@
+import json
+
+from codemodder.codemods.test import BaseSASTCodemodTest
+from core_codemods.defectdojo.semgrep.django_secure_set_cookie import (
+    DjangoSecureSetCookie,
+)
+
+
+class TestDjangoSecureSetCookie(BaseSASTCodemodTest):
+    codemod = DjangoSecureSetCookie
+    tool = "defectdojo"
+
+    def test_name(self):
+        assert self.codemod._metadata.name == "django-secure-set-cookie"
+
+    def test_simple(self, tmpdir):
+        input_code = """
+        response.set_cookie("name", "value")
+        """
+        expected = """
+        response.set_cookie("name", "value", secure=True, httponly=True, samesite='Lax')
+        """
+
+        findings = {
+            "results": [
+                {
+                    "title": "python.django.security.audit.secure-cookies.django-secure-set-cookie",
+                    "file_path": "code.py",
+                    "line": 2,
+                },
+            ]
+        }
+
+        self.run_and_assert(tmpdir, input_code, expected, results=json.dumps(findings))


### PR DESCRIPTION
## Overview
*Add new codemods to remediate (Semgrep) findings via DefectDojo*

## Description

* [DefectDojo](https://www.defectdojo.org/) is an open-source vulnerability management platform
  * It aggregates findings from multiple rule providers and exposes them via a unified API
* This PR adds the ability to process DefectDojo findings JSON files
* It also implements two codemods that remediate Semgrep rules represented as DefectDojo findings:
  * [django-secure-set-cookie](https://semgrep.dev/playground/r/python.django.security.audit.secure-cookies.django-secure-set-cookie?editorMode=advanced)
  * [avoid-insecure-deserialization](https://semgrep.dev/playground/r/python.django.security.audit.avoid-insecure-deserialization.avoid-insecure-deserialization?editorMode=advanced)
  * Eventually we can also adapt these codemods to remediate semgrep findings directly
* I did some refactoring to enable code reuse. Hopefully it's not too much of a mess
* Since this is primarily for demo purposes I skipped the integration tests for now. They can be added later