### PR TITLE
🚚 Migrate to Supported Codemod Preference

### DIFF
--- a/.github/pixeebot.yaml
+++ b/.github/pixeebot.yaml
@@ -1,2 +1,3 @@
-additional_codemods:
-  - pixee:python/use-walrus-if
+codemods:
+  prepend:
+    - pixee:python/use-walrus-if


### PR DESCRIPTION
Migrating deprecated `additional_codemods` to the new, supported `codemods.prepend` preference.
