### PR TITLE
prevent SubprocessShellFalse from causing FileNotFoundError when 1st arg is string

### DIFF
--- a/integration_tests/test_subprocess_shell_false.py
+++ b/integration_tests/test_subprocess_shell_false.py
@@ -6,11 +6,11 @@ class TestSubprocessShellFalse(BaseIntegrationTest):
     codemod = SubprocessShellFalse
     original_code = """
     import subprocess
-    subprocess.run("echo 'hi'", shell=True)
+    subprocess.run(['ls', '-l'], shell=True)
     """
-    replacement_lines = [(2, "subprocess.run(\"echo 'hi'\", shell=False)\n")]
+    replacement_lines = [(2, "subprocess.run(['ls', '-l'], shell=False)\n")]
 
-    expected_diff = "--- \n+++ \n@@ -1,2 +1,2 @@\n import subprocess\n-subprocess.run(\"echo 'hi'\", shell=True)\n+subprocess.run(\"echo 'hi'\", shell=False)\n"
+    expected_diff = "--- \n+++ \n@@ -1,2 +1,2 @@\n import subprocess\n-subprocess.run(['ls', '-l'], shell=True)\n+subprocess.run(['ls', '-l'], shell=False)\n"
     expected_line_change = "2"
     change_description = SubprocessShellFalse.change_description
     # expected because output code points to fake file

--- a/tests/codemods/test_subprocess_shell_false.py
+++ b/tests/codemods/test_subprocess_shell_false.py
@@ -20,11 +20,11 @@ class TestSubprocessShellFalse(BaseCodemodTest):
         import subprocess
         subprocess.{func}(args, shell=True)
         """
-        expexted_output = f"""
+        expected = f"""
         import subprocess
         subprocess.{func}(args, shell=False)
         """
-        self.run_and_assert(tmpdir, input_code, expexted_output)
+        self.run_and_assert(tmpdir, input_code, expected)
 
     @each_func
     def test_from_import(self, tmpdir, func):
@@ -32,11 +32,11 @@ class TestSubprocessShellFalse(BaseCodemodTest):
         from subprocess import {func}
         {func}(args, shell=True)
         """
-        expexted_output = f"""
+        expected = f"""
         from subprocess import {func}
         {func}(args, shell=False)
         """
-        self.run_and_assert(tmpdir, input_code, expexted_output)
+        self.run_and_assert(tmpdir, input_code, expected)
 
     @each_func
     def test_no_shell(self, tmpdir, func):
@@ -89,3 +89,19 @@ class TestSubprocessShellFalse(BaseCodemodTest):
         subprocess.run(args, shell=False) # noqa: S604
         """
         self.run_and_assert(tmpdir, input_code, expected)
+
+    def test_no_change_if_first_arg_is_string(self, tmpdir):
+        input_code = """
+        import subprocess
+        subprocess.run("ls -l", shell=True)
+        subprocess.run("ls" "-l", shell=True)
+        ls_args = "-l -a"
+        subprocess.run(f"ls {ls_args}", shell=True)
+        
+        subprocess.run('ls -l', shell=True)
+        subprocess.run('ls' '-l', shell=True)
+        ls_args = '-l -a'
+        subprocess.run(f'ls {ls_args}', shell=True)
+        """
+
+        self.run_and_assert(tmpdir, input_code, input_code, num_changes=0)


### PR DESCRIPTION
### `SubprocessShellFalse` 
- Problem: Current `SubprocessShellFalse` codemod will cause a `FileNotFoundError` when the first arg is a string.
- Example: Consider `subprocess.run('ls -l', shell=True)`. The codemod would break this code since with `shell=False` subprocess will try to find a non-existant file name 'ls -l'.
- Solution: Only run codeMod if the first arg is not a `m.SimpleString() | m.ConcatenatedString() | m.FormattedString()`. 

Note: This only catches m.SimpleString() | m.ConcatenatedString() | m.FormattedString(). If the first arg is a cst.Name() or cst.Call() which returns a string and the type cannot be derived then this issue could still occur.
