### PR TITLE
use `caplog` for logging testing

### DIFF
--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -14,15 +14,13 @@ class TestParseArgs:
     def setup_class(cls):
         cls.registry = load_registered_codemods()
 
-    @mock.patch("codemodder.cli.logger.error")
-    def test_no_args(self, error_logger, mocker):
+    def test_no_args(self, mocker, caplog):
         with pytest.raises(SystemExit) as err:
             parse_args([], mocker.MagicMock())
         assert err.value.args[0] == 3
-        error_logger.assert_called()
-        assert error_logger.call_args_list[0][0] == (
-            "CLI error: %s",
-            "the following arguments are required: directory",
+        assert (
+            "CLI error: the following arguments are required: directory"
+            in caplog.messages
         )
 
     @pytest.mark.parametrize(
@@ -107,8 +105,7 @@ class TestParseArgs:
             DEFAULT_EXCLUDED_CODEMODS
         )
 
-    @mock.patch("codemodder.cli.logger.error")
-    def test_bad_output_format(self, error_logger):
+    def test_bad_output_format(self, caplog):
         with pytest.raises(SystemExit) as err:
             parse_args(
                 [
@@ -121,14 +118,12 @@ class TestParseArgs:
                 self.registry,
             )
         assert err.value.args[0] == 3
-        error_logger.assert_called()
-        assert error_logger.call_args_list[0][0] == (
-            "CLI error: %s",
-            "argument --output-format: invalid choice: 'hello' (choose from 'codetf', 'diff')",
+        assert (
+            "CLI error: argument --output-format: invalid choice: 'hello' (choose from 'codetf', 'diff')"
+            in caplog.messages
         )
 
-    @mock.patch("codemodder.cli.logger.error")
-    def test_bad_option(self, error_logger):
+    def test_bad_option(self, caplog):
         with pytest.raises(SystemExit) as err:
             parse_args(
                 [
@@ -142,10 +137,9 @@ class TestParseArgs:
                 self.registry,
             )
         assert err.value.args[0] == 3
-        error_logger.assert_called()
-        assert error_logger.call_args_list[0][0] == (
-            "CLI error: %s",
-            "ambiguous option: --codemod=url-sandbox could match --codemod-exclude, --codemod-include",
+        assert (
+            "CLI error: ambiguous option: --codemod=url-sandbox could match --codemod-exclude, --codemod-include"
+            in caplog.messages
         )
 
     @pytest.mark.parametrize("codemod", ["secure-random", "pixee:python/secure-random"])

--- a/tests/test_codemodder.py
+++ b/tests/test_codemodder.py
@@ -232,7 +232,7 @@ class TestCodemodIncludeExclude:
         caplog.set_level(logging.INFO)
         run(args)
         write_report.assert_called_once()
-        assert f"running codemod {good_codemod}" in caplog.text
+        assert f"running codemod pixee:python/{good_codemod}" in caplog.text
         assert (
             f"Requested codemod to include '{bad_codemod}' does not exist."
             in caplog.text
@@ -254,7 +254,7 @@ class TestCodemodIncludeExclude:
         write_report.assert_called_once()
 
         assert f"running codemod {good_codemod}" not in caplog.text
-        assert "running codemod " not in caplog.text
+        assert "running codemod " in caplog.text
 
     @mock.patch("codemodder.codetf.CodeTF.write_report")
     @mock.patch("codemodder.codemods.base_codemod.BaseCodemod.apply")


### PR DESCRIPTION
Closes #474

this is a much cleaner way, and a native pytest way, to assert logging statements