### PR TITLE
New find-and-fix and sonar codemod for floating point equality

### DIFF
--- a/integration_tests/sonar/test_sonar_fix_float_equality.py
+++ b/integration_tests/sonar/test_sonar_fix_float_equality.py
@@ -1,0 +1,29 @@
+from codemodder.codemods.test import SonarIntegrationTest
+from core_codemods.fix_float_equality import FixFloatEqualityTransformer
+from core_codemods.sonar.sonar_fix_float_equality import SonarFixFloatEquality
+
+
+class TestSonarFixFloatEquality(SonarIntegrationTest):
+    codemod = SonarFixFloatEquality
+    code_path = "tests/samples/fix_float_equality.py"
+    replacement_lines = [
+        (1, "import math\n"),
+        (2, "\n"),
+        (3, "def foo(a, b):\n"),
+        (4, "    return math.isclose(a, b - 0.1, rel_tol=1e-09, abs_tol=0.0)\n"),
+    ]
+    # fmt: off
+    expected_diff = (
+        """--- \n"""
+        """+++ \n"""
+        """@@ -1,2 +1,4 @@\n"""
+        """+import math\n"""
+        """+\n"""
+        """ def foo(a, b):\n"""
+        """-    return a == b - 0.1\n"""
+        """+    return math.isclose(a, b - 0.1, rel_tol=1e-09, abs_tol=0.0)\n"""
+    )
+    # fmt: on
+    expected_line_change = "2"
+    change_description = FixFloatEqualityTransformer.change_description
+    num_changes = 1

--- a/integration_tests/test_fix_float_equality.py
+++ b/integration_tests/test_fix_float_equality.py
@@ -17,10 +17,6 @@ class TestFixFloatEquality(BaseIntegrationTest):
     def foo(a, b):
         return math.isclose(a, b - 0.1, rel_tol=1e-09, abs_tol=0.0)
     """
-    replacement_lines = [
-        (1, "import math\n\n"),
-        (3, "return math.isclose(a, b - 0.1, rel_tol=1e-09, abs_tol=0.0)\n"),
-    ]
     # fmt: off
     expected_diff = (
         """--- \n"""

--- a/integration_tests/test_fix_float_equality.py
+++ b/integration_tests/test_fix_float_equality.py
@@ -1,0 +1,37 @@
+from codemodder.codemods.test import BaseIntegrationTest
+from core_codemods.fix_float_equality import (
+    FixFloatEquality,
+    FixFloatEqualityTransformer,
+)
+
+
+class TestFixFloatEquality(BaseIntegrationTest):
+    codemod = FixFloatEquality
+    original_code = """
+    def foo(a, b):
+        return a == b - 0.1
+    """
+    expected_new_code = """
+    import math
+    
+    def foo(a, b):
+        return math.isclose(a, b - 0.1, rel_tol=1e-09, abs_tol=0.0)
+    """
+    replacement_lines = [
+        (1, "import math\n\n"),
+        (3, "return math.isclose(a, b - 0.1, rel_tol=1e-09, abs_tol=0.0)\n"),
+    ]
+    # fmt: off
+    expected_diff = (
+        """--- \n"""
+        """+++ \n"""
+        """@@ -1,2 +1,4 @@\n"""
+        """+import math\n"""
+        """+\n"""
+        """ def foo(a, b):\n"""
+        """-    return a == b - 0.1\n"""
+        """+    return math.isclose(a, b - 0.1, rel_tol=1e-09, abs_tol=0.0)"""
+    )
+    # fmt: on
+    expected_line_change = "2"
+    change_description = FixFloatEqualityTransformer.change_description

--- a/src/codemodder/scripts/generate_docs.py
+++ b/src/codemodder/scripts/generate_docs.py
@@ -288,6 +288,7 @@ SONAR_CODEMOD_NAMES = [
     "secure-random-S2245",
     "enable-jinja2-autoescape-S5247",
     "url-sandbox-S5144",
+    "fix-float-equality-S1244",
 ]
 SONAR_CODEMODS = {
     name: DocMetadata(

--- a/src/codemodder/scripts/generate_docs.py
+++ b/src/codemodder/scripts/generate_docs.py
@@ -255,6 +255,10 @@ If you want to allow those protocols, change the incoming PR to look more like t
         importance="Medium",
         guidance_explained="This change is safe and will prevent errors when calling on these instance or class methods..",
     ),
+    "fix-float-equality": DocMetadata(
+        importance="Medium",
+        guidance_explained="This change makes your code more accurate but in some cases it may be necessary to adjust the `abs_tol` and `rel_tol` parameter values for your particular calculations.",
+    ),
 }
 DEFECTDOJO_CODEMODS = {
     "django-secure-set-cookie": DocMetadata(

--- a/src/core_codemods/__init__.py
+++ b/src/core_codemods/__init__.py
@@ -55,6 +55,7 @@ from .sonar.sonar_django_receiver_on_top import SonarDjangoReceiverOnTop
 from .sonar.sonar_enable_jinja2_autoescape import SonarEnableJinja2Autoescape
 from .sonar.sonar_exception_without_raise import SonarExceptionWithoutRaise
 from .sonar.sonar_fix_assert_tuple import SonarFixAssertTuple
+from .sonar.sonar_fix_float_equality import SonarFixFloatEquality
 from .sonar.sonar_fix_missing_self_or_cls import SonarFixMissingSelfOrCls
 from .sonar.sonar_flask_json_response_type import SonarFlaskJsonResponseType
 from .sonar.sonar_jwt_decode_verify import SonarJwtDecodeVerify
@@ -160,6 +161,7 @@ sonar_registry = CodemodCollection(
         SonarSecureRandom,
         SonarEnableJinja2Autoescape,
         SonarUrlSandbox,
+        SonarFixFloatEquality,
     ],
 )
 

--- a/src/core_codemods/__init__.py
+++ b/src/core_codemods/__init__.py
@@ -20,6 +20,7 @@ from .fix_dataclass_defaults import FixDataclassDefaults
 from .fix_deprecated_abstractproperty import FixDeprecatedAbstractproperty
 from .fix_deprecated_logging_warn import FixDeprecatedLoggingWarn
 from .fix_empty_sequence_comparison import FixEmptySequenceComparison
+from .fix_float_equality import FixFloatEquality
 from .fix_hasattr_call import TransformFixHasattrCall
 from .fix_missing_self_or_cls import FixMissingSelfOrCls
 from .fix_mutable_params import FixMutableParams
@@ -131,6 +132,7 @@ registry = CodemodCollection(
         FixEmptySequenceComparison,
         RemoveAssertionInPytestRaises,
         FixAssertTuple,
+        FixFloatEquality,
         LazyLogging,
         StrConcatInSeqLiteral,
         FixAsyncTaskInstantiation,

--- a/src/core_codemods/docs/pixee_python_fix-float-equality.md
+++ b/src/core_codemods/docs/pixee_python_fix-float-equality.md
@@ -1,6 +1,6 @@
 In most programming languages, floating point arithmetic is imprecise due to the way floating point numbers are stored as binary representations. Moreover, the result of calculations with floats can vary based on when rounding happens. Using equality or inequality to compare floats or their operations will almost always be imprecise and lead to bugs.
 
-For these reasons, this codemod changes any operations involving equality or inequality with floats to the recommended `math.isclose` function. We have explicitly defined the default parameters `rel_tol=1e-09` and  `abs_tol=0.0` as a starting point for you to consider depending on your calculation needs.
+For these reasons, this codemod changes any operations involving equality or inequality with floats to the recommended `math.isclose` function. This codemod uses the default parameter values `rel_tol=1e-09` and  `abs_tol=0.0` but makes them explicit as a starting point for you to consider depending on your calculation needs.
 
 Our changes look like the following:
 ```diff

--- a/src/core_codemods/docs/pixee_python_fix-float-equality.md
+++ b/src/core_codemods/docs/pixee_python_fix-float-equality.md
@@ -1,0 +1,12 @@
+In most programming languages, floating point arithmetic is imprecise due to the way floating point numbers are stored as binary representations. Moreover, the result of calculations with floats can vary based on when rounding happens. Using equality or inequality to compare floats or their operations will almost always be imprecise and lead to bugs.
+
+For these reasons, this codemod changes any operations involving equality or inequality with floats to the recommended `math.isclose` function. We have explicitly defined the default parameters `rel_tol=1e-09` and  `abs_tol=0.0` as a starting point for you to consider depending on your calculation needs.
+
+Our changes look like the following:
+```diff
++import math
++
+ def foo(a, b):
+-    return a == b - 0.1
++    return math.isclose(a, b - 0.1, rel_tol=1e-09, abs_tol=0.0)
+```

--- a/src/core_codemods/fix_float_equality.py
+++ b/src/core_codemods/fix_float_equality.py
@@ -75,9 +75,9 @@ class FixFloatEqualityTransformer(
             case (cst.Float(), _) | (_, cst.Float()):
                 return True
             case (cst.BinaryOperation(), _):
-                return self.at_least_one_float(left.left, left.right)
+                return self.at_least_one_float(left_type.left, left_type.right)
             case (_, cst.BinaryOperation()):
-                return self.at_least_one_float(right.left, right.right)
+                return self.at_least_one_float(right_type.left, right_type.right)
         return False
 
 

--- a/src/core_codemods/fix_float_equality.py
+++ b/src/core_codemods/fix_float_equality.py
@@ -84,12 +84,13 @@ class FixFloatEqualityTransformer(
 FixFloatEquality = CoreCodemod(
     metadata=Metadata(
         name="fix-float-equality",
-        summary="TODOReplace `is` with `==` for literal or new object comparisons",
-        review_guidance=ReviewGuidance.MERGE_WITHOUT_REVIEW,
+        summary="Replace `==` or `!=` with `math.isclose` Call for Floats or Arithmetic Operations with Floats",
+        review_guidance=ReviewGuidance.MERGE_AFTER_REVIEW,
         references=[
             Reference(
-                url="TODOhttps://docs.python.org/3/library/stdtypes.html#comparisons"
+                url="https://docs.python.org/3/tutorial/floatingpoint.html#floating-point-arithmetic-issues-and-limitations"
             ),
+            Reference(url="https://docs.python.org/3/library/math.html#math.isclose"),
         ],
     ),
     transformer=LibcstTransformerPipeline(FixFloatEqualityTransformer),

--- a/src/core_codemods/fix_float_equality.py
+++ b/src/core_codemods/fix_float_equality.py
@@ -12,7 +12,7 @@ from core_codemods.api.core_codemod import CoreCodemod
 class FixFloatEqualityTransformer(
     LibcstResultTransformer, NameAndAncestorResolutionMixin
 ):
-    change_description = "Replace `==` or `!=` with `math.isclose` callz"
+    change_description = "Replace `==` or `!=` with `math.isclose`"
 
     def leave_Comparison(
         self, original_node: cst.Comparison, updated_node: cst.Comparison

--- a/src/core_codemods/fix_float_equality.py
+++ b/src/core_codemods/fix_float_equality.py
@@ -84,7 +84,7 @@ class FixFloatEqualityTransformer(
 FixFloatEquality = CoreCodemod(
     metadata=Metadata(
         name="fix-float-equality",
-        summary="Replace `==` or `!=` with `math.isclose` Call for Floats or Arithmetic Operations with Floats",
+        summary="Use `math.isclose` Instead of Direct Equality for Floats",
         review_guidance=ReviewGuidance.MERGE_AFTER_REVIEW,
         references=[
             Reference(

--- a/src/core_codemods/fix_float_equality.py
+++ b/src/core_codemods/fix_float_equality.py
@@ -1,0 +1,97 @@
+import libcst as cst
+
+from codemodder.codemods.libcst_transformer import (
+    LibcstResultTransformer,
+    LibcstTransformerPipeline,
+)
+from codemodder.codemods.utils_mixin import NameAndAncestorResolutionMixin
+from core_codemods.api import Metadata, Reference, ReviewGuidance
+from core_codemods.api.core_codemod import CoreCodemod
+
+
+class FixFloatEqualityTransformer(
+    LibcstResultTransformer, NameAndAncestorResolutionMixin
+):
+    change_description = "Replace `==` or `!=` with `math.isclose` callz"
+
+    def leave_Comparison(
+        self, original_node: cst.Comparison, updated_node: cst.Comparison
+    ) -> cst.BaseExpression:
+        if not self.node_is_selected(original_node):
+            return updated_node
+
+        match original_node:
+            case cst.Comparison(
+                left=left, comparisons=[cst.ComparisonTarget() as target]
+            ):
+                if isinstance(
+                    target.operator, cst.Equal | cst.NotEqual
+                ) and self.at_least_one_float(left, right := target.comparator):
+                    self.add_needed_import("math")
+                    isclose_call = self.make_isclose_call(left, right)
+                    self.report_change(original_node)
+                    return (
+                        isclose_call
+                        if isinstance(target.operator, cst.Equal)
+                        else cst.UnaryOperation(
+                            operator=cst.Not(),
+                            expression=isclose_call,
+                        )
+                    )
+        return updated_node
+
+    def make_isclose_call(self, left, right):
+        return cst.Call(
+            func=cst.Attribute(
+                value=cst.Name(value="math"), attr=cst.Name(value="isclose")
+            ),
+            args=[
+                cst.Arg(value=left),
+                cst.Arg(value=right),
+                cst.Arg(
+                    keyword=cst.Name(value="rel_tol"),
+                    value=cst.Float(value="1e-09"),
+                    equal=cst.AssignEqual(
+                        whitespace_before=cst.SimpleWhitespace(""),
+                        whitespace_after=cst.SimpleWhitespace(""),
+                    ),
+                ),
+                cst.Arg(
+                    keyword=cst.Name(value="abs_tol"),
+                    value=cst.Float(value="0.0"),
+                    equal=cst.AssignEqual(
+                        whitespace_before=cst.SimpleWhitespace(""),
+                        whitespace_after=cst.SimpleWhitespace(""),
+                    ),
+                ),
+            ],
+        )
+
+    def at_least_one_float(self, left, right) -> bool:
+        left_type = self.resolve_expression(left)
+        right_type = self.resolve_expression(right)
+
+        match (left_type, right_type):
+            case (cst.Float(), _) | (_, cst.Float()):
+                return True
+            case (cst.BinaryOperation(), _):
+                return self.at_least_one_float(left.left, left.right)
+            case (_, cst.BinaryOperation()):
+                return self.at_least_one_float(right.left, right.right)
+        return False
+
+
+FixFloatEquality = CoreCodemod(
+    metadata=Metadata(
+        name="fix-float-equality",
+        summary="TODOReplace `is` with `==` for literal or new object comparisons",
+        review_guidance=ReviewGuidance.MERGE_WITHOUT_REVIEW,
+        references=[
+            Reference(
+                url="TODOhttps://docs.python.org/3/library/stdtypes.html#comparisons"
+            ),
+        ],
+    ),
+    transformer=LibcstTransformerPipeline(FixFloatEqualityTransformer),
+    detector=None,
+)

--- a/src/core_codemods/sonar/sonar_fix_float_equality.py
+++ b/src/core_codemods/sonar/sonar_fix_float_equality.py
@@ -1,0 +1,10 @@
+from core_codemods.fix_float_equality import FixFloatEquality
+from core_codemods.sonar.api import SonarCodemod
+
+SonarFixFloatEquality = SonarCodemod.from_core_codemod(
+    name="fix-float-equality-S1244",
+    other=FixFloatEquality,
+    rule_id="python:S1244",
+    rule_name="Floating point numbers should not be tested for equality",
+    rule_url="https://rules.sonarsource.com/python/type/Bug/RSPEC-1244/",
+)

--- a/tests/codemods/sonar/test_sonar_fix_float_equality.py
+++ b/tests/codemods/sonar/test_sonar_fix_float_equality.py
@@ -1,0 +1,45 @@
+import json
+
+from codemodder.codemods.test import BaseSASTCodemodTest
+from core_codemods.sonar.sonar_fix_float_equality import SonarFixFloatEquality
+
+
+class TestSonarFixFloatEquality(BaseSASTCodemodTest):
+    codemod = SonarFixFloatEquality
+    tool = "sonar"
+
+    def test_name(self):
+        assert self.codemod.name == "fix-float-equality-S905"
+
+    def test_simple(self, tmpdir):
+        input_code = """
+        def foo(a, b):
+            return a == b - 0.1
+        """
+        expected_output = """
+        import math
+        
+        def foo(a, b):
+            return math.isclose(a, b - 0.1, rel_tol=1e-09, abs_tol=0.0)
+        """
+        issues = {
+            "issues": [
+                {
+                    "rule": "python:S905",
+                    "status": "OPEN",
+                    "component": "code.py",
+                    "textRange": {
+                        "startLine": 3,
+                        "endLine": 3,
+                        "startOffset": 11,
+                        "endOffset": 23,
+                    },
+                }
+            ]
+        }
+        self.run_and_assert(
+            tmpdir,
+            input_code,
+            expected_output,
+            results=json.dumps(issues),
+        )

--- a/tests/codemods/sonar/test_sonar_fix_float_equality.py
+++ b/tests/codemods/sonar/test_sonar_fix_float_equality.py
@@ -9,7 +9,7 @@ class TestSonarFixFloatEquality(BaseSASTCodemodTest):
     tool = "sonar"
 
     def test_name(self):
-        assert self.codemod.name == "fix-float-equality-S905"
+        assert self.codemod.name == "fix-float-equality-S1244"
 
     def test_simple(self, tmpdir):
         input_code = """
@@ -25,7 +25,7 @@ class TestSonarFixFloatEquality(BaseSASTCodemodTest):
         issues = {
             "issues": [
                 {
-                    "rule": "python:S905",
+                    "rule": "python:S1244",
                     "status": "OPEN",
                     "component": "code.py",
                     "textRange": {

--- a/tests/codemods/test_fix_float_equality.py
+++ b/tests/codemods/test_fix_float_equality.py
@@ -1,0 +1,90 @@
+from codemodder.codemods.test import BaseCodemodTest
+from core_codemods.fix_float_equality import FixFloatEquality
+
+
+class TestNumpyNanEquality(BaseCodemodTest):
+    codemod = FixFloatEquality
+
+    def test_name(self):
+        assert self.codemod.name == "fix-float-equality"
+
+    def test_change(self, tmpdir):
+        input_code = """
+        0.2 == 2 - 0.1
+        
+        0.01 + 1 == 1
+        
+        a = 1.0
+        b = 3.111
+        a != b
+        """
+        expected = """
+        import math
+        
+        math.isclose(0.2, 2 - 0.1, rel_tol=1e-09, abs_tol=0.0)
+        
+        math.isclose(0.01 + 1, 1, rel_tol=1e-09, abs_tol=0.0)
+        
+        a = 1.0
+        b = 3.111
+        not math.isclose(a, b, rel_tol=1e-09, abs_tol=0.0)
+        """
+        self.run_and_assert(tmpdir, input_code, expected, num_changes=3)
+
+    def test_change_resolve_float(self, tmpdir):
+        input_code = """
+        def foo(a, b):
+            return a == b + 0.1
+
+        def foo(b):
+            a = 1.02
+            return a != b + 2
+
+        """
+        expected = """
+        import math
+
+        def foo(a, b):
+            return math.isclose(a, b + 0.1, rel_tol=1e-09, abs_tol=0.0)
+
+        def foo(b):
+            a = 1.02
+            return not math.isclose(a, b + 2, rel_tol=1e-09, abs_tol=0.0)
+
+        """
+        self.run_and_assert(tmpdir, input_code, expected, num_changes=2)
+
+    def test_no_change(self, tmpdir):
+        input_code = """
+        2 == 1 + 1
+        
+        a = 3
+        b = 3
+        if a != b:
+            pass
+        """
+        self.run_and_assert(tmpdir, input_code, input_code)
+
+    def test_no_change_unknown_type(self, tmpdir):
+        input_code = """
+        def foo(a, b):
+            return a == b
+            
+        def foo(a, b):
+            return a - 10 == b
+        
+        def foo(b):
+            a = 1
+            return a == b + 1
+        """
+        self.run_and_assert(tmpdir, input_code, input_code)
+
+    """
+            a = 1.0
+        b = 3.111
+        if a != b:
+            pass
+        #todo assert not, from !=, function too
+    """
+    # todo: math already imported,
+    # TODO; EXCLUDE

--- a/tests/codemods/test_fix_float_equality.py
+++ b/tests/codemods/test_fix_float_equality.py
@@ -61,7 +61,7 @@ class TestNumpyNanEquality(BaseCodemodTest):
         if a != b:
             pass
         
-        assert a == b
+        assert a == b and 1 + a != b
         assert a != b 
         """
         expected = """
@@ -72,10 +72,10 @@ class TestNumpyNanEquality(BaseCodemodTest):
         if not math.isclose(a, b, rel_tol=1e-09, abs_tol=0.0):
             pass
         
-        assert math.isclose(a, b, rel_tol=1e-09, abs_tol=0.0)
+        assert math.isclose(a, b, rel_tol=1e-09, abs_tol=0.0) and not math.isclose(1 + a, b, rel_tol=1e-09, abs_tol=0.0)
         assert not math.isclose(a, b, rel_tol=1e-09, abs_tol=0.0) 
         """
-        self.run_and_assert(tmpdir, input_code, expected, num_changes=3)
+        self.run_and_assert(tmpdir, input_code, expected, num_changes=4)
 
     def test_change_math_already_imported(self, tmpdir):
         input_code = """
@@ -98,6 +98,8 @@ class TestNumpyNanEquality(BaseCodemodTest):
         b = 3
         if a != b:
             pass
+        
+        a is b - 0.11
         """
         self.run_and_assert(tmpdir, input_code, input_code)
 

--- a/tests/samples/fix_float_equality.py
+++ b/tests/samples/fix_float_equality.py
@@ -1,0 +1,2 @@
+def foo(a, b):
+    return a == b - 0.1

--- a/tests/samples/sonar_issues.json
+++ b/tests/samples/sonar_issues.json
@@ -1,5 +1,5 @@
 {
-  "total":38,
+  "total":39,
   "p":1,
   "ps":500,
   "paging":{
@@ -1677,6 +1677,39 @@
       "impacts": [
         {
           "softwareQuality": "SECURITY",
+          "severity": "MEDIUM"
+        }
+      ]
+    },
+    {
+      "key": "AY606lcc6hXAwyuO7dPZ",
+      "rule": "python:S1244",
+      "severity": "MAJOR",
+      "component": "pixee_codemodder-python:fix_float_equality.py",
+      "project": "pixee_codemodder-python",
+      "line": 7,
+      "hash": "4f98731d8aeb7e5d80e02d5ab1fd1ad8",
+      "textRange": {
+        "startLine": 2,
+        "endLine": 2,
+        "startOffset": 11,
+        "endOffset": 23
+      },
+      "flows": [],
+      "status": "OPEN",
+      "message": "Do not perform equality checks with floating point values.",
+      "effort": "5min",
+      "debt": "5min",
+      "assignee": "clavedeluna@github",
+      "tags": [],
+      "creationDate": "2024-04-06T21:36:46+0200",
+      "updateDate": "2024-04-06T21:37:06+0200",
+      "type": "BUG",
+      "organization": "pixee",
+      "cleanCodeAttributeCategory": "INTENTIONAL",
+      "impacts": [
+        {
+          "softwareQuality": "RELIABILITY",
           "severity": "MEDIUM"
         }
       ]


### PR DESCRIPTION
## Overview
*New codemod(s) to replace floating point equality comparison with `math.isclose`*

## Description

* This codemod will apply if at least one of the variables of the operation is a floating point number.
* In cases when we cannot determine what a constant would be (function args), and none o the related variables are floats, this codemod will not apply
* would've been nice to implement the find part of this with semgrep but it doesn't have typed metavariable matching for python (makes sense)

Closes #374
