### PR TITLE
Enable per-codemod configuration of included files

### DIFF
--- a/src/codemodder/cli.py
+++ b/src/codemodder/cli.py
@@ -3,7 +3,7 @@ import json
 import sys
 
 from codemodder import __version__
-from codemodder.code_directory import DEFAULT_EXCLUDED_PATHS, DEFAULT_INCLUDED_PATHS
+from codemodder.code_directory import DEFAULT_EXCLUDED_PATHS
 from codemodder.logging import OutputFormat, logger
 from codemodder.registry import CodemodRegistry
 
@@ -149,7 +149,7 @@ def parse_args(argv, codemod_registry: CodemodRegistry):
     parser.add_argument(
         "--path-include",
         action=CsvListAction,
-        default=DEFAULT_INCLUDED_PATHS,
+        default=[],
         help="Comma-separated set of UNIX glob patterns to include",
     )
     parser.add_argument(

--- a/src/codemodder/codemodder.py
+++ b/src/codemodder/codemodder.py
@@ -186,13 +186,17 @@ def run(original_args) -> int:
         sast_only=argv.sonar_issues_json or argv.sarif,
     )
 
+    included_paths = argv.path_include or codemod_registry.default_include_paths
+
     log_section("setup")
     log_list(logging.INFO, "running", codemods_to_run, predicate=lambda c: c.id)
-    log_list(logging.INFO, "including paths", argv.path_include)
+    log_list(logging.INFO, "including paths", included_paths)
     log_list(logging.INFO, "excluding paths", argv.path_exclude)
 
     files_to_analyze: list[Path] = match_files(
-        context.directory, argv.path_exclude, argv.path_include
+        context.directory,
+        argv.path_exclude,
+        included_paths,
     )
 
     full_names = [str(path) for path in files_to_analyze]

--- a/src/codemodder/codemods/base_codemod.py
+++ b/src/codemodder/codemods/base_codemod.py
@@ -67,6 +67,7 @@ class BaseCodemod(metaclass=ABCMeta):
     _metadata: Metadata
     detector: BaseDetector | None
     transformer: BaseTransformerPipeline
+    default_extensions: list[str] | None
 
     def __init__(
         self,
@@ -74,11 +75,13 @@ class BaseCodemod(metaclass=ABCMeta):
         metadata: Metadata,
         detector: BaseDetector | None = None,
         transformer: BaseTransformerPipeline,
+        default_extensions: list[str] | None = None,
     ):
         # Metadata should only be accessed via properties
         self._metadata = metadata
         self.detector = detector
         self.transformer = transformer
+        self.default_extensions = default_extensions or [".py"]
 
     @property
     @abstractmethod
@@ -152,6 +155,16 @@ class BaseCodemod(metaclass=ABCMeta):
             self.detector.apply(self.name, context, files_to_analyze)
             if self.detector
             else None
+        )
+
+        files_to_analyze = (
+            [
+                path
+                for path in files_to_analyze
+                if path.suffix in self.default_extensions
+            ]
+            if self.default_extensions
+            else files_to_analyze
         )
 
         process_file = functools.partial(

--- a/src/core_codemods/api/core_codemod.py
+++ b/src/core_codemods/api/core_codemod.py
@@ -34,9 +34,15 @@ class SASTCodemod(CoreCodemod):
         metadata: Metadata,
         detector: BaseDetector | None = None,
         transformer: BaseTransformerPipeline,
+        default_extensions: list[str] | None = None,
         requested_rules: list[str] | None = None,
     ):
-        super().__init__(metadata=metadata, detector=detector, transformer=transformer)
+        super().__init__(
+            metadata=metadata,
+            detector=detector,
+            transformer=transformer,
+            default_extensions=default_extensions,
+        )
         self.requested_rules = [self.name]
         if requested_rules:
             self.requested_rules.extend(requested_rules)

--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -1,0 +1,20 @@
+from codemodder.registry import CodemodCollection, CodemodRegistry
+
+
+def test_default_extensions(mocker):
+    registry = CodemodRegistry()
+    assert registry.default_include_paths == []
+
+    CodemodA = mocker.MagicMock(default_extensions=[".py"])
+    CodemodB = mocker.MagicMock(default_extensions=[".py", ".txt"])
+
+    registry.add_codemod_collection(
+        CodemodCollection(origin="origin", codemods=[CodemodA, CodemodB])
+    )
+
+    assert sorted(registry.default_include_paths) == [
+        "**/*.py",
+        "**/*.txt",
+        "*.py",
+        "*.txt",
+    ]


### PR DESCRIPTION
## Overview
*Enable per-codemod configuration of included files based on extensions*

## Description

* Each codemod can now express the file extensions that it will include
* The aggregate of all of these extensions in the codemod registry is used to inform the default path includes
