### PR TITLE
Report unfixed when parsing/transforming errors

### DIFF
--- a/src/codemodder/codemods/libcst_transformer.py
+++ b/src/codemodder/codemods/libcst_transformer.py
@@ -264,17 +264,20 @@ class LibcstTransformerPipeline(BaseTransformerPipeline):
                     source_tree = cst.parse_module(f.read())
         except Exception:
             file_context.add_failure(file_path)
+            if context.fixing_tool_results:
+                file_context.report_unfixed_for_file(reason="parsing file")
             logger.exception("error parsing file %s", file_path)
             return None
 
         tree = source_tree
-
         try:
             with file_context.timer.measure("transform"):
                 for transformer in self.transformers:
                     tree = transformer.transform(tree, results, file_context)
         except Exception:
             file_context.add_failure(file_path)
+            if context.fixing_tool_results:
+                file_context.report_unfixed_for_file(reason="transforming file")
             logger.exception("error transforming file %s", file_path)
             return None
 

--- a/src/codemodder/codemods/libcst_transformer.py
+++ b/src/codemodder/codemods/libcst_transformer.py
@@ -263,10 +263,8 @@ class LibcstTransformerPipeline(BaseTransformerPipeline):
                 with open(file_path, "r", encoding="utf-8") as f:
                     source_tree = cst.parse_module(f.read())
         except Exception:
-            file_context.add_failure(file_path)
-            if context.fixing_tool_results:
-                file_context.report_unfixed_for_file(reason="parsing file")
-            logger.exception("error parsing file %s", file_path)
+            file_context.add_failure(file_path, reason := "Failed to parse file")
+            logger.exception("%s %s", reason, file_path)
             return None
 
         tree = source_tree
@@ -275,10 +273,8 @@ class LibcstTransformerPipeline(BaseTransformerPipeline):
                 for transformer in self.transformers:
                     tree = transformer.transform(tree, results, file_context)
         except Exception:
-            file_context.add_failure(file_path)
-            if context.fixing_tool_results:
-                file_context.report_unfixed_for_file(reason="transforming file")
-            logger.exception("error transforming file %s", file_path)
+            file_context.add_failure(file_path, reason := "Failed to transform file")
+            logger.exception("%s %s", reason, file_path)
             return None
 
         if not file_context.codemod_changes:

--- a/src/codemodder/context.py
+++ b/src/codemodder/context.py
@@ -77,6 +77,7 @@ class CodemodExecutionContext:
         self.path_exclude = path_exclude
         self.max_workers = max_workers
         self.tool_result_files_map = tool_result_files_map or {}
+        self.fixing_tool_results = bool(self.tool_result_files_map)
         self.llm_client = self._setup_llm_client()
 
     def _setup_llm_client(self) -> Client | None:

--- a/src/codemodder/context.py
+++ b/src/codemodder/context.py
@@ -77,7 +77,6 @@ class CodemodExecutionContext:
         self.path_exclude = path_exclude
         self.max_workers = max_workers
         self.tool_result_files_map = tool_result_files_map or {}
-        self.fixing_tool_results = bool(self.tool_result_files_map)
         self.llm_client = self._setup_llm_client()
 
     def _setup_llm_client(self) -> Client | None:

--- a/src/codemodder/file_context.py
+++ b/src/codemodder/file_context.py
@@ -58,3 +58,13 @@ class FileContext:
             )
             and result.finding is not None
         ]
+
+    def get_all_findings(self):
+        return [
+            result.finding
+            for result in (self.results or [])
+            if result.finding is not None
+        ]
+
+    def report_unfixed_for_file(self, reason: str):
+        self.add_unfixed_findings(self.get_all_findings(), reason, 0)

--- a/src/codemodder/file_context.py
+++ b/src/codemodder/file_context.py
@@ -31,8 +31,9 @@ class FileContext:
     def add_changeset(self, result: ChangeSet):
         self.changesets.append(result)
 
-    def add_failure(self, filename: Path):
+    def add_failure(self, filename: Path, reason: str):
         self.failures.append(filename)
+        self.add_unfixed_findings(self.get_all_findings(), reason, 0)
 
     def add_unfixed_findings(
         self, findings: list[Finding], reason: str, line_number: int | None = None
@@ -65,6 +66,3 @@ class FileContext:
             for result in (self.results or [])
             if result.finding is not None
         ]
-
-    def report_unfixed_for_file(self, reason: str):
-        self.add_unfixed_findings(self.get_all_findings(), reason, 0)

--- a/tests/test_libcst_transformer.py
+++ b/tests/test_libcst_transformer.py
@@ -74,14 +74,14 @@ def test_parse_error(mocker, caplog):
     )
     transformer = mocker.MagicMock(spec=LibcstResultTransformer)
     _apply_and_assert(mocker, transformer)
-    assert "error parsing file" in caplog.text
+    assert "Failed to parse file" in caplog.text
 
 
 def test_transformer_error(mocker, caplog):
     transformer = mocker.MagicMock(spec=LibcstResultTransformer)
     transformer.transform.side_effect = ParserSyntaxError
     _apply_and_assert(mocker, transformer)
-    assert "error transforming file" in caplog.text
+    assert "Failed to transform file" in caplog.text
 
 
 def test_parse_error_with_tool(mocker, caplog):
@@ -90,12 +90,12 @@ def test_parse_error_with_tool(mocker, caplog):
         side_effect=ParserSyntaxError,
     )
     transformer = mocker.MagicMock(spec=LibcstResultTransformer)
-    _apply_and_assert_with_tool(mocker, transformer, "parsing file")
-    assert "error parsing file" in caplog.text
+    _apply_and_assert_with_tool(mocker, transformer, "Failed to parse file")
+    assert "Failed to parse file" in caplog.text
 
 
 def test_transformer_error_with_tool(mocker, caplog):
     transformer = mocker.MagicMock(spec=LibcstResultTransformer)
     transformer.transform.side_effect = ParserSyntaxError
-    _apply_and_assert_with_tool(mocker, transformer, "transforming file")
-    assert "error transforming file" in caplog.text
+    _apply_and_assert_with_tool(mocker, transformer, "Failed to transform file")
+    assert "Failed to transform file" in caplog.text

--- a/tests/test_libcst_transformer.py
+++ b/tests/test_libcst_transformer.py
@@ -4,6 +4,29 @@ from codemodder.codemods.libcst_transformer import (
     LibcstResultTransformer,
     LibcstTransformerPipeline,
 )
+from codemodder.context import CodemodExecutionContext
+from codemodder.file_context import FileContext
+
+
+def _apply_and_assert(mocker, transformer):
+    file_context = FileContext("home", mocker.MagicMock())
+    execution_context = CodemodExecutionContext(
+        directory=mocker.MagicMock(),
+        dry_run=True,
+        verbose=False,
+        registry=mocker.MagicMock(),
+        repo_manager=mocker.MagicMock(),
+        path_include=[],
+        path_exclude=[],
+    )
+    pipeline = LibcstTransformerPipeline(transformer)
+    pipeline.apply(
+        context=execution_context,
+        file_context=file_context,
+        results=None,
+    )
+    assert len(file_context.failures) == 1
+    assert file_context.unfixed_findings == []
 
 
 def test_parse_error(mocker, caplog):
@@ -11,32 +34,13 @@ def test_parse_error(mocker, caplog):
         "codemodder.codemods.libcst_transformer.cst.parse_module",
         side_effect=ParserSyntaxError,
     )
-
     transformer = mocker.MagicMock(spec=LibcstResultTransformer)
-    file_context = mocker.MagicMock()
-
-    pipeline = LibcstTransformerPipeline(transformer)
-    pipeline.apply(
-        context=mocker.MagicMock(),
-        file_context=file_context,
-        results=None,
-    )
-
-    file_context.add_failure.assert_called_once()
+    _apply_and_assert(mocker, transformer)
     assert "error parsing file" in caplog.text
 
 
 def test_transformer_error(mocker, caplog):
     transformer = mocker.MagicMock(spec=LibcstResultTransformer)
     transformer.transform.side_effect = ParserSyntaxError
-    file_context = mocker.MagicMock()
-
-    pipeline = LibcstTransformerPipeline(transformer)
-    pipeline.apply(
-        context=mocker.MagicMock(),
-        file_context=file_context,
-        results=None,
-    )
-
-    file_context.add_failure.assert_called_once()
+    _apply_and_assert(mocker, transformer)
     assert "error transforming file" in caplog.text

--- a/tests/test_libcst_transformer.py
+++ b/tests/test_libcst_transformer.py
@@ -6,6 +6,7 @@ from codemodder.codemods.libcst_transformer import (
 )
 from codemodder.context import CodemodExecutionContext
 from codemodder.file_context import FileContext
+from core_codemods.defectdojo.results import DefectDojoResult
 
 
 def _apply_and_assert(mocker, transformer):
@@ -29,6 +30,43 @@ def _apply_and_assert(mocker, transformer):
     assert file_context.unfixed_findings == []
 
 
+def _apply_and_assert_with_tool(mocker, transformer, reason):
+    file_path = mocker.MagicMock()
+    file_context = FileContext(
+        "home",
+        file_path,
+        results=[
+            DefectDojoResult.from_finding(
+                {
+                    "id": 1,
+                    "title": "python.django.security.audit.secure-cookies.django-secure-set-cookie",
+                    "file_path": file_path,
+                    "line": 2,
+                },
+            )
+        ],
+    )
+    execution_context = CodemodExecutionContext(
+        directory=mocker.MagicMock(),
+        dry_run=True,
+        verbose=False,
+        registry=mocker.MagicMock(),
+        repo_manager=mocker.MagicMock(),
+        path_include=[],
+        path_exclude=[],
+        tool_result_files_map={"sonar": ["results.json"]},
+    )
+    pipeline = LibcstTransformerPipeline(transformer)
+    pipeline.apply(
+        context=execution_context,
+        file_context=file_context,
+        results=None,
+    )
+    assert len(file_context.failures) == 1
+    assert len(file_context.unfixed_findings) == 1
+    assert file_context.unfixed_findings[0].reason == reason
+
+
 def test_parse_error(mocker, caplog):
     mocker.patch(
         "codemodder.codemods.libcst_transformer.cst.parse_module",
@@ -43,4 +81,21 @@ def test_transformer_error(mocker, caplog):
     transformer = mocker.MagicMock(spec=LibcstResultTransformer)
     transformer.transform.side_effect = ParserSyntaxError
     _apply_and_assert(mocker, transformer)
+    assert "error transforming file" in caplog.text
+
+
+def test_parse_error_with_tool(mocker, caplog):
+    mocker.patch(
+        "codemodder.codemods.libcst_transformer.cst.parse_module",
+        side_effect=ParserSyntaxError,
+    )
+    transformer = mocker.MagicMock(spec=LibcstResultTransformer)
+    _apply_and_assert_with_tool(mocker, transformer, "parsing file")
+    assert "error parsing file" in caplog.text
+
+
+def test_transformer_error_with_tool(mocker, caplog):
+    transformer = mocker.MagicMock(spec=LibcstResultTransformer)
+    transformer.transform.side_effect = ParserSyntaxError
+    _apply_and_assert_with_tool(mocker, transformer, "transforming file")
     assert "error transforming file" in caplog.text


### PR DESCRIPTION
## Overview
*In a codemodder run that fixes tool results, if there is a file parsing or transforming error, we will report that as an unfixed result for tools that currently support `Finding`*

Defectdojo is the only tool we currently support adding `Finding`s for so that's what I used for testing here.

Closes #514
