### PR TITLE
support >2 or's in CombineStartswithEndswith, args joined to tuple no duplicates

### DIFF
--- a/src/codemodder/codemods/utils.py
+++ b/src/codemodder/codemods/utils.py
@@ -228,11 +228,8 @@ def extract_boolean_operands(
     Recursively extract operands from a cst.BooleanOperation node from left to right as an iterator of nodes.
     """
     if isinstance(node.left, cst.BooleanOperation):
-        # Recursively yield operands from the boolean operation on the left
         yield from extract_boolean_operands(node.left, ensure_type)
     else:
-        # Yield left operand
         yield cst.ensure_type(node.left, ensure_type)
 
-    # Yield right operand
     yield cst.ensure_type(node.right, ensure_type)

--- a/src/core_codemods/combine_startswith_endswith.py
+++ b/src/core_codemods/combine_startswith_endswith.py
@@ -18,37 +18,14 @@ class CombineStartswithEndswith(SimpleCodemod, NameResolutionMixin):
     def leave_BooleanOperation(
         self, original_node: cst.BooleanOperation, updated_node: cst.BooleanOperation
     ) -> cst.CSTNode:
+        if not self.filter_by_path_includes_or_excludes(
+            self.node_position(original_node)
+        ):
+            return updated_node
+
         if self.matches_startswith_endswith_or_pattern(original_node):
-            if not self.filter_by_path_includes_or_excludes(
-                self.node_position(original_node)
-            ):
-                return updated_node
-
             self.report_change(original_node)
-
-            elements = []
-            seen_evaluated_values = set()
-            for call in extract_boolean_operands(updated_node, ensure_type=cst.Call):
-                arg_value = call.args[0].value
-                if isinstance(arg_value, cst.Tuple):
-                    arg_elements = arg_value.elements
-                else:
-                    arg_elements = (cst.Element(value=arg_value),)
-
-                for element in arg_elements:
-                    if (
-                        evaluated_value := getattr(
-                            element.value, "evaluated_value", None
-                        )
-                    ) in seen_evaluated_values:
-                        # If an element has a non-None evaluated value that has already been seen, continue to avoid duplicates
-                        continue
-                    if evaluated_value is not None:
-                        seen_evaluated_values.add(evaluated_value)
-                    elements.append(element)
-
-            new_arg = cst.Arg(value=cst.Tuple(elements=elements))
-            return cst.Call(func=call.func, args=[new_arg])
+            return self.make_new_call_from_boolean_operation(updated_node)
 
         return updated_node
 
@@ -98,5 +75,30 @@ class CombineStartswithEndswith(SimpleCodemod, NameResolutionMixin):
                 for call in extract_boolean_operands(node, ensure_type=cst.Call)
             )
 
-        # No match
         return False
+
+    def make_new_call_from_boolean_operation(
+        self, updated_node: cst.BooleanOperation
+    ) -> cst.Call:
+        elements = []
+        seen_evaluated_values = set()
+        for call in extract_boolean_operands(updated_node, ensure_type=cst.Call):
+            arg_value = call.args[0].value
+            arg_elements = (
+                arg_value.elements
+                if isinstance(arg_value, cst.Tuple)
+                else (cst.Element(value=arg_value),)
+            )
+
+            for element in arg_elements:
+                if (
+                    evaluated_value := getattr(element.value, "evaluated_value", None)
+                ) in seen_evaluated_values:
+                    # If an element has a non-None evaluated value that has already been seen, continue to avoid duplicates
+                    continue
+                if evaluated_value is not None:
+                    seen_evaluated_values.add(evaluated_value)
+                elements.append(element)
+
+        new_arg = cst.Arg(value=cst.Tuple(elements=elements))
+        return cst.Call(func=call.func, args=[new_arg])

--- a/src/core_codemods/combine_startswith_endswith.py
+++ b/src/core_codemods/combine_startswith_endswith.py
@@ -1,6 +1,7 @@
 import libcst as cst
 from libcst import matchers as m
 
+from codemodder.codemods.utils import extract_boolean_operands
 from codemodder.codemods.utils_mixin import NameResolutionMixin
 from core_codemods.api import Metadata, ReviewGuidance, SimpleCodemod
 
@@ -17,36 +18,54 @@ class CombineStartswithEndswith(SimpleCodemod, NameResolutionMixin):
     def leave_BooleanOperation(
         self, original_node: cst.BooleanOperation, updated_node: cst.BooleanOperation
     ) -> cst.CSTNode:
-        if not self.filter_by_path_includes_or_excludes(
-            self.node_position(original_node)
-        ):
-            return updated_node
-
         if self.matches_startswith_endswith_or_pattern(original_node):
-            left_call = cst.ensure_type(updated_node.left, cst.Call)
-            right_call = cst.ensure_type(updated_node.right, cst.Call)
+            if not self.filter_by_path_includes_or_excludes(
+                self.node_position(original_node)
+            ):
+                return updated_node
 
             self.report_change(original_node)
 
-            new_arg = cst.Arg(
-                value=cst.Tuple(
-                    elements=[
-                        cst.Element(value=left_call.args[0].value),
-                        cst.Element(value=right_call.args[0].value),
-                    ]
-                )
-            )
+            elements = []
+            seen_evaluated_values = set()
+            for call in extract_boolean_operands(updated_node, ensure_type=cst.Call):
+                arg_value = call.args[0].value
+                if isinstance(arg_value, cst.Tuple):
+                    arg_elements = arg_value.elements
+                else:
+                    arg_elements = (cst.Element(value=arg_value),)
 
-            return cst.Call(func=left_call.func, args=[new_arg])
+                for element in arg_elements:
+                    if (
+                        evaluated_value := getattr(
+                            element.value, "evaluated_value", None
+                        )
+                    ) in seen_evaluated_values:
+                        # If an element has a non-None evaluated value that has already been seen, continue to avoid duplicates
+                        continue
+                    if evaluated_value is not None:
+                        seen_evaluated_values.add(evaluated_value)
+                    elements.append(element)
+
+            new_arg = cst.Arg(value=cst.Tuple(elements=elements))
+            return cst.Call(func=call.func, args=[new_arg])
 
         return updated_node
 
     def matches_startswith_endswith_or_pattern(
         self, node: cst.BooleanOperation
     ) -> bool:
-        # Match the pattern: x.startswith("...") or x.startswith("...")
+        # Match the pattern: x.startswith("...") or x.startswith("...") or x.startswith("...") or ...
         # and the same but with endswith
-        args = [m.Arg(value=m.SimpleString())]
+        args = [
+            m.Arg(
+                value=m.Tuple()
+                | m.SimpleString()
+                | m.ConcatenatedString()
+                | m.FormattedString()
+                | m.Name()
+            )
+        ]
         startswith = m.Call(
             func=m.Attribute(value=m.Name(), attr=m.Name("startswith")),
             args=args,
@@ -60,7 +79,24 @@ class CombineStartswithEndswith(SimpleCodemod, NameResolutionMixin):
         )
         endswith_or = m.BooleanOperation(left=endswith, operator=m.Or(), right=endswith)
 
-        return (
+        # Check for simple case: x.startswith("...") or x.startswith("...")
+        if (
             m.matches(node, startswith_or | endswith_or)
             and node.left.func.value.value == node.right.func.value.value
+        ):
+            return True
+
+        # Check for chained case: x.startswith("...") or x.startswith("...") or x.startswith("...") or ...
+        chained_or = m.BooleanOperation(
+            left=m.BooleanOperation(operator=m.Or()),
+            operator=m.Or(),
+            right=startswith | endswith,
         )
+        if m.matches(node, chained_or):
+            return all(
+                call.func.value.value == node.right.func.value.value  # Same function
+                for call in extract_boolean_operands(node, ensure_type=cst.Call)
+            )
+
+        # No match
+        return False

--- a/src/core_codemods/combine_startswith_endswith.py
+++ b/src/core_codemods/combine_startswith_endswith.py
@@ -64,12 +64,14 @@ class CombineStartswithEndswith(SimpleCodemod, NameResolutionMixin):
             return True
 
         # Check for chained case: x.startswith("...") or x.startswith("...") or x.startswith("...") or ...
-        chained_or = m.BooleanOperation(
-            left=m.BooleanOperation(operator=m.Or()),
-            operator=m.Or(),
-            right=startswith | endswith,
-        )
-        if m.matches(node, chained_or):
+        if m.matches(
+            node,
+            m.BooleanOperation(
+                left=m.BooleanOperation(operator=m.Or()),
+                operator=m.Or(),
+                right=startswith | endswith,
+            ),
+        ):
             return all(
                 call.func.value.value == node.right.func.value.value  # Same function
                 for call in extract_boolean_operands(node, ensure_type=cst.Call)

--- a/tests/codemods/test_combine_startswith_endswith.py
+++ b/tests/codemods/test_combine_startswith_endswith.py
@@ -163,8 +163,8 @@ class TestCombineStartswithEndswith(BaseCodemodTest):
     def test_name_args(self, tmpdir, func, input_code, expected):
         self._format_func_run_test(tmpdir, func, input_code, expected)
 
-    _100_of_each_type = [
-        (f"'{i}'", f"'{i}con' 'cat{i}'", f"f'fmt{i}'", f"name{i}") for i in range(100)
+    _10_of_each_type = [
+        (f"'{i}'", f"'{i}con' 'cat{i}'", f"f'fmt{i}'", f"name{i}") for i in range(10)
     ]
 
     @each_func
@@ -186,33 +186,33 @@ class TestCombineStartswithEndswith(BaseCodemodTest):
                 "x.{func}('a') or x.{func}(('b', 'c')) or x.{func}('d') or x.{func}(('e', 'f', 'g', 'h'))",
                 "x.{func}(('a', 'b', 'c', 'd', 'e', 'f', 'g', 'h'))",
             ),
-            # 100 cst.SimpleStrings
+            # 10 cst.SimpleStrings
             (
-                " or ".join("x.{func}" + f"({item[0]})" for item in _100_of_each_type),
-                "x.{func}" + f"(({', '.join(item[0] for item in _100_of_each_type)}))",
+                " or ".join("x.{func}" + f"({item[0]})" for item in _10_of_each_type),
+                "x.{func}" + f"(({', '.join(item[0] for item in _10_of_each_type)}))",
             ),
-            # 100 cst.ConcatenatedStrings
+            # 10 cst.ConcatenatedStrings
             (
-                " or ".join("x.{func}" + f"({item[1]})" for item in _100_of_each_type),
-                "x.{func}" + f"(({', '.join(item[1] for item in _100_of_each_type)}))",
+                " or ".join("x.{func}" + f"({item[1]})" for item in _10_of_each_type),
+                "x.{func}" + f"(({', '.join(item[1] for item in _10_of_each_type)}))",
             ),
-            # 100 cst.FormattedStrings
+            # 10 cst.FormattedStrings
             (
-                " or ".join("x.{func}" + f"({item[2]})" for item in _100_of_each_type),
-                "x.{func}" + f"(({', '.join(item[2] for item in _100_of_each_type)}))",
+                " or ".join("x.{func}" + f"({item[2]})" for item in _10_of_each_type),
+                "x.{func}" + f"(({', '.join(item[2] for item in _10_of_each_type)}))",
             ),
-            # 100 cst.Names
+            # 10 cst.Names
             (
-                " or ".join("x.{func}" + f"({item[3]})" for item in _100_of_each_type),
-                "x.{func}" + f"(({', '.join(item[3] for item in _100_of_each_type)}))",
+                " or ".join("x.{func}" + f"({item[3]})" for item in _10_of_each_type),
+                "x.{func}" + f"(({', '.join(item[3] for item in _10_of_each_type)}))",
             ),
-            # 100 cst.Tuples with all types
+            # 10 cst.Tuples with all types
             (
                 " or ".join(
-                    "x.{func}" + f"(({', '.join(item)}))" for item in _100_of_each_type
+                    "x.{func}" + f"(({', '.join(item)}))" for item in _10_of_each_type
                 ),
                 "x.{func}"
-                + f"(({', '.join(', '.join(item) for item in _100_of_each_type)}))",
+                + f"(({', '.join(', '.join(item) for item in _10_of_each_type)}))",
             ),
         ],
     )

--- a/tests/codemods/test_combine_startswith_endswith.py
+++ b/tests/codemods/test_combine_startswith_endswith.py
@@ -33,6 +33,7 @@ class TestCombineStartswithEndswith(BaseCodemodTest):
             "x.startswith('foo') and x.startswith('f') or True",
             "x.startswith('foo') or x.endswith('f')",
             "x.startswith('foo') or y.startswith('f')",
+            "x.startswith('foo') or y.startswith('f') or x.startswith('f')",
         ],
     )
     def test_no_change(self, tmpdir, code):
@@ -51,4 +52,171 @@ class TestCombineStartswithEndswith(BaseCodemodTest):
             input_code,
             expected,
             lines_to_exclude=lines_to_exclude,
+        )
+
+    def _format_func_run_test(self, tmpdir, func, input_code, expected, num_changes=1):
+        self.run_and_assert(
+            tmpdir,
+            input_code.replace("{func}", func),
+            expected.replace("{func}", func),
+            num_changes,
+        )
+
+    @each_func
+    @pytest.mark.parametrize(
+        "input_code, expected",
+        [
+            # Tuple on the left
+            (
+                "x.{func}(('f', 'foo')) or x.{func}('bar')",
+                "x.{func}(('f', 'foo', 'bar'))",
+            ),
+            # Tuple on the right
+            (
+                "x.{func}('f') or x.{func}(('foo', 'bar'))",
+                "x.{func}(('f', 'foo', 'bar'))",
+            ),
+            # Tuple on both sides
+            (
+                "x.{func}(('1', '2')) or x.{func}(('3', '4'))",
+                "x.{func}(('1', '2', '3', '4'))",
+            ),
+            # Tuples on both sides with duplicate elements
+            (
+                "x.{func}(('1', '2', '3')) or x.{func}(('2', '3', '4'))",
+                "x.{func}(('1', '2', '3', '4'))",
+            ),
+        ],
+    )
+    def test_combine_tuples(self, tmpdir, func, input_code, expected):
+        self._format_func_run_test(tmpdir, func, input_code, expected)
+
+    @each_func
+    @pytest.mark.parametrize(
+        "input_code, expected",
+        [
+            # cst.ConcatenatedString on the left
+            (
+                "x.{func}('foo' 'bar') or x.{func}('baz')",
+                "x.{func}(('foo' 'bar', 'baz'))",
+            ),
+            # cst.ConcatenatedString on the right
+            (
+                "x.{func}('foo') or x.{func}('bar' 'baz')",
+                "x.{func}(('foo', 'bar' 'baz'))",
+            ),
+            # cst.ConcatenatedString on both sides
+            (
+                "x.{func}('foo' 'bar') or x.{func}('baz' 'qux')",
+                "x.{func}(('foo' 'bar', 'baz' 'qux'))",
+            ),
+        ],
+    )
+    def test_concat_string_args(self, tmpdir, func, input_code, expected):
+        self._format_func_run_test(tmpdir, func, input_code, expected)
+
+    @each_func
+    @pytest.mark.parametrize(
+        "input_code, expected",
+        [
+            # cst.FormattedString on the left
+            (
+                "x.{func}(f'formatted {foo}') or x.{func}('bar')",
+                "x.{func}((f'formatted {foo}', 'bar'))",
+            ),
+            # cst.FormattedString on the right
+            (
+                "x.{func}('foo') or x.{func}(f'formatted {bar}')",
+                "x.{func}(('foo', f'formatted {bar}'))",
+            ),
+            # cst.FormattedString on both sides
+            (
+                "x.{func}(f'formatted {foo}') or x.{func}(f'formatted {bar}')",
+                "x.{func}((f'formatted {foo}', f'formatted {bar}'))",
+            ),
+        ],
+    )
+    def test_format_string_args(self, tmpdir, func, input_code, expected):
+        self._format_func_run_test(tmpdir, func, input_code, expected)
+
+    @each_func
+    @pytest.mark.parametrize(
+        "input_code, expected",
+        [
+            # cst.Name on the left
+            ("x.{func}(y) or x.{func}('foo')", "x.{func}((y, 'foo'))"),
+            # cst.Name on the right
+            ("x.{func}('foo') or x.{func}(y)", "x.{func}(('foo', y))"),
+            # cst.Name on both sides
+            ("x.{func}(y) or x.{func}(z)", "x.{func}((y, z))"),
+            # cst.Name in tuple on the left
+            ("x.{func}((y, 'foo')) or x.{func}('bar')", "x.{func}((y, 'foo', 'bar'))"),
+            # cst.Name in tuple on the right
+            ("x.{func}('foo') or x.{func}((y, 'bar'))", "x.{func}(('foo', y, 'bar'))"),
+            # cst.Name in tuple on both sides
+            (
+                "x.{func}((y, 'foo')) or x.{func}((z, 'bar'))",
+                "x.{func}((y, 'foo', z, 'bar'))",
+            ),
+        ],
+    )
+    def test_name_args(self, tmpdir, func, input_code, expected):
+        self._format_func_run_test(tmpdir, func, input_code, expected)
+
+    _100_of_each_type = [
+        (f"'{i}'", f"'{i}con' 'cat{i}'", f"f'fmt{i}'", f"name{i}") for i in range(100)
+    ]
+
+    @each_func
+    @pytest.mark.parametrize(
+        "input_code, expected",
+        [
+            # 3 cst.SimpleStrings
+            (
+                "x.{func}('foo') or x.{func}('bar') or x.{func}('baz')",
+                "x.{func}(('foo', 'bar', 'baz'))",
+            ),
+            # 3 cst.SimpleStrings with duplicates
+            (
+                "x.{func}('foo') or x.{func}('bar') or x.{func}('foo')",
+                "x.{func}(('foo', 'bar'))",
+            ),
+            # 2 cst.SimpleStrings 2 cst.Tuple alternating
+            (
+                "x.{func}('a') or x.{func}(('b', 'c')) or x.{func}('d') or x.{func}(('e', 'f', 'g', 'h'))",
+                "x.{func}(('a', 'b', 'c', 'd', 'e', 'f', 'g', 'h'))",
+            ),
+            # 100 cst.SimpleStrings
+            (
+                " or ".join("x.{func}" + f"({item[0]})" for item in _100_of_each_type),
+                "x.{func}" + f"(({', '.join(item[0] for item in _100_of_each_type)}))",
+            ),
+            # 100 cst.ConcatenatedStrings
+            (
+                " or ".join("x.{func}" + f"({item[1]})" for item in _100_of_each_type),
+                "x.{func}" + f"(({', '.join(item[1] for item in _100_of_each_type)}))",
+            ),
+            # 100 cst.FormattedStrings
+            (
+                " or ".join("x.{func}" + f"({item[2]})" for item in _100_of_each_type),
+                "x.{func}" + f"(({', '.join(item[2] for item in _100_of_each_type)}))",
+            ),
+            # 100 cst.Names
+            (
+                " or ".join("x.{func}" + f"({item[3]})" for item in _100_of_each_type),
+                "x.{func}" + f"(({', '.join(item[3] for item in _100_of_each_type)}))",
+            ),
+            # 100 cst.Tuples with all types
+            (
+                " or ".join(
+                    "x.{func}" + f"(({', '.join(item)}))" for item in _100_of_each_type
+                ),
+                "x.{func}"
+                + f"(({', '.join(', '.join(item) for item in _100_of_each_type)}))",
+            ),
+        ],
+    )
+    def test_more_than_two_calls(self, tmpdir, func, input_code, expected):
+        self._format_func_run_test(
+            tmpdir, func, input_code, expected, num_changes=input_code.count(" or ")
         )


### PR DESCRIPTION
### `CombineStartswithEndswith`
- Problem: Current `CombineStartswithEndswith` only supports `m.SimpleString()` and does not support chaining more than 2 `startswith` or `endswith` calls.
- Solution: 
    - Allow arg to be of type `m.Tuple()| m.SimpleString() | m.ConcatenatedString() | m.FormattedString() | m.Name()`
    - Join all the `startswith` and `endswith` calls into a single call and remove duplicate args with the same `evaluated_value`
```python
# Input
s.startswith('a') or s.startswith('b') or s.startswith('c')
s.startswith(f'{a}') or s.startswith(('con' 'cat', someVar)) or s.startswith('simple')
# CodeMod result before changes
s.startswith(('a', 'b')) or s.startswith('c')
s.startswith(f'{a}') or s.startswith(('con' 'cat', someVar)) or s.startswith('simple')    
# After 
s.startswith(('a', 'b', 'c'))
s.startswith((f'{a}', 'con' 'cat', someVar, 'simple'))
```

Closes #309