### PR TITLE
Codemod for disabling GraphQL introspection

### DIFF
--- a/integration_tests/sonar/test_sonar_disable_graphql_introspection.py
+++ b/integration_tests/sonar/test_sonar_disable_graphql_introspection.py
@@ -1,0 +1,63 @@
+from codemodder.codemods.test import SonarIntegrationTest
+from core_codemods.disable_graphql_introspection import (
+    DisableGraphQLIntrospectionTransform,
+)
+from core_codemods.sonar.sonar_disable_graphql_introspection import (
+    SonarDisableGraphQLIntrospection,
+)
+
+
+class TestSonarDisableGraphQLIntrospection(SonarIntegrationTest):
+    codemod = SonarDisableGraphQLIntrospection
+    code_path = "tests/samples/disable_graphql_introspection.py"
+    expected_new_code = """\
+    from graphql_server.flask import GraphQLView
+    from flask import Flask
+    from graphql import (
+        GraphQLSchema, GraphQLObjectType, GraphQLField, GraphQLString)
+    from graphql.validation import NoSchemaIntrospectionCustomRule
+
+    schema = GraphQLSchema(
+        query=GraphQLObjectType(
+            name='RootQueryType',
+            fields={
+                'hello': GraphQLField(
+                    GraphQLString,
+                    resolve=lambda obj, info: 'world')
+            }))
+
+    app = Flask(__name__)
+
+    app.add_url_rule("/api",
+        view_func=GraphQLView.as_view(
+            name="api",
+            schema=schema,
+        validation_rules = [NoSchemaIntrospectionCustomRule,]),
+    )
+    """
+
+    # fmt: off
+    expected_diff = (
+        """--- \n"""
+        """+++ \n"""
+        """@@ -2,6 +2,7 @@\n"""
+        """ from flask import Flask\n"""
+        """ from graphql import (\n"""
+        """     GraphQLSchema, GraphQLObjectType, GraphQLField, GraphQLString)\n"""
+        """+from graphql.validation import NoSchemaIntrospectionCustomRule\n"""
+        """ \n"""
+        """ schema = GraphQLSchema(\n"""
+        """     query=GraphQLObjectType(\n"""
+        """@@ -18,5 +19,5 @@\n"""
+        """     view_func=GraphQLView.as_view(\n"""
+        """         name="api",\n"""
+        """         schema=schema,\n"""
+        """-    ),\n"""
+        """+    validation_rules = [NoSchemaIntrospectionCustomRule,]),\n"""
+        """ )\n"""
+    )
+    # fmt: on
+
+    expected_line_change = "18"
+    change_description = DisableGraphQLIntrospectionTransform.change_description
+    num_changed_files = 1

--- a/integration_tests/test_disable_graphql_introspection.py
+++ b/integration_tests/test_disable_graphql_introspection.py
@@ -1,0 +1,84 @@
+from codemodder.codemods.test.integration_utils import BaseIntegrationTest
+from core_codemods.disable_graphql_introspection import (
+    DisableGraphQLIntrospection,
+    DisableGraphQLIntrospectionTransform,
+)
+
+
+class TestDisableGraphQLIntrospection(BaseIntegrationTest):
+    codemod = DisableGraphQLIntrospection
+    original_code = """
+        from graphql_server.flask import GraphQLView
+        from flask import Flask
+        from graphql import (
+            GraphQLSchema, GraphQLObjectType, GraphQLField, GraphQLString)
+
+        schema = GraphQLSchema(
+            query=GraphQLObjectType(
+                name='RootQueryType',
+                fields={
+                    'hello': GraphQLField(
+                        GraphQLString,
+                        resolve=lambda obj, info: 'world')
+                }))
+
+        app = Flask(__name__)
+
+        app.add_url_rule("/api",
+            view_func=GraphQLView.as_view(
+                name="api",
+                schema=schema,
+            ),
+        )
+    """
+    expected_new_code = """
+        from graphql_server.flask import GraphQLView
+        from flask import Flask
+        from graphql import (
+            GraphQLSchema, GraphQLObjectType, GraphQLField, GraphQLString)
+        from graphql.validation import NoSchemaIntrospectionCustomRule
+
+        schema = GraphQLSchema(
+            query=GraphQLObjectType(
+                name='RootQueryType',
+                fields={
+                    'hello': GraphQLField(
+                        GraphQLString,
+                        resolve=lambda obj, info: 'world')
+                }))
+
+        app = Flask(__name__)
+
+        app.add_url_rule("/api",
+            view_func=GraphQLView.as_view(
+                name="api",
+                schema=schema,
+            validation_rules = [NoSchemaIntrospectionCustomRule,]),
+        )
+    """
+
+    # fmt: off
+    expected_diff = (
+        """--- \n"""
+        """+++ \n"""
+        """@@ -2,6 +2,7 @@\n"""
+        """ from flask import Flask\n"""
+        """ from graphql import (\n"""
+        """     GraphQLSchema, GraphQLObjectType, GraphQLField, GraphQLString)\n"""
+        """+from graphql.validation import NoSchemaIntrospectionCustomRule\n"""
+        """ \n"""
+        """ schema = GraphQLSchema(\n"""
+        """     query=GraphQLObjectType(\n"""
+        """@@ -18,5 +19,5 @@\n"""
+        """     view_func=GraphQLView.as_view(\n"""
+        """         name="api",\n"""
+        """         schema=schema,\n"""
+        """-    ),\n"""
+        """+    validation_rules = [NoSchemaIntrospectionCustomRule,]),\n"""
+        """ )"""
+    )
+    # fmt: on
+
+    expected_line_change = "18"
+    change_description = DisableGraphQLIntrospectionTransform.change_description
+    num_changed_files = 1

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -69,8 +69,7 @@ test = [
     "numpy~=1.26.0",
     "flask_wtf~=1.2.0",
     "fickling~=0.1.0,>=0.1.3",
-    "graphql-core~=3.2.3",
-    "graphql-server~=3",
+    "graphql-server~=3.0.0b7",
 ]
 complexity = [
     "radon==6.0.*",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -69,6 +69,8 @@ test = [
     "numpy~=1.26.0",
     "flask_wtf~=1.2.0",
     "fickling~=0.1.0,>=0.1.3",
+    "graphql-core~=3.2.3",
+    "graphql-server~=3",
 ]
 complexity = [
     "radon==6.0.*",

--- a/src/codemodder/codemods/test/integration_utils.py
+++ b/src/codemodder/codemods/test/integration_utils.py
@@ -178,8 +178,6 @@ class BaseIntegrationTest(DependencyTestMixin):
     def check_code_after(self) -> ModuleType:
         with open(self.code_path, "r", encoding="utf-8") as f:  # type: ignore
             new_code = f.read()
-        # diff = difflib.ndiff(new_code.splitlines(keepends=True), self.expected_new_code.splitlines(keepends = True))
-        # print(''.join(diff))
         assert new_code == self.expected_new_code  # type: ignore
         return execute_code(
             path=self.code_path, allowed_exceptions=self.allowed_exceptions  # type: ignore

--- a/src/codemodder/codemods/test/integration_utils.py
+++ b/src/codemodder/codemods/test/integration_utils.py
@@ -178,6 +178,8 @@ class BaseIntegrationTest(DependencyTestMixin):
     def check_code_after(self) -> ModuleType:
         with open(self.code_path, "r", encoding="utf-8") as f:  # type: ignore
             new_code = f.read()
+        # diff = difflib.ndiff(new_code.splitlines(keepends=True), self.expected_new_code.splitlines(keepends = True))
+        # print(''.join(diff))
         assert new_code == self.expected_new_code  # type: ignore
         return execute_code(
             path=self.code_path, allowed_exceptions=self.allowed_exceptions  # type: ignore
@@ -256,13 +258,21 @@ class SonarIntegrationTest(BaseIntegrationTest):
     @classmethod
     def setup_class(cls):
         cls.codemod_registry = registry.load_registered_codemods()
-        cls.original_code, cls.expected_new_code = original_and_expected_from_code_path(
-            cls.code_path, cls.replacement_lines
-        )
-
-        cls.code_filename = os.path.relpath(cls.code_path, SAMPLES_DIR)
-        cls.code_dir = SAMPLES_DIR
         cls.output_path = tempfile.mkstemp()[1]
+        cls.code_dir = SAMPLES_DIR
+        cls.code_filename = os.path.relpath(cls.code_path, SAMPLES_DIR)
+
+        if hasattr(cls, "expected_new_code"):
+            # Some tests are easier to understand with the expected new code provided
+            # instead of calculated
+            cls.original_code = "".join(_lines_from_codepath(cls.code_path))
+            cls.expected_new_code = dedent(cls.expected_new_code)
+        else:
+            cls.original_code, cls.expected_new_code = (
+                original_and_expected_from_code_path(
+                    cls.code_path, cls.replacement_lines
+                )
+            )
 
         # TODO: support sonar integration tests that add a dependency to
         # `requirements_file_name`. These tests would not be able to run

--- a/src/codemodder/codemods/utils_mixin.py
+++ b/src/codemodder/codemods/utils_mixin.py
@@ -634,10 +634,11 @@ class NameAndAncestorResolutionMixin(NameResolutionMixin, AncestorPatternsMixin)
                 return {resolved_key_value: resolved_value}
 
     def resolve_dict(self, dictionary: cst.Dict):
-        compilation = dict()
-        for e in dictionary.elements:
-            compilation.update(self._resolve_dict_element(e))
-        return compilation
+        return {
+            k: v
+            for e in dictionary.elements
+            for k, v in self._resolve_dict_element(e).items()
+        }
 
     def _transform_string_elements(self, expr):
         match expr:

--- a/src/codemodder/codemods/utils_mixin.py
+++ b/src/codemodder/codemods/utils_mixin.py
@@ -535,7 +535,7 @@ class NameAndAncestorResolutionMixin(NameResolutionMixin, AncestorPatternsMixin)
                         return self._resolve_name_transitive(value)
                     case _:
                         return value
-        return None
+        return node
 
     def _find_direct_name_assignment_targets(
         self, name: cst.Name

--- a/src/codemodder/codemods/utils_mixin.py
+++ b/src/codemodder/codemods/utils_mixin.py
@@ -658,7 +658,7 @@ class NameAndAncestorResolutionMixin(NameResolutionMixin, AncestorPatternsMixin)
                         resolved_starred_element = self.resolve_dict(resolved)
                         keyword_to_expr_dict |= {
                             self._transform_string_elements(k): v
-                            for k, v in resolved_starred_element
+                            for k, v in resolved_starred_element.items()
                         }
             if arg.keyword:
                 keyword_to_expr_dict |= {

--- a/src/codemodder/scripts/generate_docs.py
+++ b/src/codemodder/scripts/generate_docs.py
@@ -271,6 +271,10 @@ If you want to allow those protocols, change the incoming PR to look more like t
         importance="Low",
         guidance_explained="While this change will make the code consistent, it is likely that the `break` or `continue` statement is a symptom of an error in program logic.",
     ),
+    "disable-graphql-introspection": DocMetadata(
+        importance="High",
+        guidance_explained="This change may disable a feature that was left on purpose. Moreover the rule added may be framework specific.",
+    ),
 }
 DEFECTDOJO_CODEMODS = {
     "django-secure-set-cookie": DocMetadata(

--- a/src/codemodder/scripts/generate_docs.py
+++ b/src/codemodder/scripts/generate_docs.py
@@ -309,6 +309,7 @@ SONAR_CODEMOD_NAMES = [
     "sql-parameterization-S3649",
     "django-model-without-dunder-str-S6554",
     "break-or-continue-out-of-loop-S1716",
+    "disable-graphql-introspection-S6786",
 ]
 SONAR_CODEMODS = {
     name: DocMetadata(

--- a/src/core_codemods/__init__.py
+++ b/src/core_codemods/__init__.py
@@ -55,6 +55,7 @@ from .secure_flask_cookie import SecureFlaskCookie
 from .secure_flask_session_config import SecureFlaskSessionConfig
 from .secure_random import SecureRandom
 from .sonar.sonar_break_or_continue_out_of_loop import SonarBreakOrContinueOutOfLoop
+from .sonar.sonar_disable_graphql_introspection import SonarDisableGraphQLIntrospection
 from .sonar.sonar_django_json_response_type import SonarDjangoJsonResponseType
 from .sonar.sonar_django_model_without_dunder_str import (
     SonarDjangoModelWithoutDunderStr,
@@ -180,6 +181,7 @@ sonar_registry = CodemodCollection(
         SonarSQLParameterization,
         SonarDjangoModelWithoutDunderStr,
         SonarBreakOrContinueOutOfLoop,
+        SonarDisableGraphQLIntrospection,
     ],
 )
 

--- a/src/core_codemods/__init__.py
+++ b/src/core_codemods/__init__.py
@@ -8,6 +8,7 @@ from .defectdojo.semgrep.avoid_insecure_deserialization import (
     AvoidInsecureDeserialization,
 )
 from .defectdojo.semgrep.django_secure_set_cookie import DjangoSecureSetCookie
+from .disable_graphql_introspection import DisableGraphQLIntrospection
 from .django_debug_flag_on import DjangoDebugFlagOn
 from .django_json_response_type import DjangoJsonResponseType
 from .django_model_without_dunder_str import DjangoModelWithoutDunderStr
@@ -153,6 +154,7 @@ registry = CodemodCollection(
         FixMissingSelfOrCls,
         FixMathIsClose,
         BreakOrContinueOutOfLoop,
+        DisableGraphQLIntrospection,
     ],
 )
 

--- a/src/core_codemods/disable_graphql_introspection.py
+++ b/src/core_codemods/disable_graphql_introspection.py
@@ -1,0 +1,202 @@
+from itertools import chain
+
+import libcst as cst
+from libcst.codemod import CodemodContext, ContextAwareVisitor
+
+from codemodder.codemods.base_codemod import Metadata, ReviewGuidance
+from codemodder.codemods.libcst_transformer import (
+    LibcstResultTransformer,
+    LibcstTransformerPipeline,
+)
+from codemodder.codemods.utils import ReplacementNodeType, ReplaceNodes
+from codemodder.codemods.utils_mixin import NameAndAncestorResolutionMixin
+from codemodder.codetf import Reference
+from core_codemods.api.core_codemod import CoreCodemod
+
+
+class DisableGraphQLIntrospectionTransform(
+    LibcstResultTransformer, NameAndAncestorResolutionMixin
+):
+
+    def transform_module_impl(self, tree: cst.Module) -> cst.Module:
+        visitor = FindGraphQLViewsWithIntrospection(self.context)
+        tree.visit(visitor)
+        all_changes: dict[cst.CSTNode, ReplacementNodeType] = {}
+        for call, changes in visitor.calls_to_change.items():
+            if self.node_is_selected(call):
+                all_changes |= changes
+                self.report_change(call)
+        if all_changes:
+            self.add_needed_import(
+                "graphql.validation", "NoSchemaIntrospectionCustomRule"
+            )
+            return tree.visit(ReplaceNodes(all_changes))
+        return super().transform_module_impl(tree)
+
+
+class FindGraphQLViewsWithIntrospection(
+    ContextAwareVisitor, NameAndAncestorResolutionMixin
+):
+
+    supported_functions = {
+        "graphql_server.flask.GraphQLView",
+        "graphql_server.flask.GraphQLView.as_view",
+        "graphql_server.sanic.GraphQLView",
+        "graphql_server.aiohttp.GraphQLView",
+        "graphql_server.webob.GraphQLView",
+    }
+
+    introspection_rules_objects = {
+        "graphql.validation.NoSchemaIntrospectionCustomRule",
+        "graphql.NoSchemaIntrospectionCustomRule",
+        "graphene.validation.DisableIntrospection",
+    }
+
+    def __init__(self, context: CodemodContext) -> None:
+        self.calls_to_change: dict[cst.Call, dict[cst.CSTNode, ReplacementNodeType]] = (
+            {}
+        )
+        super().__init__(context)
+
+    def leave_Call(self, original_node: cst.Call):
+        # accumulates the changes associated with the detected call
+        nodes_to_change = {}
+        if self.find_base_name(original_node) in self.supported_functions:
+            resolved_args = self.resolve_keyword_args(original_node)
+            if "validation_rules" in resolved_args.keys():
+                # is it a list literal that I can append?
+                resolved = resolved_args["validation_rules"]
+                match resolved:
+                    case cst.List():
+                        # does it have any introspection rule
+                        print(list(self.resolve_list_literal(resolved)))
+                        if not any(
+                            filter(
+                                lambda e: self._is_introspection_rule_or_starred(e),
+                                self.resolve_list_literal(resolved),
+                            )
+                        ):
+                            nodes_to_change[resolved] = resolved.with_changes(
+                                elements=[
+                                    *resolved.elements,
+                                    cst.Element(
+                                        value=cst.Name(
+                                            "NoSchemaIntrospectionCustomRule"
+                                        )
+                                    ),
+                                ]
+                            )
+
+            else:
+                nodes_to_change[original_node] = original_node.with_changes(
+                    args=[
+                        *original_node.args,
+                        cst.Arg(
+                            value=cst.parse_expression(
+                                "[NoSchemaIntrospectionCustomRule,]"
+                            ),
+                            keyword=cst.Name("validation_rules"),
+                        ),
+                    ]
+                )
+        if nodes_to_change:
+            self.calls_to_change[original_node] = nodes_to_change
+
+    def _is_introspection_rule_or_starred(
+        self, node: cst.BaseExpression | cst.StarredElement
+    ) -> bool:
+        # Does it have a starred element?
+        if isinstance(node, cst.StarredElement):
+            return True
+        print(node)
+        if isinstance(node, cst.Name):
+            return self.find_base_name(node.value) in self.introspection_rules_objects
+        return False
+
+    def _resolve_starred_element(self, element: cst.StarredElement):
+        resolved = self.resolve_expression(element.value)
+        match resolved:
+            case cst.List():
+                return self.resolve_list_literal(resolved)
+        return [element]
+
+    def _resolve_list_element(self, element: cst.BaseElement):
+        match element:
+            case cst.Element():
+                return [self.resolve_expression(element.value)]
+            case cst.StarredElement():
+                return self._resolve_starred_element(element)
+        return []
+
+    def resolve_list_literal(self, list_literal: cst.List):
+        """
+        Returns an iterable of all the elements of that list resolved. It will recurse into starred elements whenever possible.
+        """
+        return chain.from_iterable(
+            map(self._resolve_list_element, list_literal.elements)
+        )
+
+    def _resolve_starred_dict_element(self, element: cst.StarredDictElement):
+        resolved = self.resolve_expression(element.value)
+        match resolved:
+            case cst.Dict():
+                return self.resolve_dict(resolved)
+        return dict()
+
+    def _resolve_dict_element(self, element: cst.BaseDictElement):
+        match element:
+            case cst.StarredDictElement():
+                return self._resolve_starred_dict_element(element)
+            case _:
+                resolved_key = self.resolve_expression(element.key)
+                resolved_key_value = resolved_key
+                match resolved_key:
+                    case cst.SimpleString():
+                        resolved_key_value = resolved_key.raw_value
+                resolved_value = self.resolve_expression(element.value)
+                return {resolved_key_value: resolved_value}
+
+    def resolve_dict(self, dictionary: cst.Dict):
+        compilation = dict()
+        for e in dictionary.elements:
+            compilation.update(self._resolve_dict_element(e))
+        return compilation
+
+    def resolve_keyword_args(self, call: cst.Call):
+        """
+        Returns a dict with all the keyword arguments resolved. It will recurse into starred elements whenever possible.
+        """
+        keyword_to_expr_dict: dict = dict()
+        for arg in call.args:
+            if arg.star == "**":
+                resolved = self.resolve_expression(arg.value)
+                match resolved:
+                    case cst.Dict():
+                        keyword_to_expr_dict |= self.resolve_dict(resolved)
+            if arg.keyword:
+                keyword_to_expr_dict |= {
+                    arg.keyword.value: self.resolve_expression(arg.value)
+                }
+        return keyword_to_expr_dict
+
+
+DisableGraphQLIntrospection = CoreCodemod(
+    metadata=Metadata(
+        name="disable-graphql-introspection",
+        summary="",
+        review_guidance=ReviewGuidance.MERGE_AFTER_REVIEW,
+        references=[
+            Reference(
+                url="https://owasp.org/Top10/A05_2021-Security_Misconfiguration/",
+            ),
+            Reference(
+                url="https://owasp.org/www-project-top-ten/2017/A3_2017-Sensitive_Data_Exposure",
+            ),
+            Reference(
+                url="https://owasp.org/www-project-web-security-testing-guide/v42/4-Web_Application_Security_Testing/12-API_Testing/01-Testing_GraphQL#introspection-queries",
+            ),
+        ],
+    ),
+    transformer=LibcstTransformerPipeline(DisableGraphQLIntrospectionTransform),
+    detector=None,
+)

--- a/src/core_codemods/disable_graphql_introspection.py
+++ b/src/core_codemods/disable_graphql_introspection.py
@@ -23,7 +23,7 @@ class DisableGraphQLIntrospectionTransform(
         tree.visit(visitor)
         all_changes: dict[cst.CSTNode, ReplacementNodeType] = {}
         for call, changes in visitor.calls_to_change.items():
-            if self.node_is_selected(call):
+            if self.node_is_selected(call.func) or self.node_is_selected(call):
                 all_changes |= changes
                 self.report_change(call)
         if all_changes:

--- a/src/core_codemods/disable_graphql_introspection.py
+++ b/src/core_codemods/disable_graphql_introspection.py
@@ -1,5 +1,3 @@
-from itertools import chain
-
 import libcst as cst
 from libcst.codemod import CodemodContext, ContextAwareVisitor
 
@@ -112,72 +110,6 @@ class FindGraphQLViewsWithIntrospection(
         if isinstance(node, cst.Name):
             return self.find_base_name(node.value) in self.introspection_rules_objects
         return False
-
-    def _resolve_starred_element(self, element: cst.StarredElement):
-        resolved = self.resolve_expression(element.value)
-        match resolved:
-            case cst.List():
-                return self.resolve_list_literal(resolved)
-        return [element]
-
-    def _resolve_list_element(self, element: cst.BaseElement):
-        match element:
-            case cst.Element():
-                return [self.resolve_expression(element.value)]
-            case cst.StarredElement():
-                return self._resolve_starred_element(element)
-        return []
-
-    def resolve_list_literal(self, list_literal: cst.List):
-        """
-        Returns an iterable of all the elements of that list resolved. It will recurse into starred elements whenever possible.
-        """
-        return chain.from_iterable(
-            map(self._resolve_list_element, list_literal.elements)
-        )
-
-    def _resolve_starred_dict_element(self, element: cst.StarredDictElement):
-        resolved = self.resolve_expression(element.value)
-        match resolved:
-            case cst.Dict():
-                return self.resolve_dict(resolved)
-        return dict()
-
-    def _resolve_dict_element(self, element: cst.BaseDictElement):
-        match element:
-            case cst.StarredDictElement():
-                return self._resolve_starred_dict_element(element)
-            case _:
-                resolved_key = self.resolve_expression(element.key)
-                resolved_key_value = resolved_key
-                match resolved_key:
-                    case cst.SimpleString():
-                        resolved_key_value = resolved_key.raw_value
-                resolved_value = self.resolve_expression(element.value)
-                return {resolved_key_value: resolved_value}
-
-    def resolve_dict(self, dictionary: cst.Dict):
-        compilation = dict()
-        for e in dictionary.elements:
-            compilation.update(self._resolve_dict_element(e))
-        return compilation
-
-    def resolve_keyword_args(self, call: cst.Call):
-        """
-        Returns a dict with all the keyword arguments resolved. It will recurse into starred elements whenever possible.
-        """
-        keyword_to_expr_dict: dict = dict()
-        for arg in call.args:
-            if arg.star == "**":
-                resolved = self.resolve_expression(arg.value)
-                match resolved:
-                    case cst.Dict():
-                        keyword_to_expr_dict |= self.resolve_dict(resolved)
-            if arg.keyword:
-                keyword_to_expr_dict |= {
-                    arg.keyword.value: self.resolve_expression(arg.value)
-                }
-        return keyword_to_expr_dict
 
 
 DisableGraphQLIntrospection = CoreCodemod(

--- a/src/core_codemods/disable_graphql_introspection.py
+++ b/src/core_codemods/disable_graphql_introspection.py
@@ -115,7 +115,7 @@ class FindGraphQLViewsWithIntrospection(
 DisableGraphQLIntrospection = CoreCodemod(
     metadata=Metadata(
         name="disable-graphql-introspection",
-        summary="Adds rule to disable introspection",
+        summary="Disable GraphQL Introspection to Prevent Sensitive Data Leakage",
         review_guidance=ReviewGuidance.MERGE_AFTER_REVIEW,
         references=[
             Reference(

--- a/src/core_codemods/disable_graphql_introspection.py
+++ b/src/core_codemods/disable_graphql_introspection.py
@@ -16,6 +16,8 @@ class DisableGraphQLIntrospectionTransform(
     LibcstResultTransformer, NameAndAncestorResolutionMixin
 ):
 
+    change_description = "Added rule to disable introspection"
+
     def transform_module_impl(self, tree: cst.Module) -> cst.Module:
         visitor = FindGraphQLViewsWithIntrospection(self.context)
         tree.visit(visitor)
@@ -67,7 +69,6 @@ class FindGraphQLViewsWithIntrospection(
                 match resolved:
                     case cst.List():
                         # does it have any introspection rule
-                        print(list(self.resolve_list_literal(resolved)))
                         if not any(
                             filter(
                                 lambda e: self._is_introspection_rule_or_starred(e),
@@ -106,16 +107,15 @@ class FindGraphQLViewsWithIntrospection(
         # Does it have a starred element?
         if isinstance(node, cst.StarredElement):
             return True
-        print(node)
         if isinstance(node, cst.Name):
-            return self.find_base_name(node.value) in self.introspection_rules_objects
+            return self.find_base_name(node) in self.introspection_rules_objects
         return False
 
 
 DisableGraphQLIntrospection = CoreCodemod(
     metadata=Metadata(
         name="disable-graphql-introspection",
-        summary="",
+        summary="Adds rule to disable introspection",
         review_guidance=ReviewGuidance.MERGE_AFTER_REVIEW,
         references=[
             Reference(

--- a/src/core_codemods/docs/pixee_python_disable-graphql-introspection.md
+++ b/src/core_codemods/docs/pixee_python_disable-graphql-introspection.md
@@ -1,0 +1,31 @@
+Introspection allows a client to query the schema of a GraphQL API. Allowing introspection in production code may allow a malicious user to gather information about data types and operations for a potential attack.
+
+Introspection is often enabled by default in GraphQL without authentication. This codemod disables introspection altogether at the view level by introducing a validation rule for that. The rules used may be dependent on the framework used. Please check your framework documentation for specific rules for disabling introspection.
+
+Our changes look something like this:
+```diff
+from graphql_server.flask import GraphQLView
+from flask import Flask
+from graphql import (
+    GraphQLSchema, GraphQLObjectType, GraphQLField, GraphQLString)
++from graphql.validation import NoSchemaIntrospectionCustomRule
+
+schema = GraphQLSchema(
+    query=GraphQLObjectType(
+        name='RootQueryType',
+        fields={
+            'hello': GraphQLField(
+                GraphQLString,
+                resolve=lambda obj, info: 'world')
+        }))
+
+app = Flask(__name__)
+
+app.add_url_rule("/api",
+    view_func=GraphQLView.as_view(  # Noncompliant
+        name="api",
+        schema=schema,
++       validation_rules = [NoSchemaIntrospectionCustomRule]
+    ),
+)
+```

--- a/src/core_codemods/docs/pixee_python_disable-graphql-introspection.md
+++ b/src/core_codemods/docs/pixee_python_disable-graphql-introspection.md
@@ -1,6 +1,6 @@
 Introspection allows a client to query the schema of a GraphQL API. Allowing introspection in production code may allow a malicious user to gather information about data types and operations for a potential attack.
 
-Introspection is often enabled by default in GraphQL without authentication. This codemod disables introspection altogether at the view level by introducing a validation rule for that. The rules used may be dependent on the framework used. Please check your framework documentation for specific rules for disabling introspection.
+Introspection is often enabled by default in GraphQL without authentication. This codemod disables introspection altogether at the view level by introducing a validation rule. The required rules may be dependent on the framework that you are using. Please check your framework documentation for specific rules for disabling introspection.
 
 Our changes look something like this:
 ```diff

--- a/src/core_codemods/docs/pixee_python_remove-debug-breakpoint.md
+++ b/src/core_codemods/docs/pixee_python_remove-debug-breakpoint.md
@@ -2,6 +2,8 @@ This codemod removes any calls to `breakpoint()` or `pdb.set_trace()` which are 
 
 In most cases if these calls are included in committed code, they were left there by mistake and indicate a potential problem.
 
+Our changes look something like this:
+
 ```diff
  print("hello")
 - breakpoint()

--- a/src/core_codemods/sonar/sonar_disable_graphql_introspection.py
+++ b/src/core_codemods/sonar/sonar_disable_graphql_introspection.py
@@ -1,0 +1,10 @@
+from core_codemods.disable_graphql_introspection import DisableGraphQLIntrospection
+from core_codemods.sonar.api import SonarCodemod
+
+SonarDisableGraphQLIntrospection = SonarCodemod.from_core_codemod(
+    name="disable-graphql-introspection-S6786",
+    other=DisableGraphQLIntrospection,
+    rule_id="python:S6786",
+    rule_name="GraphQL introspection should be disabled in production",
+    rule_url="https://rules.sonarsource.com/python/RSPEC-6786/",
+)

--- a/tests/codemods/sonar/test_sonar_disable_graphql_introspection.py
+++ b/tests/codemods/sonar/test_sonar_disable_graphql_introspection.py
@@ -1,0 +1,61 @@
+import json
+
+from codemodder.codemods.test import BaseSASTCodemodTest
+from core_codemods.sonar.sonar_disable_graphql_introspection import (
+    SonarDisableGraphQLIntrospection,
+)
+
+
+class TestSonarDisableGraphQLIntrospection(BaseSASTCodemodTest):
+    codemod = SonarDisableGraphQLIntrospection
+    tool = "sonar"
+
+    def test_name(self):
+        assert self.codemod.name == "disable-graphql-introspection-S6786"
+
+    def test_simple(self, tmpdir):
+        input_code = """
+        from graphql_server.flask import GraphQLView
+        from flask import Flask
+        from .schemas import schema
+
+        app = Flask(__name__)
+
+        app.add_url_rule("/api",
+            view_func=GraphQLView.as_view(
+                name="api",
+                schema=schema,
+            ),
+        )
+        """
+        expected = """
+        from graphql_server.flask import GraphQLView
+        from flask import Flask
+        from .schemas import schema
+        from graphql.validation import NoSchemaIntrospectionCustomRule
+
+        app = Flask(__name__)
+
+        app.add_url_rule("/api",
+            view_func=GraphQLView.as_view(
+                name="api",
+                schema=schema,
+            validation_rules = [NoSchemaIntrospectionCustomRule,]),
+        )
+        """
+        issues = {
+            "issues": [
+                {
+                    "rule": "python:S6786",
+                    "status": "OPEN",
+                    "component": "code.py",
+                    "textRange": {
+                        "startLine": 9,
+                        "endLine": 9,
+                        "startOffset": 14,
+                        "endOffset": 33,
+                    },
+                }
+            ]
+        }
+        self.run_and_assert(tmpdir, input_code, expected, results=json.dumps(issues))

--- a/tests/codemods/test_disable_graphql_introspection.py
+++ b/tests/codemods/test_disable_graphql_introspection.py
@@ -1,0 +1,192 @@
+import pytest
+
+from codemodder.codemods.test import BaseCodemodTest
+from core_codemods.disable_graphql_introspection import DisableGraphQLIntrospection
+
+
+class TestDisableGraphQLIntrospection(BaseCodemodTest):
+    codemod = DisableGraphQLIntrospection
+
+    def test_name(self):
+        assert self.codemod.name == "disable-graphql-introspection"
+
+    def test_simple_flask(self, tmpdir):
+        input_code = """
+        from graphql_server.flask import GraphQLView
+        from flask import Flask
+        from .schemas import schema
+
+        app = Flask(__name__)
+
+        app.add_url_rule("/api",
+            view_func=GraphQLView.as_view(
+                name="api",
+                schema=schema,
+            ),
+        )
+        """
+        expected = """
+        from graphql_server.flask import GraphQLView
+        from flask import Flask
+        from .schemas import schema
+        from graphql.validation import NoSchemaIntrospectionCustomRule
+
+        app = Flask(__name__)
+
+        app.add_url_rule("/api",
+            view_func=GraphQLView.as_view(
+                name="api",
+                schema=schema,
+            validation_rules = [NoSchemaIntrospectionCustomRule,]),
+        )
+        """
+        self.run_and_assert(tmpdir, input_code, expected)
+
+    @pytest.mark.parametrize(
+        "module",
+        [
+            "graphql_server.flask",
+            "graphql_server.sanic",
+            "graphql_server.aiohttp",
+            "graphql_server.webob",
+        ],
+    )
+    def test_simple_constructor(self, tmpdir, module):
+        input_code = f"""
+        from {module} import GraphQLView
+        from flask import Flask
+        from .schemas import schema
+
+        GraphQLView(
+            name="api",
+            schema=schema,
+        )
+        """
+        expected = f"""
+        from {module} import GraphQLView
+        from flask import Flask
+        from .schemas import schema
+        from graphql.validation import NoSchemaIntrospectionCustomRule
+
+        GraphQLView(
+            name="api",
+            schema=schema,
+        validation_rules = [NoSchemaIntrospectionCustomRule,])
+        """
+        self.run_and_assert(tmpdir, input_code, expected)
+
+    def test_add_indirect(self, tmpdir):
+        input_code = """
+        from graphql_server.flask import GraphQLView
+        from flask import Flask
+        from .schemas import schema
+
+        validation_rules = []
+        GraphQLView(
+            name="api",
+            schema=schema,
+            validation_rules = validation_rules,
+        )
+        """
+        expected = """
+        from graphql_server.flask import GraphQLView
+        from flask import Flask
+        from .schemas import schema
+        from graphql.validation import NoSchemaIntrospectionCustomRule
+
+        validation_rules = [NoSchemaIntrospectionCustomRule]
+        GraphQLView(
+            name="api",
+            schema=schema,
+            validation_rules = validation_rules,
+        )
+        """
+        self.run_and_assert(tmpdir, input_code, expected)
+
+    def test_add_list_double_indirect(self, tmpdir):
+        input_code = """
+        from graphql_server.flask import GraphQLView
+        from flask import Flask
+        from .schemas import schema
+
+        validation_rules = []
+        GraphQLView(
+            name="api",
+            schema=schema,
+            validation_rules = [*validation_rules],
+        )
+        """
+        expected = """
+        from graphql_server.flask import GraphQLView
+        from flask import Flask
+        from .schemas import schema
+        from graphql.validation import NoSchemaIntrospectionCustomRule
+
+        validation_rules = []
+        GraphQLView(
+            name="api",
+            schema=schema,
+            validation_rules = [*validation_rules, NoSchemaIntrospectionCustomRule],
+        )
+        """
+        self.run_and_assert(tmpdir, input_code, expected)
+
+    def test_add_dict_indirect(self, tmpdir):
+        input_code = """
+        from graphql_server.flask import GraphQLView
+        from flask import Flask
+        from .schemas import schema
+
+        validation_rules = []
+        kwargs = {'validation_rules' : validation_rules}
+        GraphQLView(
+            name="api",
+            schema=schema,
+            **kwargs,
+        )
+        """
+        expected = """
+        from graphql_server.flask import GraphQLView
+        from flask import Flask
+        from .schemas import schema
+        from graphql.validation import NoSchemaIntrospectionCustomRule
+
+        validation_rules = [NoSchemaIntrospectionCustomRule]
+        kwargs = {'validation_rules' : validation_rules}
+        GraphQLView(
+            name="api",
+            schema=schema,
+            **kwargs,
+        )
+        """
+        self.run_and_assert(tmpdir, input_code, expected)
+
+    def test_has_validation_rule(self, tmpdir):
+        input_code = """
+        from graphql_server.flask import GraphQLView
+        from flask import Flask
+        from .schemas import schema
+        from graphql.validation import NoSchemaIntrospectionCustomRule
+
+        GraphQLView(
+            name="api",
+            schema=schema,
+            validation_rules = [NoSchemaIntrospectionCustomRule],
+        )
+        """
+        self.run_and_assert(tmpdir, input_code, input_code)
+
+    def test_has_graphene_validation_rule(self, tmpdir):
+        input_code = """
+        from graphql_server.flask import GraphQLView
+        from flask import Flask
+        from .schemas import schema
+        from graphene.validation import DisableIntrospection
+
+        GraphQLView(
+            name="api",
+            schema=schema,
+            validation_rules = [DisableIntrospection],
+        )
+        """
+        self.run_and_assert(tmpdir, input_code, input_code)

--- a/tests/samples/disable_graphql_introspection.py
+++ b/tests/samples/disable_graphql_introspection.py
@@ -1,0 +1,22 @@
+from graphql_server.flask import GraphQLView
+from flask import Flask
+from graphql import (
+    GraphQLSchema, GraphQLObjectType, GraphQLField, GraphQLString)
+
+schema = GraphQLSchema(
+    query=GraphQLObjectType(
+        name='RootQueryType',
+        fields={
+            'hello': GraphQLField(
+                GraphQLString,
+                resolve=lambda obj, info: 'world')
+        }))
+
+app = Flask(__name__)
+
+app.add_url_rule("/api",
+    view_func=GraphQLView.as_view(
+        name="api",
+        schema=schema,
+    ),
+)

--- a/tests/samples/sonar_issues.json
+++ b/tests/samples/sonar_issues.json
@@ -1,15 +1,51 @@
 {
-  "total": 43,
+  "total": 44,
   "p": 1,
   "ps": 500,
   "paging": {
     "pageIndex": 1,
     "pageSize": 500,
-    "total": 170
+    "total": 171
   },
-  "effortTotal": 1050,
-  "debtTotal": 1050,
+  "effortTotal": 1110,
+  "debtTotal": 1110,
   "issues": [
+    {
+      "key": "AY9OF405h-JU-nc_LHoK",
+      "rule": "python:S6786",
+      "severity": "MAJOR",
+      "component": "pixee_codemodder-python:disable_graphql_introspection.py",
+      "project": "pixee_codemodder-python",
+      "line": 18,
+      "hash": "9c3e253c0724553f5a6121109c75b44a",
+      "textRange": {
+        "startLine": 18,
+        "endLine": 18,
+        "startOffset": 14,
+        "endOffset": 33
+      },
+      "flows": [],
+      "status": "OPEN",
+      "message": "Disable introspection on this \"GraphQL\" server endpoint.",
+      "effort": "1h",
+      "debt": "1h",
+      "tags": [
+        "cwe"
+      ],
+      "creationDate": "2024-05-06T15:27:53+0200",
+      "updateDate": "2024-05-06T15:28:15+0200",
+      "type": "VULNERABILITY",
+      "organization": "pixee",
+      "pullRequest": "542",
+      "cleanCodeAttribute": "TRUSTWORTHY",
+      "cleanCodeAttributeCategory": "RESPONSIBLE",
+      "impacts": [
+        {
+          "softwareQuality": "SECURITY",
+          "severity": "MEDIUM"
+        }
+      ]
+    },
     {
       "key": "AY5_zeRwqkyzjj5fBCfH",
       "rule": "python:S5719",
@@ -1934,6 +1970,27 @@
     }
   ],
   "components": [
+    {
+      "organization": "pixee",
+      "key": "pixee_codemodder-python",
+      "uuid": "AY9OFy2CQktd1_0m0s0M",
+      "enabled": true,
+      "qualifier": "TRK",
+      "name": "codemodder-python",
+      "longName": "codemodder-python",
+      "pullRequest": "542"
+    },
+    {
+      "organization": "pixee",
+      "key": "pixee_codemodder-python:disable_graphql_introspection.py",
+      "uuid": "AY9OF4qsh-JU-nc_LHla",
+      "enabled": true,
+      "qualifier": "FIL",
+      "name": "disable_graphql_introspection.py",
+      "longName": "disable_graphql_introspection.py",
+      "path": "disable_graphql_introspection.py",
+      "pullRequest": "542"
+    },
     {
       "organization": "pixee",
       "key": "pixee_codemodder-python:tests/project_analysis/file_parsers/test_pyproject_toml_file_parser.py",

--- a/tests/test_resolve_expressions.py
+++ b/tests/test_resolve_expressions.py
@@ -1,0 +1,144 @@
+from textwrap import dedent
+
+import libcst as cst
+from libcst.codemod import Codemod, CodemodContext
+
+from codemodder.codemods.utils_mixin import NameAndAncestorResolutionMixin
+
+
+class TestResolveExpression:
+    def test_resolve_expression_transitive(self):
+        class TestCodemod(Codemod, NameAndAncestorResolutionMixin):
+            def transform_module_impl(self, tree: cst.Module) -> cst.Module:
+                stmt = cst.ensure_type(tree.body[-1], cst.SimpleStatementLine)
+                expr = cst.ensure_type(stmt.body[0], cst.Expr)
+                node = expr.value
+
+                first_stmt = cst.ensure_type(tree.body[0], cst.SimpleStatementLine)
+                assign = cst.ensure_type(first_stmt.body[0], cst.Assign)
+
+                resolved = self.resolve_expression(node)
+                assert resolved == assign.value
+                return tree
+
+        input_code = dedent(
+            """\
+        b = 'resolved'
+        a = b
+        name = a
+        name
+        """
+        )
+        tree = cst.parse_module(input_code)
+        TestCodemod(CodemodContext()).transform_module(tree)
+
+    def test_resolve_expression_imported_name(self):
+        class TestCodemod(Codemod, NameAndAncestorResolutionMixin):
+            def transform_module_impl(self, tree: cst.Module) -> cst.Module:
+                stmt = cst.ensure_type(tree.body[-1], cst.SimpleStatementLine)
+                expr = cst.ensure_type(stmt.body[0], cst.Expr)
+                node = expr.value
+
+                second_stmt = cst.ensure_type(tree.body[1], cst.SimpleStatementLine)
+                assign = cst.ensure_type(second_stmt.body[0], cst.Assign)
+
+                resolved = self.resolve_expression(node)
+                assert resolved == assign.value
+                return tree
+
+        input_code = dedent(
+            """\
+        from x import y
+        a = y
+        name = a
+        name
+        """
+        )
+        tree = cst.parse_module(input_code)
+        TestCodemod(CodemodContext()).transform_module(tree)
+
+    def test_not_resolved_idempotent(self):
+        class TestCodemod(Codemod, NameAndAncestorResolutionMixin):
+            def transform_module_impl(self, tree: cst.Module) -> cst.Module:
+                stmt = cst.ensure_type(tree.body[-1], cst.SimpleStatementLine)
+                expr = cst.ensure_type(stmt.body[0], cst.Expr)
+                node = expr.value
+
+                resolved = self.resolve_expression(node)
+                assert resolved == node
+                return tree
+
+        input_code = dedent(
+            """\
+        print('unresolved')
+        """
+        )
+        tree = cst.parse_module(input_code)
+        TestCodemod(CodemodContext()).transform_module(tree)
+
+    def test_resolve_list_literal(self):
+        class TestCodemod(Codemod, NameAndAncestorResolutionMixin):
+            def transform_module_impl(self, tree: cst.Module) -> cst.Module:
+                stmt = cst.ensure_type(tree.body[-1], cst.SimpleStatementLine)
+                expr = cst.ensure_type(stmt.body[0], cst.Expr)
+                node = cst.ensure_type(expr.value, cst.List)
+
+                first = cst.ensure_type(
+                    cst.ensure_type(tree.body[3], cst.SimpleStatementLine).body[0],
+                    cst.Assign,
+                ).value
+                second = node.elements[1].value
+                third = cst.ensure_type(
+                    cst.ensure_type(tree.body[1], cst.SimpleStatementLine).body[0],
+                    cst.Assign,
+                ).value
+                fourth = node.elements[-1]
+
+                resolved = list(self.resolve_list_literal(node))
+                assert resolved == [first, second, third, fourth]
+                return tree
+
+        input_code = dedent(
+            """\
+        from somewhere import unresolved
+        third = 'third'
+        rest = [third]
+        first = 'first'
+        [first, 'second', *rest, *unresolved]
+        """
+        )
+        tree = cst.parse_module(input_code)
+        TestCodemod(CodemodContext()).transform_module(tree)
+
+    def test_resolve_dict_literal(self):
+        class TestCodemod(Codemod, NameAndAncestorResolutionMixin):
+            def transform_module_impl(self, tree: cst.Module) -> cst.Module:
+                stmt = cst.ensure_type(tree.body[-1], cst.SimpleStatementLine)
+                expr = cst.ensure_type(stmt.body[0], cst.Expr)
+                node = cst.ensure_type(expr.value, cst.Dict)
+
+                first = cst.ensure_type(
+                    cst.ensure_type(tree.body[3], cst.SimpleStatementLine).body[0],
+                    cst.Assign,
+                ).value
+                second = node.elements[1].value
+                third = cst.ensure_type(
+                    cst.ensure_type(tree.body[1], cst.SimpleStatementLine).body[0],
+                    cst.Assign,
+                ).value
+
+                resolved = self.resolve_dict(node)
+                assert resolved == {"1": first, "2": second, "3": third}
+                return tree
+
+        input_code = dedent(
+            """\
+        from somewhere import unresolved
+        third = 'third'
+        rest = {'3':third}
+        first = 'first'
+        {'1':first, '2':'second', **rest, **unresolved}
+        """
+        )
+        tree = cst.parse_module(input_code)
+        TestCodemod(CodemodContext()).transform_module(tree)

--- a/tests/test_resolve_expressions.py
+++ b/tests/test_resolve_expressions.py
@@ -127,8 +127,28 @@ class TestResolveExpression:
                     cst.Assign,
                 ).value
 
+                first_key = node.elements[0].key
+                second_key = node.elements[1].key
+                third_key = (
+                    cst.ensure_type(
+                        cst.ensure_type(
+                            cst.ensure_type(tree.body[2], cst.SimpleStatementLine).body[
+                                0
+                            ],
+                            cst.Assign,
+                        ).value,
+                        cst.Dict,
+                    )
+                    .elements[0]
+                    .key
+                )
+
                 resolved = self.resolve_dict(node)
-                assert resolved == {"1": first, "2": second, "3": third}
+                assert resolved == {
+                    first_key: first,
+                    second_key: second,
+                    third_key: third,
+                }
                 return tree
 
         input_code = dedent(


### PR DESCRIPTION
## Overview
Adds a codemod that introduces a rule to disable introspection for GraphQL views. Includes Sonar version.

Closes #369