### PR TITLE
Do not add hashes to requirements.txt

### DIFF
--- a/integration_tests/test_flask_enable_csrf_protection.py
+++ b/integration_tests/test_flask_enable_csrf_protection.py
@@ -41,14 +41,10 @@ class TestFlaskEnableCSRFProtection(BaseIntegrationTest):
         "pylint>1\n"
     )
     expected_requirements = (
-        (
-            "# file used to test dependency management\n"
-            "requests==2.31.0\n"
-            "black==23.7.*\n"
-            "mypy~=1.4\n"
-            "pylint>1\n"
-            f"{FlaskWTF.requirement} \\\n"
-        )
-        + "\n".join(FlaskWTF.build_hashes())
-        + "\n"
+        "# file used to test dependency management\n"
+        "requests==2.31.0\n"
+        "black==23.7.*\n"
+        "mypy~=1.4\n"
+        "pylint>1\n"
+        f"{FlaskWTF.requirement}\n"
     )

--- a/integration_tests/test_harden_pickle_load.py
+++ b/integration_tests/test_harden_pickle_load.py
@@ -48,14 +48,10 @@ class TestHardenPickleLoad(BaseIntegrationTest):
         "pylint>1\n"
     )
     expected_requirements = (
-        (
-            "# file used to test dependency management\n"
-            "requests==2.31.0\n"
-            "black==23.7.*\n"
-            "mypy~=1.4\n"
-            "pylint>1\n"
-            f"{Fickling.requirement} \\\n"
-        )
-        + "\n".join(Fickling.build_hashes())
-        + "\n"
+        "# file used to test dependency management\n"
+        "requests==2.31.0\n"
+        "black==23.7.*\n"
+        "mypy~=1.4\n"
+        "pylint>1\n"
+        f"{Fickling.requirement}\n"
     )

--- a/integration_tests/test_process_sandbox.py
+++ b/integration_tests/test_process_sandbox.py
@@ -44,14 +44,10 @@ class TestProcessSandbox(BaseIntegrationTest):
         "pylint>1\n"
     )
     expected_requirements = (
-        (
-            "# file used to test dependency management\n"
-            "requests==2.31.0\n"
-            "black==23.7.*\n"
-            "mypy~=1.4\n"
-            "pylint>1\n"
-            f"{Security.requirement} \\\n"
-        )
-        + "\n".join(Security.build_hashes())
-        + "\n"
+        "# file used to test dependency management\n"
+        "requests==2.31.0\n"
+        "black==23.7.*\n"
+        "mypy~=1.4\n"
+        "pylint>1\n"
+        f"{Security.requirement}\n"
     )

--- a/integration_tests/test_url_sandbox.py
+++ b/integration_tests/test_url_sandbox.py
@@ -44,16 +44,12 @@ class TestUrlSandbox(BaseIntegrationTest):
         "pylint>1\n"
     )
     expected_requirements = (
-        (
-            "# file used to test dependency management\n"
-            "requests==2.31.0\n"
-            "black==23.7.*\n"
-            "mypy~=1.4\n"
-            "pylint>1\n"
-            f"{Security.requirement} \\\n"
-        )
-        + "\n".join(Security.build_hashes())
-        + "\n"
+        "# file used to test dependency management\n"
+        "requests==2.31.0\n"
+        "black==23.7.*\n"
+        "mypy~=1.4\n"
+        "pylint>1\n"
+        f"{Security.requirement}\n"
     )
 
     # expected because output code points to fake module

--- a/integration_tests/test_use_defusedxml.py
+++ b/integration_tests/test_use_defusedxml.py
@@ -46,14 +46,10 @@ class TestUseDefusedXml(BaseIntegrationTest):
         "pylint>1\n"
     )
     expected_requirements = (
-        (
-            "# file used to test dependency management\n"
-            "requests==2.31.0\n"
-            "black==23.7.*\n"
-            "mypy~=1.4\n"
-            "pylint>1\n"
-            f"{DefusedXML.requirement} \\\n"
-        )
-        + "\n".join(DefusedXML.build_hashes())
-        + "\n"
+        "# file used to test dependency management\n"
+        "requests==2.31.0\n"
+        "black==23.7.*\n"
+        "mypy~=1.4\n"
+        "pylint>1\n"
+        f"{DefusedXML.requirement}\n"
     )

--- a/src/codemodder/dependency_management/requirements_txt_writer.py
+++ b/src/codemodder/dependency_management/requirements_txt_writer.py
@@ -23,9 +23,7 @@ class RequirementsTxtWriter(DependencyWriter):
 
         requirement_lines = []
         for dep in dependencies:
-            requirement_lines.append(f"{dep.requirement} \\\n")
-            for hash_line in dep.build_hashes():
-                requirement_lines.append(f"{hash_line}\n")
+            requirement_lines.append(f"{dep.requirement}\n")
 
         updated_lines = original_lines + requirement_lines
 

--- a/tests/dependency_management/test_requirements_txt_writer.py
+++ b/tests/dependency_management/test_requirements_txt_writer.py
@@ -34,33 +34,23 @@ class TestRequirementsTxtWriter:
             if dry_run
             else (
                 "# comment\n\nrequests\n"
-                + f"{DefusedXML.requirement} \\\n"
-                + "\n".join(DefusedXML.build_hashes())
-                + "\n"
-                + f"{Security.requirement} \\\n"
-                + "\n".join(Security.build_hashes())
-                + "\n"
+                + f"{DefusedXML.requirement}\n"
+                + f"{Security.requirement}\n"
             )
         )
 
         assert changeset is not None
         assert changeset.path == dependency_file.name
 
-        defused_xml_hashes = DefusedXML.build_hashes()
-        security_hashes = Security.build_hashes()
         assert changeset.diff == (
             "--- \n"
             "+++ \n"
-            "@@ -1,3 +1,9 @@\n"
+            "@@ -1,3 +1,5 @@\n"
             " # comment\n"
             " \n"
             " requests\n"
-            f"+{DefusedXML.requirement} \\\n"
-            f"+{defused_xml_hashes[0]}\n"
-            f"+{defused_xml_hashes[1]}\n"
-            f"+{Security.requirement} \\\n"
-            f"+{security_hashes[0]}\n"
-            f"+{security_hashes[1]}\n"
+            f"+{DefusedXML.requirement}\n"
+            f"+{Security.requirement}\n"
         )
         assert len(changeset.changes) == 2
         change_one = changeset.changes[0]
@@ -96,9 +86,7 @@ class TestRequirementsTxtWriter:
         assert len(changeset.changes) == 1
 
         assert dependency_file.read_text(encoding="utf-8") == (
-            f"requests\n{Security.requirement} \\\n"
-            + "\n".join(Security.build_hashes())
-            + "\n"
+            f"requests\n{Security.requirement}\n"
         )
 
     def test_dont_add_existing_dependency(self, tmpdir):
@@ -156,30 +144,20 @@ class TestRequirementsTxtWriter:
         assert (
             dependency_file.read_text(encoding="utf-8")
             == "# comment\n\nrequests\n"
-            + f"{DefusedXML.requirement} \\\n"
-            + "\n".join(DefusedXML.build_hashes())
-            + "\n"
-            + f"{Security.requirement} \\\n"
-            + "\n".join(Security.build_hashes())
-            + "\n"
+            + f"{DefusedXML.requirement}\n"
+            + f"{Security.requirement}\n"
         )
 
         assert changeset is not None
         assert changeset.path == dependency_file.name
 
-        defused_xml_hashes = DefusedXML.build_hashes()
-        security_hashes = Security.build_hashes()
         assert changeset.diff == (
             "--- \n"
             "+++ \n"
-            "@@ -1,3 +1,9 @@\n"
+            "@@ -1,3 +1,5 @@\n"
             " # comment\n"
             " \n"
             " requests\n"
-            f"+{DefusedXML.requirement} \\\n"
-            f"+{defused_xml_hashes[0]}\n"
-            f"+{defused_xml_hashes[1]}\n"
-            f"+{Security.requirement} \\\n"
-            f"+{security_hashes[0]}\n"
-            f"+{security_hashes[1]}\n"
+            f"+{DefusedXML.requirement}\n"
+            f"+{Security.requirement}\n"
         )


### PR DESCRIPTION
## Overview
*Do not add package hashes to `requirements.txt`*

## Description

* This pretty much reverts the changes introduced in #273 😢 
* Unfortunately we can't do this without also adding hashes to every other dependency in `requirements.txt`:
> ERROR: Hashes are required in --require-hashes mode, but they are missing from some requirements. Here is a list of those requirements along with the hashes their downloaded archives actually had. Add lines like these to your requirements files to prevent tampering. (If you did not enable --require-hashes manually, note that it turns on automatically when any package has a hash.)
* I'm keeping most of the machinery in place in case we ever need this. Maybe we could add it to files that already have hashes? But for now I just need to turn it off.
