### PR TITLE
Populate Sonar findings

### DIFF
--- a/src/core_codemods/defectdojo/results.py
+++ b/src/core_codemods/defectdojo/results.py
@@ -12,28 +12,28 @@ from codemodder.result import LineInfo, Location, ResultSet, SASTResult
 
 class DefectDojoLocation(Location):
     @classmethod
-    def from_finding(cls, finding: dict) -> Self:
+    def from_result(cls, result: dict) -> Self:
         return cls(
-            file=Path(finding["file_path"]),
+            file=Path(result["file_path"]),
             # TODO: parse snippet from "description" field?
-            start=LineInfo(finding["line"]),
-            end=LineInfo(finding["line"]),
+            start=LineInfo(result["line"]),
+            end=LineInfo(result["line"]),
         )
 
 
 class DefectDojoResult(SASTResult):
     @classmethod
-    def from_finding(cls, finding: dict) -> Self:
+    def from_result(cls, result: dict) -> Self:
         return cls(
-            finding_id=finding["id"],
-            rule_id=finding["title"],
-            locations=[DefectDojoLocation.from_finding(finding)],
+            finding_id=result["id"],
+            rule_id=result["title"],
+            locations=[DefectDojoLocation.from_result(result)],
             finding=Finding(
-                id=str(finding["id"]),
+                id=str(result["id"]),
                 rule=Rule(
                     # TODO: it's possible that these fields actually come from the codemod and not the result
-                    id=str(finding["title"]),
-                    name=str(finding["title"]),
+                    id=str(result["title"]),
+                    name=str(result["title"]),
                     url=None,
                 ),
             ),
@@ -62,7 +62,7 @@ class DefectDojoResultSet(ResultSet):
             data = json.load(file)
 
         result_set = cls()
-        for finding in data.get("results"):
-            result_set.add_result(DefectDojoResult.from_finding(finding))
+        for result in data.get("results"):
+            result_set.add_result(DefectDojoResult.from_result(result))
 
         return result_set

--- a/tests/codemods/sonar/test_sonar_break_or_continue_out_of_loop.py
+++ b/tests/codemods/sonar/test_sonar_break_or_continue_out_of_loop.py
@@ -37,13 +37,4 @@ class TestSonarSQLParameterization(BaseSASTCodemodTest):
                 }
             ]
         }
-        changes = self.run_and_assert(
-            tmpdir, input_code, expected, results=json.dumps(issues)
-        )
-        assert changes is not None
-        assert changes[0].changes[0].finding is not None
-        # assert changes[0].changes[0].finding.id == "1"
-        # assert (
-        #     changes[0].changes[0].finding.rule.id
-        #     == "python.django.security.audit.secure-cookies.django-secure-set-cookie"
-        # )
+        self.run_and_assert(tmpdir, input_code, expected, results=json.dumps(issues))

--- a/tests/codemods/sonar/test_sonar_break_or_continue_out_of_loop.py
+++ b/tests/codemods/sonar/test_sonar_break_or_continue_out_of_loop.py
@@ -37,4 +37,13 @@ class TestSonarSQLParameterization(BaseSASTCodemodTest):
                 }
             ]
         }
-        self.run_and_assert(tmpdir, input_code, expected, results=json.dumps(issues))
+        changes = self.run_and_assert(
+            tmpdir, input_code, expected, results=json.dumps(issues)
+        )
+        assert changes is not None
+        assert changes[0].changes[0].finding is not None
+        # assert changes[0].changes[0].finding.id == "1"
+        # assert (
+        #     changes[0].changes[0].finding.rule.id
+        #     == "python.django.security.audit.secure-cookies.django-secure-set-cookie"
+        # )

--- a/tests/codemods/sonar/test_sonar_django_json_response_type.py
+++ b/tests/codemods/sonar/test_sonar_django_json_response_type.py
@@ -14,6 +14,7 @@ class TestDjangoJsonResponseType(BaseSASTCodemodTest):
         assert self.codemod.name == "django-json-response-type-S5131"
 
     def test_simple(self, tmpdir):
+        rule_id = "pythonsecurity:S5131"
         input_code = """
         from django.http import HttpResponse
         import json
@@ -33,7 +34,7 @@ class TestDjangoJsonResponseType(BaseSASTCodemodTest):
         issues = {
             "issues": [
                 {
-                    "rule": "pythonsecurity:S5131",
+                    "rule": rule_id,
                     "status": "OPEN",
                     "component": "code.py",
                     "textRange": {
@@ -45,4 +46,11 @@ class TestDjangoJsonResponseType(BaseSASTCodemodTest):
                 }
             ]
         }
-        self.run_and_assert(tmpdir, input_code, expected, results=json.dumps(issues))
+        changes = self.run_and_assert(
+            tmpdir, input_code, expected, results=json.dumps(issues)
+        )
+        assert changes is not None
+        assert changes[0].changes[0].findings is not None
+        assert changes[0].changes[0].findings[0].id == rule_id
+        assert changes[0].changes[0].findings[0].rule.id == rule_id
+        assert changes[0].changes[0].findings[0].rule.name == rule_id

--- a/tests/test_libcst_transformer.py
+++ b/tests/test_libcst_transformer.py
@@ -36,7 +36,7 @@ def _apply_and_assert_with_tool(mocker, transformer, reason):
         "home",
         file_path,
         results=[
-            DefectDojoResult.from_finding(
+            DefectDojoResult.from_result(
                 {
                     "id": 1,
                     "title": "python.django.security.audit.secure-cookies.django-secure-set-cookie",


### PR DESCRIPTION
## Overview
*Sonar results should now populate `finding=...` and report these as either fixed or unfixed*

## Description

* I renamed some methods for consistency. We could enforce a protocol later on.
* I'm not 100% sure the values I set for sonar's `Finding(...)` are correct?
* We don't have a sonar codemod that calls `report_unfixed` nor could I think of one at the top of my head, so. I just tested this as a transformer error to ensure a Finding is correctly populated as unfixed.

Closes #503
