### PR TITLE
fix lazy logging codemod bug with acceptable concatnation

### DIFF
--- a/src/core_codemods/lazy_logging.py
+++ b/src/core_codemods/lazy_logging.py
@@ -54,21 +54,34 @@ class LazyLogging(SimpleCodemod, NameAndAncestorResolutionMixin):
                 ...
             {_log_funcs}
           - patterns:
-            - pattern: logging.$FUNC(..., $ANYTHING + ..., ...)
+            - pattern: logging.$FUNC($MSG + ..., ...)
             {_pattern_inside}
             {_log_funcs}
           - patterns:
-            - pattern: logging.getLogger(...).$FUNC(..., $ANYTHING + ..., ...)
+            - pattern: logging.getLogger(...).$FUNC($MSG + ..., ...)
             {_pattern_inside}
             {_log_funcs}
           - patterns:
-            - pattern: $VAR.$FUNC(..., $ANYTHING + ..., ...)
+            - pattern: $VAR.$FUNC($MSG + ..., ...)
             - pattern-inside: |
                 import logging
                 ...
                 $VAR = logging.getLogger(...)
                 ...
             {_log_funcs}
+          - patterns:
+            - pattern: logging.log($LEVEL, $MSG + ..., ...)
+            {_pattern_inside}
+          - patterns:
+            - pattern: logging.getLogger(...).log($LEVEL, $MSG + ..., ...)
+            {_pattern_inside}
+          - patterns:
+            - pattern: $VAR.log($LEVEL, $MSG + ..., ...)
+            - pattern-inside: |
+                import logging
+                ...
+                $VAR = logging.getLogger(...)
+                ...
         """
 
     def on_result_found(self, original_node, updated_node):

--- a/tests/codemods/test_lazy_logging.py
+++ b/tests/codemods/test_lazy_logging.py
@@ -321,6 +321,27 @@ class TestLazyLoggingModulo(BaseSemgrepCodemodTest):
             import logging
             logging.info("% something", "hi")
             """,
+            """
+            import logging
+            logger = logging.getLogger(__name__)
+            logger.debug(
+                "At depth %d, updating best step: %s (score: %f).",
+                10,
+                [swap] + next_step.swaps_added,
+                next_score,
+            )
+            """,
+            """
+            import logging
+            logger = logging.getLogger(__name__)
+            logger.log(
+                logging.INFO,
+                "At depth %d, updating best step: %s (score: %f).",
+                10,
+                [swap] + next_step.swaps_added,
+                next_score,
+            )
+            """,
         ],
     )
     def test_no_change(self, tmpdir, code):


### PR DESCRIPTION
## Overview
*Fix bug reported in issue where codemod was matching on a correct lazy logging line*

## Description

* The fix is to change the semgrep pattern to not match acceptable args concatenation. This meant I had to do a bit of duplication in the pattern but that's worth it to fix this.

Fixes #487
I re-ran the codemodder command on the repo from the issue and this PR does indeed fix the error.
