### PR TITLE
Add new CodeMod CombineIsinstanceIssubclass. isistance(x, str) or isnstance(x, (bytes, list)) -> isinstance(x, (str, bytes, list))

### DIFF
--- a/integration_tests/test_combine_isinstance_issubclass.py
+++ b/integration_tests/test_combine_isinstance_issubclass.py
@@ -1,0 +1,16 @@
+from codemodder.codemods.test import BaseIntegrationTest
+from core_codemods.combine_isinstance_issubclass import CombineIsinstanceIssubclass
+
+
+class TestCombineStartswithEndswith(BaseIntegrationTest):
+    codemod = CombineIsinstanceIssubclass
+    original_code = """
+    x = 'foo'
+    if isinstance(x, str) or isinstance(x, bytes):
+        print("Yes")
+    """
+    replacement_lines = [(2, "if isinstance(x, (str, bytes)):\n")]
+
+    expected_diff = "--- \n+++ \n@@ -1,3 +1,3 @@\n x = 'foo'\n-if isinstance(x, str) or isinstance(x, bytes):\n+if isinstance(x, (str, bytes)):\n     print(\"Yes\")\n"
+    expected_line_change = "2"
+    change_description = CombineIsinstanceIssubclass.change_description

--- a/src/codemodder/codemods/utils.py
+++ b/src/codemodder/codemods/utils.py
@@ -228,11 +228,8 @@ def extract_boolean_operands(
     Recursively extract operands from a cst.BooleanOperation node from left to right as an iterator of nodes.
     """
     if isinstance(node.left, cst.BooleanOperation):
-        # Recursively yield operands from the boolean operation on the left
         yield from extract_boolean_operands(node.left, ensure_type)
     else:
-        # Yield left operand
         yield cst.ensure_type(node.left, ensure_type)
 
-    # Yield right operand
     yield cst.ensure_type(node.right, ensure_type)

--- a/src/codemodder/codemods/utils.py
+++ b/src/codemodder/codemods/utils.py
@@ -1,6 +1,6 @@
 from enum import Enum
 from pathlib import Path
-from typing import Any, Iterator, Optional, Type, TypeAlias, TypeVar
+from typing import Any, Optional, TypeAlias
 
 import libcst as cst
 from libcst import MetadataDependent, matchers
@@ -216,20 +216,3 @@ def is_zero(node: cst.CSTNode) -> bool:
         case cst.Call(func=cst.Name("int")) | cst.Call(func=cst.Name("float")):
             return is_zero(node.args[0].value)
     return False
-
-
-_CSTNode = TypeVar("_CSTNode", bound=cst.CSTNode)
-
-
-def extract_boolean_operands(
-    node: cst.BooleanOperation, ensure_type: Type[_CSTNode] = cst.CSTNode
-) -> Iterator[_CSTNode]:
-    """
-    Recursively extract operands from a cst.BooleanOperation node from left to right as an iterator of nodes.
-    """
-    if isinstance(node.left, cst.BooleanOperation):
-        yield from extract_boolean_operands(node.left, ensure_type)
-    else:
-        yield cst.ensure_type(node.left, ensure_type)
-
-    yield cst.ensure_type(node.right, ensure_type)

--- a/src/codemodder/scripts/generate_docs.py
+++ b/src/codemodder/scripts/generate_docs.py
@@ -199,6 +199,10 @@ If you want to allow those protocols, change the incoming PR to look more like t
         importance="Low",
         guidance_explained="Simplifying expressions involving `startswith` or `endswith` calls is safe.",
     ),
+    "combine-isinstance-issubclass": DocMetadata(
+        importance="Low",
+        guidance_explained="Simplifying expressions involving `isinstance` or `issubclass` calls is safe.",
+    ),
     "fix-deprecated-logging-warn": DocMetadata(
         importance="Low",
         guidance_explained="This change fixes deprecated uses and is safe.",

--- a/src/core_codemods/__init__.py
+++ b/src/core_codemods/__init__.py
@@ -2,6 +2,7 @@ from codemodder.registry import CodemodCollection
 
 from .add_requests_timeouts import AddRequestsTimeouts
 from .break_or_continue_out_of_loop import BreakOrContinueOutOfLoop
+from .combine_isinstance_issubclass import CombineIsinstanceIssubclass
 from .combine_startswith_endswith import CombineStartswithEndswith
 from .defectdojo.semgrep.avoid_insecure_deserialization import (
     AvoidInsecureDeserialization,
@@ -135,6 +136,7 @@ registry = CodemodCollection(
         RemoveModuleGlobal,
         RemoveDebugBreakpoint,
         CombineStartswithEndswith,
+        CombineIsinstanceIssubclass,
         FixDeprecatedLoggingWarn,
         FlaskEnableCSRFProtection,
         ReplaceFlaskSendFile,

--- a/src/core_codemods/combine_calls_base.py
+++ b/src/core_codemods/combine_calls_base.py
@@ -1,0 +1,139 @@
+import libcst as cst
+from libcst import matchers as m
+
+from codemodder.codemods.utils_mixin import NameResolutionMixin
+from core_codemods.api import SimpleCodemod
+
+
+class CombineCallsBaseCodemod(SimpleCodemod, NameResolutionMixin):
+    combinable_funcs: list[str] = []
+    dedupilcation_attr: str = "value"
+    args_to_combine: list[int] = [0]
+    args_to_keep_as_is: list[int] = []
+
+    def leave_BooleanOperation(
+        self, original_node: cst.BooleanOperation, updated_node: cst.BooleanOperation
+    ) -> cst.CSTNode:
+        if not self.filter_by_path_includes_or_excludes(
+            self.node_position(original_node)
+        ):
+            return updated_node
+
+        for call_matcher in map(self.make_call_matcher, self.combinable_funcs):
+            if self.matches_call_or_call(updated_node, call_matcher):
+                self.report_change(original_node)
+                return self.combine_calls(updated_node.left, updated_node.right)
+
+            if self.matches_call_or_boolop(updated_node, call_matcher):
+                self.report_change(original_node)
+                return self.combine_call_or_boolop_fold_right(updated_node)
+
+            if self.matches_boolop_or_call(updated_node, call_matcher):
+                self.report_change(original_node)
+                return self.combine_boolop_or_call_fold_left(updated_node)
+
+        return updated_node
+
+    def make_call_matcher(self, func_name: str) -> m.Call:
+        raise NotImplementedError("Subclasses must implement this method")
+
+    def check_calls_same_instance(
+        self, left_call: cst.Call, right_call: cst.Call
+    ) -> bool:
+        raise NotImplementedError("Subclasses must implement this method")
+
+    def matches_call_or_call(
+        self, node: cst.BooleanOperation, call_matcher: m.Call
+    ) -> bool:
+        # Check for simple case: x.startswith("...") or x.startswith("...")
+        call_or_call = m.BooleanOperation(
+            left=call_matcher, operator=m.Or(), right=call_matcher
+        )
+        # True if the node matches the pattern and the calls are the same instance
+        return m.matches(node, call_or_call) and self.check_calls_same_instance(
+            node.left, node.right
+        )
+
+    def matches_call_or_boolop(
+        self, node: cst.BooleanOperation, call_matcher: m.Call
+    ) -> bool:
+
+        # Check for case when call on left and call on left of right boolop can be combined like:
+        # x.startswith("...") or x.startswith("...") and/or <any>
+        call_or_boolop = m.BooleanOperation(
+            left=call_matcher,
+            operator=m.Or(),
+            right=m.BooleanOperation(left=call_matcher),
+        )
+        # True if the node matches the pattern and the calls are the same instance
+        return m.matches(node, call_or_boolop) and self.check_calls_same_instance(
+            node.left, node.right.left
+        )
+
+    def matches_boolop_or_call(
+        self, node: cst.BooleanOperation, call_matcher: m.Call
+    ) -> bool:
+
+        # Check for case when call on right and call on right of left boolop can be combined like:
+        # <any> and/or x.startswith("...") or x.startswith("...")
+        boolop_or_call = m.BooleanOperation(
+            left=m.BooleanOperation(right=call_matcher),
+            operator=m.Or(),
+            right=call_matcher,
+        )
+        # True if the node matches the pattern and the calls are the same instance
+        return m.matches(node, boolop_or_call) and self.check_calls_same_instance(
+            node.left.right, node.right
+        )
+
+    def combine_calls(self, *calls: cst.Call) -> cst.Call:
+        first_call = calls[0]
+        new_args = []
+        for arg_index in sorted(self.args_to_keep_as_is + self.args_to_combine):
+            if arg_index in self.args_to_combine:
+                new_args.append(self.combine_args(*calls, arg_index=arg_index))
+            else:
+                new_args.append(first_call.args[arg_index])
+
+        return cst.Call(func=first_call.func, args=new_args)
+
+    def combine_args(self, *calls: cst.Call, arg_index: int) -> cst.Arg:
+        elements = []
+        seen_values = set()
+        for call in calls:
+            arg_value = call.args[arg_index].value
+            arg_elements = (
+                arg_value.elements
+                if isinstance(arg_value, cst.Tuple)
+                else (cst.Element(value=arg_value),)
+            )
+
+            for element in arg_elements:
+                if (
+                    value := getattr(element.value, self.dedupilcation_attr, None)
+                ) in seen_values:
+                    # If an element has a non-None value that has already been seen, continue to avoid duplicates
+                    continue
+                if value is not None:
+                    seen_values.add(value)
+                elements.append(element)
+
+        return cst.Arg(value=cst.Tuple(elements=elements))
+
+    def combine_call_or_boolop_fold_right(
+        self, node: cst.BooleanOperation
+    ) -> cst.BooleanOperation:
+        new_left = self.combine_calls(node.left, node.right.left)
+        new_right = node.right.right
+        return cst.BooleanOperation(
+            left=new_left, operator=node.right.operator, right=new_right
+        )
+
+    def combine_boolop_or_call_fold_left(
+        self, node: cst.BooleanOperation
+    ) -> cst.BooleanOperation:
+        new_left = node.left.left
+        new_right = self.combine_calls(node.left.right, node.right)
+        return cst.BooleanOperation(
+            left=new_left, operator=node.left.operator, right=new_right
+        )

--- a/src/core_codemods/combine_calls_base.py
+++ b/src/core_codemods/combine_calls_base.py
@@ -45,7 +45,6 @@ class CombineCallsBaseCodemod(SimpleCodemod, NameResolutionMixin):
     def matches_call_or_call(
         self, node: cst.BooleanOperation, call_matcher: m.Call
     ) -> bool:
-        # Check for simple case: x.startswith("...") or x.startswith("...")
         call_or_call = m.BooleanOperation(
             left=call_matcher, operator=m.Or(), right=call_matcher
         )
@@ -57,9 +56,6 @@ class CombineCallsBaseCodemod(SimpleCodemod, NameResolutionMixin):
     def matches_call_or_boolop(
         self, node: cst.BooleanOperation, call_matcher: m.Call
     ) -> bool:
-
-        # Check for case when call on left and call on left of right boolop can be combined like:
-        # x.startswith("...") or x.startswith("...") and/or <any>
         call_or_boolop = m.BooleanOperation(
             left=call_matcher,
             operator=m.Or(),
@@ -73,9 +69,6 @@ class CombineCallsBaseCodemod(SimpleCodemod, NameResolutionMixin):
     def matches_boolop_or_call(
         self, node: cst.BooleanOperation, call_matcher: m.Call
     ) -> bool:
-
-        # Check for case when call on right and call on right of left boolop can be combined like:
-        # <any> and/or x.startswith("...") or x.startswith("...")
         boolop_or_call = m.BooleanOperation(
             left=m.BooleanOperation(right=call_matcher),
             operator=m.Or(),

--- a/src/core_codemods/combine_isinstance_issubclass.py
+++ b/src/core_codemods/combine_isinstance_issubclass.py
@@ -1,0 +1,99 @@
+import libcst as cst
+from libcst import matchers as m
+
+from codemodder.codemods.utils import extract_boolean_operands
+from codemodder.codemods.utils_mixin import NameResolutionMixin
+from core_codemods.api import Metadata, ReviewGuidance, SimpleCodemod
+
+
+class CombineIsinstanceIssubclass(SimpleCodemod, NameResolutionMixin):
+    metadata = Metadata(
+        name="combine-isinstance-issubclass",
+        summary="Simplify Boolean Expressions Using `isinstance` and `issubclass`",
+        review_guidance=ReviewGuidance.MERGE_WITHOUT_REVIEW,
+        references=[],
+    )
+    change_description = "Use tuple of matches instead of boolean expression with `isinstance` or `issubclass`"
+
+    def leave_BooleanOperation(
+        self, original_node: cst.BooleanOperation, updated_node: cst.BooleanOperation
+    ) -> cst.CSTNode:
+        if self.matches_isinstance_issubclass_or_pattern(original_node):
+            if not self.filter_by_path_includes_or_excludes(
+                self.node_position(original_node)
+            ):
+                return updated_node
+
+            self.report_change(original_node)
+
+            elements = []
+            seen_values = set()
+            for call in extract_boolean_operands(updated_node, ensure_type=cst.Call):
+                class_tuple_arg_value = call.args[1].value
+                if isinstance(class_tuple_arg_value, cst.Tuple):
+                    arg_elements = class_tuple_arg_value.elements
+                else:
+                    arg_elements = (cst.Element(value=class_tuple_arg_value),)
+
+                for element in arg_elements:
+                    if (value := getattr(element.value, "value", None)) in seen_values:
+                        # If an element has a non-None evaluated value that has already been seen, continue to avoid duplicates
+                        continue
+                    if value is not None:
+                        seen_values.add(value)
+                    elements.append(element)
+
+            instance_arg = updated_node.left.args[0]
+            new_class_tuple_arg = cst.Arg(value=cst.Tuple(elements=elements))
+            return cst.Call(func=call.func, args=[instance_arg, new_class_tuple_arg])
+
+        return updated_node
+
+    def matches_isinstance_issubclass_or_pattern(
+        self, node: cst.BooleanOperation
+    ) -> bool:
+        # Match the pattern: isinstance(x, cls1) or isinstance(x, cls2) or isinstance(x, cls3) or ...
+        # and the same but with issubclass
+        args = [m.Arg(value=m.Name()), m.Arg(value=m.Name() | m.Tuple())]
+        isinstance_call = m.Call(
+            func=m.Name("isinstance"),
+            args=args,
+        )
+        issubclass_call = m.Call(
+            func=m.Name("issubclass"),
+            args=args,
+        )
+        isinstance_or = m.BooleanOperation(
+            left=isinstance_call, operator=m.Or(), right=isinstance_call
+        )
+        issubclass_or = m.BooleanOperation(
+            left=issubclass_call, operator=m.Or(), right=issubclass_call
+        )
+
+        # Check for simple case: isinstance(x, cls) or issubclass(x, cls)
+        if (
+            m.matches(node, isinstance_or | issubclass_or)
+            and node.left.func.value == node.right.func.value  # Same function
+            and node.left.args[0].value.value
+            == node.right.args[0].value.value  # Same first argument (instance)
+        ):
+            return True
+
+        # Check for chained case: isinstance(x, cls1) or isinstance(x, cls2) or isinstance(x, cls3) or ...
+        chained_or = m.BooleanOperation(
+            left=m.BooleanOperation(operator=m.Or()),
+            operator=m.Or(),
+            right=isinstance_call | issubclass_call,
+        )
+        if m.matches(node, chained_or):
+            return all(
+                (
+                    call.func.value == node.right.func.value  # Same function
+                    and call.args[0].value.value
+                    == node.right.args[0].value.value  # Same first argument (instance)
+                )
+                for call in extract_boolean_operands(node, ensure_type=cst.Call)
+            )
+
+        # No match
+        return False

--- a/src/core_codemods/docs/pixee_python_combine-isinstance-issubclass.md
+++ b/src/core_codemods/docs/pixee_python_combine-isinstance-issubclass.md
@@ -1,0 +1,12 @@
+Many developers are not necessarily aware that the `isinstance` and `issubclass` builtin methods can accept a tuple of classes to match. This means that there is a lot of code that uses boolean expressions such as `isinstance(x, str) or isinstance(x, bytes)` instead of the simpler expression `isinstance(x, (str, bytes))`.
+
+This codemod simplifies the boolean expressions where possible which leads to cleaner and more concise code.
+
+The changes from this codemod look like this:
+
+```diff
+  x = 'foo'
+- if isinstance(x, str) or isinstance(x, bytes):
++ if isinstance(x, (str, bytes)):
+     ...
+```

--- a/tests/codemods/test_combine_isinstance_issubclass.py
+++ b/tests/codemods/test_combine_isinstance_issubclass.py
@@ -1,0 +1,135 @@
+import pytest
+
+from codemodder.codemods.test import BaseCodemodTest
+from core_codemods.combine_isinstance_issubclass import CombineIsinstanceIssubclass
+
+each_func = pytest.mark.parametrize("func", ["isinstance", "issubclass"])
+
+
+class TestCombineIsinstanceIssubclass(BaseCodemodTest):
+    codemod = CombineIsinstanceIssubclass
+
+    def test_name(self):
+        assert self.codemod.name == "combine-isinstance-issubclass"
+
+    @each_func
+    def test_combine(self, tmpdir, func):
+        input_code = f"""
+        {func}(x, str) or {func}(x, bytes)
+        """
+        expected = f"""
+        {func}(x, (str, bytes))
+        """
+        self.run_and_assert(tmpdir, input_code, expected)
+
+    @pytest.mark.parametrize(
+        "code",
+        [
+            "isinstance(x, str)",
+            "isinstance(x, (str, bytes))",
+            "isinstance(x, str) and isinstance(x, bytes)",
+            "isinstance(x, str) and isinstance(x, str) or True",
+            "isinstance(x, str) or issubclass(x, str)",
+            "isinstance(x, str) or isinstance(y, str)",
+        ],
+    )
+    def test_no_change(self, tmpdir, code):
+        self.run_and_assert(tmpdir, code, code)
+
+    def test_exclude_line(self, tmpdir):
+        input_code = (
+            expected
+        ) = """
+        x = "foo"
+        isinstance(x, str) or isinstance(x, bytes)
+        """
+        lines_to_exclude = [3]
+        self.run_and_assert(
+            tmpdir,
+            input_code,
+            expected,
+            lines_to_exclude=lines_to_exclude,
+        )
+
+    def _format_func_run_test(self, tmpdir, func, input_code, expected, num_changes=1):
+        self.run_and_assert(
+            tmpdir,
+            input_code.replace("{func}", func),
+            expected.replace("{func}", func),
+            num_changes,
+        )
+
+    @each_func
+    @pytest.mark.parametrize(
+        "input_code, expected",
+        [
+            # Tuple on the left
+            (
+                "{func}(x, (str, bytes)) or {func}(x, bytearray)",
+                "{func}(x, (str, bytes, bytearray))",
+            ),
+            # Tuple on the right
+            (
+                "{func}(x, str) or {func}(x, (bytes, bytearray))",
+                "{func}(x, (str, bytes, bytearray))",
+            ),
+            # Tuple on both sides no duplicates
+            (
+                "{func}(x, (str, bytes)) or {func}(x, (bytearray, memoryview))",
+                "{func}(x, (str, bytes, bytearray, memoryview))",
+            ),
+            # Tuple on both sides with duplicates
+            (
+                "{func}(x, (str, bytes)) or {func}(x, (str, bytes, bytearray))",
+                "{func}(x, (str, bytes, bytearray))",
+            ),
+        ],
+    )
+    def test_combine_tuples(self, tmpdir, func, input_code, expected):
+        self._format_func_run_test(tmpdir, func, input_code, expected)
+
+    @each_func
+    @pytest.mark.parametrize(
+        "input_code, expected",
+        [
+            # 3 cst.Names
+            (
+                "{func}(x, str) or {func}(x, bytes) or {func}(x, bytearray)",
+                "{func}(x, (str, bytes, bytearray))",
+            ),
+            # 4 cst.Names
+            (
+                "{func}(x, str) or {func}(x, bytes) or {func}(x, bytearray) or {func}(x, some_type)",
+                "{func}(x, (str, bytes, bytearray, some_type))",
+            ),
+            # 5 cst.Names
+            (
+                "{func}(x, str) or {func}(x, bytes) or {func}(x, bytearray) or {func}(x, some_type) or {func}(x, another_type)",
+                "{func}(x, (str, bytes, bytearray, some_type, another_type))",
+            ),
+            # 2 cst.Names and 1 cst.Tuple
+            (
+                "{func}(x, str) or {func}(x, bytes) or {func}(x, (bytearray, memoryview))",
+                "{func}(x, (str, bytes, bytearray, memoryview))",
+            ),
+            # 2 cst.Name and 2 cst.Tuples
+            (
+                "{func}(x, str) or {func}(x, (bytes, bytearray)) or {func}(x, (memoryview, bytearray)) or {func}(x, list)",
+                "{func}(x, (str, bytes, bytearray, memoryview, list))",
+            ),
+            # 3 cst.Tuples
+            (
+                "{func}(x, (str, bytes)) or {func}(x, (bytes, bytearray)) or {func}(x, (bytearray, memoryview))",
+                "{func}(x, (str, bytes, bytearray, memoryview))",
+            ),
+            # 4 cst.Tuples
+            (
+                "{func}(x, (str, bytes)) or {func}(x, (bytes, bytearray)) or {func}(x, (bytearray, memoryview)) or {func}(x, (memoryview, str))",
+                "{func}(x, (str, bytes, bytearray, memoryview))",
+            ),
+        ],
+    )
+    def test_more_than_two_calls(self, tmpdir, func, input_code, expected):
+        self._format_func_run_test(
+            tmpdir, func, input_code, expected, input_code.count(" or ")
+        )


### PR DESCRIPTION
### `CombineIsinstanceIssubclass`
- New CodeMod very similar to `CombineStartswithEndswith` but for `isinstance` and `issubclass` calls.
```python
# Input
isinstance(a, int) or isinstance(a, float) or isinstance(a, str)
issubclass(a, str) or issubclass(a, (bytes, bytearray)) or issubclass(a, memoryview)

# Output
isinstance(a, (int, float, str))
issubclass(a, (str, bytes, bytearray, memoryview))
```