### PR TITLE
Add a mechanism to enforce testing files for new codemods

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,12 +1,12 @@
 PYTEST = pytest -v
-COV_FLAGS = --cov-fail-under=93.5 --cov=codemodder --cov=core_codemods
+COV_FLAGS = --cov=codemodder --cov=core_codemods
 XDIST_FLAGS = --numprocesses auto
 
 test:
-	COVERAGE_CORE=sysmon ${PYTEST} ${COV_FLAGS} tests ${XDIST_FLAGS}
+	COVERAGE_CORE=sysmon ${PYTEST} ${COV_FLAGS} tests ${XDIST_FLAGS} && coverage json && coverage-threshold
 
 integration-test:
-	${PYTEST} integration_tests ${XDIST_FLAGS}
+	COVERAGE_CORE=sysmon ${PYTEST} integration_tests --cov=core_codemods ${XDIST_FLAGS}  && coverage json && coverage-threshold
 
 pygoat-test:
 	${PYTEST} -v ci_tests/test_pygoat_findings.py

--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ test:
 	COVERAGE_CORE=sysmon ${PYTEST} ${COV_FLAGS} tests ${XDIST_FLAGS} && coverage json && coverage-threshold
 
 integration-test:
-	COVERAGE_CORE=sysmon ${PYTEST} integration_tests --cov=core_codemods ${XDIST_FLAGS}  && coverage json && coverage-threshold
+	COVERAGE_CORE=sysmon ${PYTEST} integration_tests --cov=core_codemods ${XDIST_FLAGS}  && coverage json && coverage-threshold --line-coverage-min 80
 
 pygoat-test:
 	${PYTEST} -v ci_tests/test_pygoat_findings.py

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,6 +49,7 @@ get-hashes = 'codemodder.scripts.get_hashes:main'
 [project.optional-dependencies]
 test = [
     "coverage>=7.3,<7.6",
+    "coverage-threshold~=0.4",
     "Flask<4",
     "Jinja2~=3.1.2",
     "jsonschema~=4.22.0",
@@ -110,3 +111,9 @@ extend-exclude = '''
   src/codemodder/_version.py
 )/
 '''
+
+[coverage-threshold]
+line_coverage_min = 93.5
+    [coverage-threshold.modules."src/core_codemods/"]
+    # Detect if a codemod is missing unit or integration tests
+    file_line_coverage_min = 50

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -114,6 +114,6 @@ extend-exclude = '''
 
 [coverage-threshold]
 line_coverage_min = 93.5
-    [coverage-threshold.modules."src/core_codemods/"]
-    # Detect if a codemod is missing unit or integration tests
-    file_line_coverage_min = 50
+[coverage-threshold.modules."src/core_codemods/"]
+# Detect if a codemod is missing unit or integration tests
+file_line_coverage_min = 50


### PR DESCRIPTION
## Overview
*Use `coverage-threshold` to detect if a new codemod is missing unit or integration test*

## Description
It's common for contributors of new core_codemods to forget to add unit tests, and even more common, integration tests. [Here's](https://github.com/pixee/codemodder-python/pull/494/commits/207647f94cfb9a0fd37550750f706dfd7f8a1ae5) an example when a contributor got all the way to PR but forgot to add an integration test because it wasn't enforced anywhere. Without an integration test, we also don't enforce registering the new codemod or adding docs. While there may be rare cases when we want to just add the codemod, 99% of the time we want the testing to be there.

To remind us to add the right testing for a new codemod, I decided to use [coverage-threshold](https://github.com/DeanWay/coverage-threshold) after reading [this issue](https://github.com/nedbat/coveragepy/issues/691).  I also considered something in pre-commit or a pytest fixture to look at all core_codemods and find matching test files.

But adding this mechanism for per-file test coverage is clean and does the job. Setting `file_line_coverage_min` at 50 for any file in core_codemods correctly detects if a new codemod is untested or undertested, in both unit and integration tests. I moved our existing overall test coverage to `line_coverage_min` but allowed integration tests to have a lower configured value to pass.

Overall, I think this will reduce our mental load to remember to add the correct testing for a new codemod and will make it easier for new contributors. 🚀 

Closes #507
