### PR TITLE
CLI: only pixee codemods can be requested by name

### DIFF
--- a/src/codemodder/codemods/base_codemod.py
+++ b/src/codemodder/codemods/base_codemod.py
@@ -251,3 +251,6 @@ class BaseCodemod(metaclass=ABCMeta):
             file_context.add_changeset(change_set)
 
         return file_context
+
+    def __repr__(self) -> str:
+        return f"{self.id}"

--- a/src/codemodder/codemods/test/integration_utils.py
+++ b/src/codemodder/codemods/test/integration_utils.py
@@ -88,14 +88,12 @@ class BaseIntegrationTest(DependencyTestMixin):
 
     def setup_method(self):
         try:
-            name = (
-                self.codemod().name
-                if isinstance(self.codemod, type)
-                else self.codemod.name
+            codemod_id = (
+                self.codemod().id if isinstance(self.codemod, type) else self.codemod.id
             )
             # This is how we ensure that the codemod is actually in the registry
             self.codemod_instance = self.codemod_registry.match_codemods(
-                codemod_include=[name]
+                codemod_include=[codemod_id]
             )[0]
         except IndexError as exc:
             raise IndexError(
@@ -109,7 +107,7 @@ class BaseIntegrationTest(DependencyTestMixin):
         assert run["elapsed"] != ""
         assert run[
             "commandLine"
-        ] == f'codemodder {self.code_dir} --output {output_path} --codemod-include={self.codemod_instance.name} --path-include={self.code_filename} --path-exclude=""' + (
+        ] == f'codemodder {self.code_dir} --output {output_path} --codemod-include={self.codemod_instance.id} --path-include={self.code_filename} --path-exclude=""' + (
             f" --sonar-issues-json={self.sonar_issues_json}"
             if self.sonar_issues_json
             else ""
@@ -198,7 +196,7 @@ class BaseIntegrationTest(DependencyTestMixin):
             self.code_dir,
             "--output",
             self.output_path,
-            f"--codemod-include={self.codemod_instance.name}",
+            f"--codemod-include={self.codemod_instance.id}",
             f"--path-include={self.code_filename}",
             '--path-exclude=""',
         ]

--- a/src/codemodder/registry.py
+++ b/src/codemodder/registry.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import os
 import re
 from dataclasses import dataclass
+from functools import cached_property
 from importlib.metadata import entry_points
 from itertools import chain
 from typing import TYPE_CHECKING, Optional
@@ -56,6 +57,14 @@ class CodemodRegistry:
     def default_include_paths(self) -> list[str]:
         return list(self._default_include_paths)
 
+    @cached_property
+    def pixee_codemods_by_name(self) -> dict:
+        return {
+            name: codemod
+            for name, codemod in self._codemods_by_name.items()
+            if codemod.origin == "pixee"
+        }
+
     def add_codemod_collection(self, collection: CodemodCollection):
         for codemod in collection.codemods:
             wrapper = codemod() if isinstance(codemod, type) else codemod
@@ -87,6 +96,7 @@ class CodemodRegistry:
                 if "*" in exclude
             ]
             names = set(name for name in codemod_exclude if "*" not in name)
+
             for codemod in self.codemods:
                 if (
                     codemod.id in names
@@ -115,7 +125,7 @@ class CodemodRegistry:
 
             try:
                 matched_codemods.append(
-                    self._codemods_by_name.get(name) or self._codemods_by_id[name]
+                    self.pixee_codemods_by_name.get(name) or self._codemods_by_id[name]
                 )
             except KeyError:
                 logger.warning(f"Requested codemod to include '{name}' does not exist.")

--- a/tests/codemods/test_include_exclude.py
+++ b/tests/codemods/test_include_exclude.py
@@ -136,3 +136,9 @@ class TestMatchCodemods:
             for c in self.registry.codemods
             if not c.origin == "pixee" and c.id in self.all_ids
         ]
+
+    def test_non_pixee_name_no_match(self):
+        assert self.registry.match_codemods(["secure-random-S2245"], None) == []
+        assert self.registry.match_codemods(None, ["secure-random-S2245"]) == [
+            c for c in self.registry.codemods if c.id in self.all_ids
+        ]


### PR DESCRIPTION
## Overview
*for include/exclude CLI codemods, only pixee codemods can be requested by name*

This logic for "exclude" already existed so I only implemented the includes logic and tested both.

Closes #388