### PR TITLE
Add fixed/unfixed finding metadata support; populate for defectdojo

### DIFF
--- a/src/codemodder/codemods/base_codemod.py
+++ b/src/codemodder/codemods/base_codemod.py
@@ -248,6 +248,6 @@ class BaseCodemod(metaclass=ABCMeta):
         if change_set := self.transformer.apply(
             context, file_context, findings_for_rule
         ):
-            file_context.add_result(change_set)
+            file_context.add_changeset(change_set)
 
         return file_context

--- a/src/codemodder/codemods/imported_call_modifier.py
+++ b/src/codemodder/codemods/imported_call_modifier.py
@@ -40,6 +40,7 @@ class ImportedCallModifier(
         self.change_description = change_description
         self.changes_in_file: list[Change] = []
         self.results = results
+        self.file_context = file_context
 
     def updated_args(self, original_args: Sequence[cst.Arg]):
         return original_args
@@ -74,8 +75,13 @@ class ImportedCallModifier(
                 and true_name
                 and true_name in self.matching_functions
             ):
+                findings = self.file_context.get_findings_for_location(line_number)
                 self.changes_in_file.append(
-                    Change(lineNumber=line_number, description=self.change_description)
+                    Change(
+                        lineNumber=line_number,
+                        description=self.change_description,
+                        finding=findings[0] if findings else None,
+                    )
                 )
 
                 new_args = self.updated_args(updated_node.args)

--- a/src/codemodder/codemods/libcst_transformer.py
+++ b/src/codemodder/codemods/libcst_transformer.py
@@ -120,11 +120,12 @@ class LibcstResultTransformer(BaseTransformer):
 
     def report_change(self, original_node, description: str | None = None):
         line_number = self.lineno_for_node(original_node)
+        findings = self.file_context.get_findings_for_location(line_number)
         self.file_context.codemod_changes.append(
             Change(
                 lineNumber=line_number,
                 description=description or self.change_description,
-                # TODO: add fixed findings
+                finding=findings[0] if findings else None,
             )
         )
 

--- a/src/codemodder/codemods/libcst_transformer.py
+++ b/src/codemodder/codemods/libcst_transformer.py
@@ -130,9 +130,9 @@ class LibcstResultTransformer(BaseTransformer):
         )
 
     def report_unfixed(self, original_node: cst.CSTNode, reason: str):
-        pass
-        # results = self.results_for_node(original_node)
-        # self.file_context.unfixed_findings.extend(results)
+        line_number = self.lineno_for_node(original_node)
+        findings = self.file_context.get_findings_for_location(line_number)
+        self.file_context.add_unfixed_findings(findings, reason, line_number)
 
     def remove_unused_import(self, original_node):
         RemoveImportsVisitor.remove_unused_import_by_node(self.context, original_node)

--- a/src/codemodder/codemods/libcst_transformer.py
+++ b/src/codemodder/codemods/libcst_transformer.py
@@ -276,8 +276,7 @@ class LibcstTransformerPipeline(BaseTransformerPipeline):
         if not file_context.codemod_changes:
             return None
 
-        diff = create_diff_from_tree(source_tree, tree)
-        if not diff:
+        if not (diff := create_diff_from_tree(source_tree, tree)):
             return None
 
         change_set = ChangeSet(

--- a/src/codemodder/codemods/test/utils.py
+++ b/src/codemodder/codemods/test/utils.py
@@ -54,7 +54,7 @@ class BaseCodemodTest:
         )
 
         self.codemod.apply(self.execution_context, files_to_check)
-        changes = self.execution_context.get_results(self.codemod.id)
+        changes = self.execution_context.get_changesets(self.codemod.id)
 
         self.changeset = changes
 
@@ -172,7 +172,7 @@ class BaseSASTCodemodTest(BaseCodemodTest):
         )
 
         self.codemod.apply(self.execution_context, files_to_check)
-        changes = self.execution_context.get_results(self.codemod.id)
+        changes = self.execution_context.get_changesets(self.codemod.id)
 
         if input_code == expected:
             assert not changes

--- a/src/codemodder/codemods/test/utils.py
+++ b/src/codemodder/codemods/test/utils.py
@@ -188,3 +188,5 @@ class BaseSASTCodemodTest(BaseCodemodTest):
             expected,
             changes[0],
         )
+
+        return changes

--- a/src/codemodder/codetf.py
+++ b/src/codemodder/codetf.py
@@ -83,6 +83,21 @@ class Finding(BaseModel):
     id: str
     rule: Rule
 
+    def to_unfixed_finding(
+        self,
+        *,
+        path: str,
+        line_number: Optional[int] = None,
+        reason: str,
+    ) -> UnfixedFinding:
+        return UnfixedFinding(
+            id=self.id,
+            rule=self.rule,
+            path=path,
+            lineNumber=line_number,
+            reason=reason,
+        )
+
 
 class UnfixedFinding(Finding):
     path: str

--- a/src/codemodder/context.py
+++ b/src/codemodder/context.py
@@ -128,8 +128,7 @@ class CodemodExecutionContext:
         """Write the dependencies a codemod added to the appropriate dependency
         file in the project. Returns a dict listing the locations the dependencies were added.
         """
-        dependencies = self.dependencies.get(codemod_id)
-        if not dependencies:
+        if not (dependencies := self.dependencies.get(codemod_id)):
             return {}
 
         # populate everything with None and then change the ones added
@@ -137,8 +136,7 @@ class CodemodExecutionContext:
         for dep in dependencies:
             record[dep] = None
 
-        store_list = self.repo_manager.package_stores
-        if not store_list:
+        if not (store_list := self.repo_manager.package_stores):
             logger.info(
                 "unable to write dependencies for %s: no dependency file found",
                 codemod_id,

--- a/src/codemodder/file_context.py
+++ b/src/codemodder/file_context.py
@@ -33,3 +33,14 @@ class FileContext:
 
     def add_failure(self, filename: Path):
         self.failures.append(filename)
+
+    def get_findings_for_location(self, line_number: int):
+        return [
+            result.finding
+            for result in (self.results or [])
+            if any(
+                location.start.line <= line_number <= location.end.line
+                for location in result.locations
+            )
+            and result.finding is not None
+        ]

--- a/src/codemodder/file_context.py
+++ b/src/codemodder/file_context.py
@@ -1,7 +1,7 @@
 from dataclasses import dataclass, field
 from pathlib import Path
 
-from codemodder.codetf import Change, ChangeSet, UnfixedFinding
+from codemodder.codetf import Change, ChangeSet, Finding, UnfixedFinding
 from codemodder.dependency import Dependency
 from codemodder.result import Result
 from codemodder.utils.timer import Timer
@@ -33,6 +33,20 @@ class FileContext:
 
     def add_failure(self, filename: Path):
         self.failures.append(filename)
+
+    def add_unfixed_findings(
+        self, findings: list[Finding], reason: str, line_number: int | None = None
+    ):
+        self.unfixed_findings.extend(
+            [
+                finding.to_unfixed_finding(
+                    path=str(self.file_path.relative_to(self.base_directory)),
+                    line_number=line_number,
+                    reason=reason,
+                )
+                for finding in findings
+            ]
+        )
 
     def get_findings_for_location(self, line_number: int):
         return [

--- a/src/codemodder/file_context.py
+++ b/src/codemodder/file_context.py
@@ -17,19 +17,19 @@ class FileContext:
     file_path: Path
     line_exclude: list[int] = field(default_factory=list)
     line_include: list[int] = field(default_factory=list)
-    findings: list[Result] | None = field(default_factory=list)
+    results: list[Result] | None = field(default_factory=list)
     dependencies: set[Dependency] = field(default_factory=set)
     codemod_changes: list[Change] = field(default_factory=list)
     unfixed_findings: list[UnfixedFinding] = field(default_factory=list)
-    results: list[ChangeSet] = field(default_factory=list)
+    changesets: list[ChangeSet] = field(default_factory=list)
     failures: list[Path] = field(default_factory=list)
     timer: Timer = field(default_factory=Timer)
 
     def add_dependency(self, dependency: Dependency):
         self.dependencies.add(dependency)
 
-    def add_result(self, result: ChangeSet):
-        self.results.append(result)
+    def add_changeset(self, result: ChangeSet):
+        self.changesets.append(result)
 
     def add_failure(self, filename: Path):
         self.failures.append(filename)

--- a/src/codemodder/result.py
+++ b/src/codemodder/result.py
@@ -7,6 +7,8 @@ from typing import TYPE_CHECKING, Any
 import libcst as cst
 from libcst._position import CodeRange
 
+from codemodder.codetf import Finding
+
 from .utils.abc_dataclass import ABCDataclass
 
 if TYPE_CHECKING:
@@ -31,6 +33,7 @@ class Location(ABCDataclass):
 class Result(ABCDataclass):
     rule_id: str
     locations: list[Location]
+    finding: Finding | None = None
 
     def match_location(self, pos: CodeRange, node: cst.CSTNode) -> bool:
         del node

--- a/src/core_codemods/defectdojo/results.py
+++ b/src/core_codemods/defectdojo/results.py
@@ -6,6 +6,7 @@ import libcst as cst
 from libcst._position import CodeRange
 from typing_extensions import Self, override
 
+from codemodder.codetf import Finding, Rule
 from codemodder.result import LineInfo, Location, ResultSet, SASTResult
 
 
@@ -27,6 +28,15 @@ class DefectDojoResult(SASTResult):
             finding_id=finding["id"],
             rule_id=finding["title"],
             locations=[DefectDojoLocation.from_finding(finding)],
+            finding=Finding(
+                id=str(finding["id"]),
+                rule=Rule(
+                    # TODO: it's possible that these fields actually come from the codemod and not the result
+                    id=str(finding["title"]),
+                    name=str(finding["title"]),
+                    url=None,
+                ),
+            ),
         )
 
     @override

--- a/src/core_codemods/url_sandbox.py
+++ b/src/core_codemods/url_sandbox.py
@@ -34,7 +34,7 @@ class UrlSandboxTransformer(LibcstResultTransformer):
         find_requests_visitor = FindRequestCallsAndImports(
             self.context,
             self.file_context,
-            self.file_context.findings,
+            self.file_context.results,
         )
         tree.visit(find_requests_visitor)
         if find_requests_visitor.nodes_to_change:

--- a/tests/codemods/defectdojo/semgrep/test_avoid_insecure_deserialization.py
+++ b/tests/codemods/defectdojo/semgrep/test_avoid_insecure_deserialization.py
@@ -158,3 +158,11 @@ class TestDjangoAvoidInsecureDeserialization(BaseSASTCodemodTest):
 
         self.run_and_assert(tmpdir, input_code, expected, results=json.dumps(findings))
         adds_dependency.assert_not_called()
+
+        unfixed = self.execution_context.get_unfixed_findings(self.codemod.id)
+        assert len(unfixed) == 1
+        assert unfixed[0].id == "5"
+        assert unfixed[0].rule.id == RULE_ID
+        assert unfixed[0].lineNumber == 4
+        assert unfixed[0].reason == "`fickling` does not yet support `pickle.loads`"
+        assert unfixed[0].path == "code.py"

--- a/tests/codemods/defectdojo/semgrep/test_avoid_insecure_deserialization.py
+++ b/tests/codemods/defectdojo/semgrep/test_avoid_insecure_deserialization.py
@@ -41,7 +41,14 @@ class TestDjangoAvoidInsecureDeserialization(BaseSASTCodemodTest):
             ]
         }
 
-        self.run_and_assert(tmpdir, input_code, expected, results=json.dumps(findings))
+        changes = self.run_and_assert(
+            tmpdir, input_code, expected, results=json.dumps(findings)
+        )
+
+        assert changes is not None
+        assert changes[0].changes[0].finding is not None
+        assert changes[0].changes[0].finding.id == "1"
+        assert changes[0].changes[0].finding.rule.id == RULE_ID
 
     @mock.patch("codemodder.codemods.api.FileContext.add_dependency")
     def test_pickle_load(self, adds_dependency, tmpdir):
@@ -67,8 +74,15 @@ class TestDjangoAvoidInsecureDeserialization(BaseSASTCodemodTest):
             ]
         }
 
-        self.run_and_assert(tmpdir, input_code, expected, results=json.dumps(findings))
+        changes = self.run_and_assert(
+            tmpdir, input_code, expected, results=json.dumps(findings)
+        )
         adds_dependency.assert_called_once_with(Fickling)
+
+        assert changes is not None
+        assert changes[0].changes[0].finding is not None
+        assert changes[0].changes[0].finding.id == "2"
+        assert changes[0].changes[0].finding.rule.id == RULE_ID
 
     @mock.patch("codemodder.codemods.api.FileContext.add_dependency")
     def test_pickle_and_yaml(self, adds_dependency, tmpdir):
@@ -104,7 +118,7 @@ class TestDjangoAvoidInsecureDeserialization(BaseSASTCodemodTest):
             ]
         }
 
-        self.run_and_assert(
+        changes = self.run_and_assert(
             tmpdir,
             input_code,
             expected,
@@ -112,6 +126,14 @@ class TestDjangoAvoidInsecureDeserialization(BaseSASTCodemodTest):
             num_changes=2,
         )
         adds_dependency.assert_called_once_with(Fickling)
+
+        assert changes is not None
+        assert changes[0].changes[0].finding is not None
+        assert changes[0].changes[0].finding.id == "4"
+        assert changes[0].changes[0].finding.rule.id == RULE_ID
+        assert changes[0].changes[1].finding is not None
+        assert changes[0].changes[1].finding.id == "3"
+        assert changes[0].changes[1].finding.rule.id == RULE_ID
 
     @mock.patch("codemodder.codemods.api.FileContext.add_dependency")
     def test_pickle_loads(self, adds_dependency, tmpdir):

--- a/tests/codemods/defectdojo/semgrep/test_django_secure_set_cookie.py
+++ b/tests/codemods/defectdojo/semgrep/test_django_secure_set_cookie.py
@@ -32,4 +32,14 @@ class TestDjangoSecureSetCookie(BaseSASTCodemodTest):
             ]
         }
 
-        self.run_and_assert(tmpdir, input_code, expected, results=json.dumps(findings))
+        changes = self.run_and_assert(
+            tmpdir, input_code, expected, results=json.dumps(findings)
+        )
+
+        assert changes is not None
+        assert changes[0].changes[0].finding is not None
+        assert changes[0].changes[0].finding.id == "1"
+        assert (
+            changes[0].changes[0].finding.rule.id
+            == "python.django.security.audit.secure-cookies.django-secure-set-cookie"
+        )


### PR DESCRIPTION
## Overview
*Add support for fixed and unfixed finding metadata and populate for defectdojo codemods*

## Details
* This is an important part of our storytelling and it was added to the CodeTF spec recently
* I expect there to be some iteration on the internal representation of these data models but this should get us started for now
* We'll need to go back and populate the same for our Sonar codemods as well