### PR TITLE
Change default behavior for Semgrep and ResultSet

### DIFF
--- a/src/codemodder/result.py
+++ b/src/codemodder/result.py
@@ -76,8 +76,7 @@ class ResultSet(dict[str, dict[Path, list[Result]]]):
 
         Some implementers may need to use the context to compute paths that are relative to the target directory.
         """
-        del context
-        return self.get(rule_id, {}).get(file, [])
+        return self.get(rule_id, {}).get(file.relative_to(context.directory), [])
 
     def files_for_rule(self, rule_id: str) -> list[Path]:
         return list(self.get(rule_id, {}).keys())

--- a/src/codemodder/semgrep.py
+++ b/src/codemodder/semgrep.py
@@ -116,7 +116,6 @@ def run(
         command = [
             "semgrep",
             "scan",
-            "--legacy",
             "--no-error",
             "--dataflow-traces",
             "--sarif",

--- a/src/core_codemods/defectdojo/results.py
+++ b/src/core_codemods/defectdojo/results.py
@@ -6,7 +6,6 @@ import libcst as cst
 from libcst._position import CodeRange
 from typing_extensions import Self, override
 
-from codemodder.context import CodemodExecutionContext
 from codemodder.result import LineInfo, Location, Result, ResultSet
 
 
@@ -56,10 +55,3 @@ class DefectDojoResultSet(ResultSet):
             result_set.add_result(DefectDojoResult.from_finding(finding))
 
         return result_set
-
-    @override
-    def results_for_rule_and_file(
-        self, context: CodemodExecutionContext, rule_id: str, file: Path
-    ) -> list[Result]:
-        paths_for_rule = self.get(rule_id, {})
-        return paths_for_rule.get(file.relative_to(context.directory), [])

--- a/src/core_codemods/sonar/results.py
+++ b/src/core_codemods/sonar/results.py
@@ -4,9 +4,8 @@ from functools import cache
 from pathlib import Path
 
 import libcst as cst
-from typing_extensions import Self, override
+from typing_extensions import Self
 
-from codemodder.context import CodemodExecutionContext
 from codemodder.logging import logger
 from codemodder.result import LineInfo, Location, Result, ResultSet
 
@@ -61,10 +60,3 @@ class SonarResultSet(ResultSet):
         except Exception:
             logger.debug("Could not parse sonar json %s", json_file)
         return cls()
-
-    @override
-    def results_for_rule_and_file(
-        self, context: CodemodExecutionContext, rule_id: str, file: Path
-    ) -> list[Result]:
-        paths_for_rule = self.get(rule_id, {})
-        return paths_for_rule.get(file.relative_to(context.directory), [])

--- a/tests/test_semgrep.py
+++ b/tests/test_semgrep.py
@@ -33,5 +33,8 @@ def test_semgrep_sarif_codemode_detector(mocker):
     }
     results = detector.apply(codemod_id="foo", context=context, files_to_analyze=[])
     assert isinstance(results, SemgrepResultSet)
-    assert len(results) == 24
-    assert "django-secure-set-cookie" in results
+    assert len(results) == 25
+    assert (
+        "python.django.security.audit.secure-cookies.django-secure-set-cookie"
+        in results
+    )


### PR DESCRIPTION
## Overview
*Change default path and rule ID normalization for Semgrep and `ResultSet`*

## Description

* Essentially this PR inverts the default behavior of path normalization for SAST results
* Now all SAST detectors compute paths relative to the given base directory _except_ for our internal Semgrep runs
* It turns out that the way we do it for internal Semgrep runs is a little weird, and most/all other SAST tools need to handle it the other way
* The same is true for the way that we handle Semgrep rule IDs: our internal usage is a special case