### PR TITLE
Support simple patterns for codemod include/exclude

### DIFF
--- a/src/codemodder/registry.py
+++ b/src/codemodder/registry.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import re
 from dataclasses import dataclass
 from importlib.metadata import entry_points
 from typing import TYPE_CHECKING, Optional
@@ -64,36 +65,41 @@ class CodemodRegistry:
 
         if codemod_exclude and not codemod_include:
             base_codemods = {}
+            patterns = [
+                re.compile(exclude.replace("*", ".*"))
+                for exclude in codemod_exclude
+                if "*" in exclude
+            ]
+            names = set(name for name in codemod_exclude if "*" not in name)
             for codemod in self.codemods:
-                if (sast_only and codemod.origin != "pixee") or (
-                    not sast_only and codemod.origin == "pixee"
+                if (
+                    codemod.id in names
+                    or (codemod.origin == "pixee" and codemod.name in names)
+                    or any(pat.match(codemod.id) for pat in patterns)
                 ):
-                    base_codemods[codemod.id] = codemod
-                    base_codemods[codemod.name] = codemod
-
-            for name_or_id in codemod_exclude:
-                try:
-                    codemod = base_codemods[name_or_id]
-                except KeyError:
-                    logger.warning(
-                        f"Requested codemod to exclude'{name_or_id}' does not exist."
-                    )
                     continue
 
-                # remove both by name and id since we don't know which `name_or_id` represented
-                base_codemods.pop(codemod.name, None)
-                base_codemods.pop(codemod.id, None)
+                if bool(sast_only) != bool(codemod.origin == "pixee"):
+                    base_codemods[codemod.id] = codemod
+
             # Remove duplicates and preserve order
             return list(dict.fromkeys(base_codemods.values()))
 
         matched_codemods = []
         for name in codemod_include:
+            if "*" in name:
+                pat = re.compile(name.replace("*", ".*"))
+                matched_codemods.extend(
+                    [codemod for codemod in self.codemods if pat.match(codemod.id)]
+                )
+                continue
+
             try:
                 matched_codemods.append(
                     self._codemods_by_name.get(name) or self._codemods_by_id[name]
                 )
             except KeyError:
-                logger.warning(f"Requested codemod to include'{name}' does not exist.")
+                logger.warning(f"Requested codemod to include '{name}' does not exist.")
         return matched_codemods
 
     def describe_codemods(

--- a/src/codemodder/registry.py
+++ b/src/codemodder/registry.py
@@ -83,15 +83,18 @@ class CodemodRegistry:
                     base_codemods[codemod.id] = codemod
 
             # Remove duplicates and preserve order
-            return list(dict.fromkeys(base_codemods.values()))
+            return list(base_codemods.values())
 
         matched_codemods = []
         for name in codemod_include:
             if "*" in name:
                 pat = re.compile(name.replace("*", ".*"))
-                matched_codemods.extend(
-                    [codemod for codemod in self.codemods if pat.match(codemod.id)]
-                )
+                pattern_matches = [code for code in self.codemods if pat.match(code.id)]
+                matched_codemods.extend(pattern_matches)
+                if not pattern_matches:
+                    logger.warning(
+                        "Given codemod pattern '%s' does not match any codemods.", name
+                    )
                 continue
 
             try:

--- a/tests/codemods/test_include_exclude.py
+++ b/tests/codemods/test_include_exclude.py
@@ -89,3 +89,43 @@ class TestMatchCodemods:
             for c in self.registry.codemods
             if c.name not in "secure-random" and c.id in self.all_ids
         ]
+
+    def test_include_with_pattern(self):
+        assert self.registry.match_codemods(["*django*"], None) == [
+            c for c in self.registry.codemods if "django" in c.id
+        ]
+
+    def test_include_with_pattern_and_another(self):
+        assert self.registry.match_codemods(["*django*", "use-defusedxml"], None) == [
+            c for c in self.registry.codemods if "django" in c.id
+        ] + [self.codemod_map["use-defusedxml"]]
+
+    def test_include_sast_with_prefix(self):
+        assert self.registry.match_codemods(["sonar*"], None, sast_only=False) == [
+            c for c in self.registry.codemods if c.origin == "sonar"
+        ]
+
+    def test_exclude_with_pattern(self):
+        assert self.registry.match_codemods(None, ["*django*"], sast_only=False) == [
+            c
+            for c in self.registry.codemods
+            if "django" not in c.id and c.id in self.all_ids
+        ]
+
+    def test_exclude_with_pattern_and_another(self):
+        assert self.registry.match_codemods(
+            None, ["*django*", "use-defusedxml"], sast_only=False
+        ) == [
+            c
+            for c in self.registry.codemods
+            if "django" not in c.id
+            and c.id in self.all_ids
+            and c.name != "use-defusedxml"
+        ]
+
+    def test_exclude_pixee_with_prefix(self):
+        assert self.registry.match_codemods(None, ["pixee*"], sast_only=False) == [
+            c
+            for c in self.registry.codemods
+            if not c.origin == "pixee" and c.id in self.all_ids
+        ]

--- a/tests/codemods/test_include_exclude.py
+++ b/tests/codemods/test_include_exclude.py
@@ -105,6 +105,13 @@ class TestMatchCodemods:
             c for c in self.registry.codemods if c.origin == "sonar"
         ]
 
+    def test_warn_pattern_no_match(self, caplog):
+        assert self.registry.match_codemods(["*doesntexist*"], None) == []
+        assert (
+            "Given codemod pattern '*doesntexist*' does not match any codemods"
+            in caplog.text
+        )
+
     def test_exclude_with_pattern(self):
         assert self.registry.match_codemods(None, ["*django*"], sast_only=False) == [
             c

--- a/tests/test_codemodder.py
+++ b/tests/test_codemodder.py
@@ -210,7 +210,7 @@ class TestCodemodIncludeExclude:
         assert any(x[0] == ("scanned: %s files", 0) for x in info_logger.call_args_list)
 
         assert any(
-            f"Requested codemod to include'{bad_codemod}' does not exist." in x[0][0]
+            f"Requested codemod to include '{bad_codemod}' does not exist." in x[0][0]
             for x in warning_logger.call_args_list
         )
 
@@ -233,7 +233,7 @@ class TestCodemodIncludeExclude:
         write_report.assert_called_once()
         assert any("running codemod %s" in x[0][0] for x in info_logger.call_args_list)
         assert any(
-            f"Requested codemod to include'{bad_codemod}' does not exist." in x[0][0]
+            f"Requested codemod to include '{bad_codemod}' does not exist." in x[0][0]
             for x in warning_logger.call_args_list
         )
 
@@ -262,10 +262,6 @@ class TestCodemodIncludeExclude:
 
         assert f"pixee:python/{good_codemod}" not in codemods_that_ran
         assert any("running codemod %s" in x[0][0] for x in info_logger.call_args_list)
-        assert any(
-            f"Requested codemod to exclude'{bad_codemod}' does not exist." in x[0][0]
-            for x in warning_logger.call_args_list
-        )
 
     @mock.patch("codemodder.registry.logger.warning")
     @mock.patch("codemodder.codemodder.logger.info")
@@ -286,10 +282,6 @@ class TestCodemodIncludeExclude:
         run(args)
         write_report.assert_called_once()
         assert any("running codemod %s" in x[0][0] for x in info_logger.call_args_list)
-        assert any(
-            f"Requested codemod to exclude'{bad_codemod}' does not exist." in x[0][0]
-            for x in warning_logger.call_args_list
-        )
 
     @mock.patch("codemodder.codemods.semgrep.semgrep_run")
     def test_exclude_all_registered_codemods(self, mock_semgrep_run, dir_structure):


### PR DESCRIPTION
## Overview
*Support simple patterns for codemod include/exclude CLI flags*

## Description

* The spec was updated to enable simple pattern matching for codemod include/exclude
* In order to support this I simplified the exclusion logic a bit
* I took the liberty of removing the warning for non-existing codemods given to exclude; I'm not sure it's necessary
* I'm still a little unsure about the need for `sast_only` but I left it as-is for this PR

Closes #316 
