### PR TITLE
parse codeql results without region

### DIFF
--- a/tests/test_codeql.py
+++ b/tests/test_codeql.py
@@ -8,13 +8,19 @@ from codemodder.codeql import CodeQLResultSet
 class TestCodeQLResultSet(TestCase):
 
     def test_from_sarif(self):
-        # Given a SARIF file with known content
         sarif_content = {
             "runs": [
                 {
                     "tool": {
                         "driver": {"name": "CodeQL"},
-                        "extensions": [{"rules": [{"id": "python/sql-injection"}]}],
+                        "extensions": [
+                            {
+                                "rules": [
+                                    {"id": "python/sql-injection"},
+                                    {"id": "cs/web/missing-x-frame-options"},
+                                ]
+                            },
+                        ],
                     },
                     "results": [
                         {
@@ -37,7 +43,28 @@ class TestCodeQLResultSet(TestCase):
                                 "toolComponent": {"index": 0},
                                 "index": 0,
                             },
-                        }
+                        },
+                        {
+                            "ruleId": "cs/web/missing-x-frame-options",
+                            "message": {
+                                "text": "Configuration file is missing the X-Frame-Options setting."
+                            },
+                            "locations": [
+                                {
+                                    "physicalLocation": {
+                                        "artifactLocation": {
+                                            "index": 5,
+                                            "uri": "Web.config",
+                                        }
+                                    }
+                                }
+                            ],
+                            "rule": {
+                                "id": "cs/web/missing-x-frame-options",
+                                "toolComponent": {"index": 0},
+                                "index": 1,
+                            },
+                        },
                     ],
                 }
             ]
@@ -46,44 +73,62 @@ class TestCodeQLResultSet(TestCase):
         with mock.patch(
             "builtins.open", mock.mock_open(read_data=json.dumps(sarif_content))
         ):
-            # When parsing the SARIF file
             result_set = CodeQLResultSet.from_sarif(sarif_file)
 
-            # Then the result set should contain the expected results
-            self.assertEqual(len(result_set), 1)
+            self.assertEqual(len(result_set), 2)
             self.assertIn("python/sql-injection", result_set)
-            self.assertEqual(len(result_set["python/sql-injection"]), 1)
+            self.assertIn("cs/web/missing-x-frame-options", result_set)
+
+            sql_result = result_set["python/sql-injection"]
+            self.assertEqual(len(sql_result), 1)
             self.assertEqual(
-                result_set["python/sql-injection"][Path("example.py")][0].rule_id,
+                sql_result[Path("example.py")][0].rule_id,
                 "python/sql-injection",
             )
             self.assertEqual(
-                result_set["python/sql-injection"][Path("example.py")][0]
-                .locations[0]
-                .file,
+                sql_result[Path("example.py")][0].locations[0].file,
                 Path("example.py"),
             )
             self.assertEqual(
-                result_set["python/sql-injection"][Path("example.py")][0]
-                .locations[0]
-                .start.line,
+                sql_result[Path("example.py")][0].locations[0].start.line,
                 10,
             )
             self.assertEqual(
-                result_set["python/sql-injection"][Path("example.py")][0]
-                .locations[0]
-                .start.column,
+                sql_result[Path("example.py")][0].locations[0].start.column,
                 5,
             )
             self.assertEqual(
-                result_set["python/sql-injection"][Path("example.py")][0]
-                .locations[0]
-                .end.line,
+                sql_result[Path("example.py")][0].locations[0].end.line,
                 10,
             )
             self.assertEqual(
-                result_set["python/sql-injection"][Path("example.py")][0]
-                .locations[0]
-                .end.column,
+                sql_result[Path("example.py")][0].locations[0].end.column,
                 20,
+            )
+
+            xframe_result = result_set["cs/web/missing-x-frame-options"]
+            self.assertEqual(len(xframe_result), 1)
+            self.assertEqual(
+                xframe_result[Path("Web.config")][0].rule_id,
+                "cs/web/missing-x-frame-options",
+            )
+            self.assertEqual(
+                xframe_result[Path("Web.config")][0].locations[0].file,
+                Path("Web.config"),
+            )
+            self.assertEqual(
+                xframe_result[Path("Web.config")][0].locations[0].start.line,
+                0,
+            )
+            self.assertEqual(
+                xframe_result[Path("Web.config")][0].locations[0].start.column,
+                -1,
+            )
+            self.assertEqual(
+                xframe_result[Path("Web.config")][0].locations[0].end.line,
+                0,
+            )
+            self.assertEqual(
+                xframe_result[Path("Web.config")][0].locations[0].end.column,
+                -1,
             )


### PR DESCRIPTION
## Overview
*Support parsing codeql results that don't have a region*

## Description

A codeql result [like this one](https://github.com/pixee/ClassicWebGoat.NET/security/code-scanning/5) applies to the entire file. In these cases, the result doesn't have a "region" key and information about start/end line and column.
