### PR TITLE
Redo `tempfile.mktemp` codemod

### DIFF
--- a/integration_tests/sonar/test_sonar_tempfile_mktemp.py
+++ b/integration_tests/sonar/test_sonar_tempfile_mktemp.py
@@ -6,7 +6,10 @@ from core_codemods.tempfile_mktemp import TempfileMktempTransformer
 class TestTempfileMktemp(SonarIntegrationTest):
     codemod = SonarTempfileMktemp
     code_path = "tests/samples/tempfile_mktemp.py"
-    replacement_lines = [(3, "tempfile.mkstemp()\n")]
-    expected_diff = "--- \n+++ \n@@ -1,3 +1,3 @@\n import tempfile\n \n-tempfile.mktemp()\n+tempfile.mkstemp()\n"
+    replacement_lines = [
+        (3, "with tempfile.NamedTemporaryFile(delete=False) as tf:\n"),
+        (4, "    filename = tf.name\n"),
+    ]
+    expected_diff = "--- \n+++ \n@@ -1,3 +1,4 @@\n import tempfile\n \n-filename = tempfile.mktemp()\n+with tempfile.NamedTemporaryFile(delete=False) as tf:\n+    filename = tf.name\n"
     expected_line_change = "3"
     change_description = TempfileMktempTransformer.change_description

--- a/integration_tests/test_tempfile_mktemp.py
+++ b/integration_tests/test_tempfile_mktemp.py
@@ -7,10 +7,12 @@ class TestTempfileMktemp(BaseIntegrationTest):
     original_code = """
     import tempfile
 
-    tempfile.mktemp()
-    var = "hello"
+    filename = tempfile.mktemp()
     """
-    replacement_lines = [(3, "tempfile.mkstemp()\n")]
-    expected_diff = '--- \n+++ \n@@ -1,4 +1,4 @@\n import tempfile\n \n-tempfile.mktemp()\n+tempfile.mkstemp()\n var = "hello"\n'
+    replacement_lines = [
+        (3, "with tempfile.NamedTemporaryFile(delete=False) as tf:\n"),
+        (4, "    filename = tf.name\n"),
+    ]
+    expected_diff = "--- \n+++ \n@@ -1,3 +1,4 @@\n import tempfile\n \n-filename = tempfile.mktemp()\n+with tempfile.NamedTemporaryFile(delete=False) as tf:\n+    filename = tf.name\n"
     expected_line_change = "3"
     change_description = TempfileMktempTransformer.change_description

--- a/src/codemodder/scripts/generate_docs.py
+++ b/src/codemodder/scripts/generate_docs.py
@@ -94,7 +94,7 @@ CORE_CODEMODS = {
     ),
     "secure-tempfile": DocMetadata(
         importance="High",
-        guidance_explained="We believe this codemod is safe and will cause no unexpected errors.",
+        guidance_explained="We believe this codemod is safe. You should review this code before merging to make sure temporary files are created, used, and closed according to your expectations.",
     ),
     "upgrade-sslcontext-minimum-version": DocMetadata(
         importance="High",

--- a/src/core_codemods/docs/pixee_python_secure-tempfile.md
+++ b/src/core_codemods/docs/pixee_python_secure-tempfile.md
@@ -1,12 +1,14 @@
-This codemod replaces all `tempfile.mktemp` calls to the more secure `tempfile.mkstemp`.
+This codemod replaces all `tempfile.mktemp` calls with the more secure `tempfile.NamedTemporaryFile`
 
-The Python [tempfile documentation](https://docs.python.org/3/library/tempfile.html#tempfile.mktemp) is explicit
-that `tempfile.mktemp` should be deprecated to avoid an unsafe and unexpected race condition.
+The Python [tempfile documentation](https://docs.python.org/3/library/tempfile.html#tempfile.mktemp) is explicit that `tempfile.mktemp` should be deprecated to avoid an unsafe and unexpected race condition. `tempfile.mktemp` does not handle the possibility that the returned file name could already be used by another process by the time your code opens the file. A more secure approach to create temporary files is to use `tempfile.NamedTemporaryFile` which will create the file for you and handle all security conditions. 
+
 The changes from this codemod look like this:
-
 
 ```diff
   import tempfile
-- tempfile.mktemp(...)
-+ tempfile.mkstemp(...)
+- filename = tempfile.mktemp()
++ with tempfile.NamedTemporaryFile(delete=False) as tf:
++     filename = tf.name
 ```
+
+The change sets `delete=False` to closely follow your code's intention when calling `tempfile.mktemp`. However, you should use this as a starting point to determine when your temporary file should be deleted.

--- a/src/core_codemods/tempfile_mktemp.py
+++ b/src/core_codemods/tempfile_mktemp.py
@@ -1,22 +1,111 @@
+from typing import Optional
+
+import libcst as cst
+from libcst import ensure_type, matchers
+
 from codemodder.codemods.libcst_transformer import (
     LibcstResultTransformer,
     LibcstTransformerPipeline,
 )
-from codemodder.codemods.semgrep import SemgrepRuleDetector
-from codemodder.codemods.utils_mixin import NameResolutionMixin
+from codemodder.codemods.utils_mixin import NameAndAncestorResolutionMixin
 from core_codemods.api import CoreCodemod, Metadata, Reference, ReviewGuidance
 
 
-class TempfileMktempTransformer(LibcstResultTransformer, NameResolutionMixin):
+class TempfileMktempTransformer(
+    LibcstResultTransformer, NameAndAncestorResolutionMixin
+):
     change_description = "Replaces `tempfile.mktemp` with `tempfile.mkstemp`."
     _module_name = "tempfile"
 
-    def on_result_found(self, original_node, updated_node):
-        maybe_name = self.get_aliased_prefix_name(original_node, self._module_name)
-        if (maybe_name := maybe_name or self._module_name) == self._module_name:
-            self.add_needed_import(self._module_name)
-        self.remove_unused_import(original_node)
-        return self.update_call_target(updated_node, maybe_name, "mkstemp")
+    def leave_SimpleStatementLine(self, original_node, updated_node):
+        match original_node:
+            case cst.SimpleStatementLine(body=[bsstmt]):
+                block = self.get_parent(original_node)
+                # SimpleStatementLine is always part of a IndentedBlock or Module body
+                block = ensure_type(block, cst.IndentedBlock | cst.Module)
+                if isinstance(block, cst.Module):
+                    return self.check_mktemp(original_node, bsstmt)
+        return updated_node
+
+    def check_mktemp(
+        self, original_node: cst.SimpleStatementLine, bsstmt: cst.BaseSmallStatement
+    ) -> cst.SimpleStatementLine | cst.FlattenSentinel:
+        if maybe_tuple := self._is_assigned_to_mktemp(bsstmt):  # type: ignore
+            assign_name, call = maybe_tuple
+
+            self.report_change(call)
+            new_line = cst.parse_statement(
+                f"""
+with tempfile.NamedTemporaryFile(delete=False) as tf:
+    {assign_name} = tf.name
+"""
+            )
+            return cst.FlattenSentinel(
+                [
+                    new_line,
+                ]
+            )
+
+        if maybe_tuple := self._mktemp_is_sink(bsstmt):
+            wrapper_func_name, call = maybe_tuple
+            self.report_change(call)
+
+            new_line = cst.parse_statement(
+                f"""
+with tempfile.NamedTemporaryFile(delete=False) as tf:
+    {wrapper_func_name.value}(tf.name)
+"""
+            )
+            return cst.FlattenSentinel(
+                [
+                    new_line,
+                ]
+            )
+        return original_node
+
+    def _is_assigned_to_mktemp(
+        self, bsstmt: cst.BaseSmallStatement
+    ) -> Optional[tuple[cst.AnnAssign | cst.Assign, cst.Call]]:
+        match bsstmt:
+            case cst.Assign(value=value, targets=targets):
+                maybe_value = self._is_mktemp_call(value)  # type: ignore
+                if maybe_value and all(
+                    map(
+                        lambda t: matchers.matches(
+                            t, matchers.AssignTarget(target=matchers.Name())
+                        ),
+                        targets,  # type: ignore
+                    )
+                ):
+                    # # Todo: handle multiple potential targets
+                    return (targets[0], maybe_value)
+            case cst.AnnAssign(target=target, value=value):
+                maybe_value = self._is_mktemp_call(value)  # type: ignore
+                if maybe_value and isinstance(target, cst.Name):  # type: ignore
+                    return (target, maybe_value)
+        return None
+
+    def _is_mktemp_call(self, value) -> Optional[cst.Call]:
+        match value:
+            case cst.Call() if self.find_base_name(value.func) == "tempfile.mktemp":
+                return value
+        return None
+
+    def _mktemp_is_sink(
+        self, bsstmt: cst.BaseSmallStatement
+    ) -> Optional[tuple[cst.AnnAssign | cst.Assign, cst.Call]]:
+        match bsstmt:
+            case cst.Expr(value=cst.Call() as call):
+                if not (args := call.args):
+                    return None
+
+                # todo: handle more complex cases of mktemp in different arg pos
+                match first_arg_call := args[0].value:
+                    case cst.Call():
+                        if maybe_value := self._is_mktemp_call(first_arg_call):  # type: ignore
+                            wrapper_func = call.func
+                            return (wrapper_func, maybe_value)
+        return None
 
 
 TempfileMktemp = CoreCodemod(
@@ -29,16 +118,6 @@ TempfileMktemp = CoreCodemod(
                 url="https://docs.python.org/3/library/tempfile.html#tempfile.mktemp"
             ),
         ],
-    ),
-    detector=SemgrepRuleDetector(
-        """
-        rules:
-          - patterns:
-            - pattern: tempfile.mktemp(...)
-            - pattern-inside: |
-                import tempfile
-                ...
-        """
     ),
     transformer=LibcstTransformerPipeline(TempfileMktempTransformer),
 )

--- a/src/core_codemods/tempfile_mktemp.py
+++ b/src/core_codemods/tempfile_mktemp.py
@@ -45,7 +45,7 @@ class TempfileMktempTransformer(
     ) -> cst.FlattenSentinel:
         self.report_change(node)
         maybe_name = self.get_aliased_prefix_name(node, self._module_name)
-        if maybe_name or self._module_name == self._module_name:
+        if (maybe_name or self._module_name) == self._module_name:
             self.add_needed_import(self._module_name)
         self.remove_unused_import(node)
         with_block = (
@@ -125,7 +125,7 @@ TempfileMktemp = CoreCodemod(
     metadata=Metadata(
         name="secure-tempfile",
         summary="Upgrade and Secure Temp File Creation",
-        review_guidance=ReviewGuidance.MERGE_WITHOUT_REVIEW,
+        review_guidance=ReviewGuidance.MERGE_AFTER_REVIEW,
         references=[
             Reference(
                 url="https://docs.python.org/3/library/tempfile.html#tempfile.mktemp"

--- a/src/core_codemods/tempfile_mktemp.py
+++ b/src/core_codemods/tempfile_mktemp.py
@@ -2,7 +2,7 @@ from textwrap import dedent
 from typing import Optional
 
 import libcst as cst
-from libcst import ensure_type, matchers
+from libcst import matchers
 
 from codemodder.codemods.libcst_transformer import (
     LibcstResultTransformer,
@@ -22,11 +22,7 @@ class TempfileMktempTransformer(
     def leave_SimpleStatementLine(self, original_node, updated_node):
         match original_node:
             case cst.SimpleStatementLine(body=[bsstmt]):
-                block = self.get_parent(original_node)
-                # SimpleStatementLine is always part of a IndentedBlock or Module body
-                block = ensure_type(block, cst.IndentedBlock | cst.Module)
-                if isinstance(block, cst.Module):
-                    return self.check_mktemp(original_node, bsstmt)
+                return self.check_mktemp(original_node, bsstmt)
         return updated_node
 
     def check_mktemp(

--- a/src/core_codemods/tempfile_mktemp.py
+++ b/src/core_codemods/tempfile_mktemp.py
@@ -44,9 +44,7 @@ class TempfileMktempTransformer(
         self, node: cst.Call, name: cst.Name, assignment=True
     ) -> cst.FlattenSentinel:
         self.report_change(node)
-        maybe_name = self.get_aliased_prefix_name(node, self._module_name)
-        if (maybe_name or self._module_name) == self._module_name:
-            self.add_needed_import(self._module_name)
+        self.add_needed_import(self._module_name)
         self.remove_unused_import(node)
         with_block = (
             f"{name.value} = tf.name" if assignment else f"{name.value}(tf.name)"

--- a/tests/codemods/sonar/test_sonar_tempfile_mktemp.py
+++ b/tests/codemods/sonar/test_sonar_tempfile_mktemp.py
@@ -15,12 +15,13 @@ class TestSonarTempfileMktemp(BaseSASTCodemodTest):
         input_code = """
         import tempfile
         
-        tempfile.mktemp()
+        filename = tempfile.mktemp()
         """
         expected = """
         import tempfile
         
-        tempfile.mkstemp()
+        with tempfile.NamedTemporaryFile(delete=False) as tf:
+            filename = tf.name
         """
         issues = {
             "issues": [

--- a/tests/codemods/test_tempfile_mktemp.py
+++ b/tests/codemods/test_tempfile_mktemp.py
@@ -98,56 +98,59 @@ class TestTempfileMktemp(BaseSemgrepCodemodTest):
         """
         self.run_and_assert(tmpdir, input_code, expected_output)
 
-    # def test_import_alias(self, tmpdir):
-    #     input_code = """
-    #     import tempfile as _tempfile
-    #
-    #     filename = _tempfile.mktemp()
-    #     var = "hello"
-    #     """
-    #     expected_output = """
-    #     import tempfile as _tempfile
-    #
-    #     with _tempfile.NamedTemporaryFile(delete=False) as tf:
-    #         filename = tf.name
-    #     var = "hello"
-    #     """
-    #     self.run_and_assert(tmpdir, input_code, expected_output)
-    #
-    # def test_import_method_alias(self, tmpdir):
-    #     input_code = """
-    #     from tempfile import mktemp as get_temp_file
-    #
-    #     filename = get_temp_file()
-    #     var = "hello"
-    #     """
-    #     expected_output = """
-    #     import tempfile
-    #
-    #     with tempfile.NamedTemporaryFile(delete=False) as tf:
-    #         filename = tf.name
-    #     var = "hello"
-    #     """
-    #     self.run_and_assert(tmpdir, input_code, expected_output)
-    #
-    # def test_random_multifunctions(self, tmpdir):
-    #     input_code = """
-    #     from tempfile import mktemp, TemporaryFile
-    #
-    #     filename = mktemp()
-    #     TemporaryFile()
-    #     var = "hello"
-    #     """
-    #     expected_output = """
-    #     from tempfile import TemporaryFile
-    #     import tempfile
-    #
-    #     with tempfile.NamedTemporaryFile(delete=False) as tf:
-    #         filename = tf.name
-    #     TemporaryFile()
-    #     var = "hello"
-    #     """
-    #     self.run_and_assert(tmpdir, input_code, expected_output)
+    def test_import_alias(self, tmpdir):
+        input_code = """
+        import tempfile as _tempfile
+
+        filename = _tempfile.mktemp()
+        var = "hello"
+        _tempfile.template
+        """
+        expected_output = """
+        import tempfile as _tempfile
+        import tempfile
+
+        with tempfile.NamedTemporaryFile(delete=False) as tf:
+            filename = tf.name
+        var = "hello"
+        _tempfile.template
+        """
+        self.run_and_assert(tmpdir, input_code, expected_output)
+
+    def test_import_method_alias(self, tmpdir):
+        input_code = """
+        from tempfile import mktemp as get_temp_file
+
+        filename = get_temp_file()
+        var = "hello"
+        """
+        expected_output = """
+        import tempfile
+
+        with tempfile.NamedTemporaryFile(delete=False) as tf:
+            filename = tf.name
+        var = "hello"
+        """
+        self.run_and_assert(tmpdir, input_code, expected_output)
+
+    def test_random_multifunctions(self, tmpdir):
+        input_code = """
+        from tempfile import mktemp, TemporaryFile
+
+        filename = mktemp()
+        TemporaryFile()
+        var = "hello"
+        """
+        expected_output = """
+        from tempfile import TemporaryFile
+        import tempfile
+
+        with tempfile.NamedTemporaryFile(delete=False) as tf:
+            filename = tf.name
+        TemporaryFile()
+        var = "hello"
+        """
+        self.run_and_assert(tmpdir, input_code, expected_output)
 
     @pytest.mark.xfail(reason="Not currently supported")
     def test_as_str_concat(self, tmpdir):

--- a/tests/codemods/test_tempfile_mktemp.py
+++ b/tests/codemods/test_tempfile_mktemp.py
@@ -156,6 +156,16 @@ class TestTempfileMktemp(BaseSemgrepCodemodTest):
         """
         self.run_and_assert(tmpdir, input_code, expected_output)
 
+    def test_open_and_write_no_change(self, tmpdir):
+        input_code = """
+        import tempfile
+
+        tmp_file = open(tempfile.mktemp(), "w+")
+        tmp_file.write("text")
+        print(tmp_file.name)
+        """
+        self.run_and_assert(tmpdir, input_code, input_code)
+
     @pytest.mark.xfail(reason="Not currently supported")
     def test_as_str_concat(self, tmpdir):
         input_code = """

--- a/tests/codemods/test_tempfile_mktemp.py
+++ b/tests/codemods/test_tempfile_mktemp.py
@@ -1,3 +1,5 @@
+import pytest
+
 from codemodder.codemods.test import BaseSemgrepCodemodTest
 from core_codemods.tempfile_mktemp import TempfileMktemp
 
@@ -52,23 +54,6 @@ class TestTempfileMktemp(BaseSemgrepCodemodTest):
         """
         self.run_and_assert(tmpdir, input_code, expected_output, num_changes=2)
 
-    # def test_as_str_concat(self, tmpdir):
-    #     input_code = """
-    #     import tempfile
-    #
-    #     var = "hello"
-    #     filename = tempfile.mktemp() + var
-    #     """
-    #     expected_output = """
-    #     import tempfile
-    #
-    #     var = "hello"
-    #
-    #     with tempfile.NamedTemporaryFile(delete=False) as tf:
-    #         filename = tf.name + var
-    #     """
-    #     self.run_and_assert(tmpdir, input_code, expected_output)
-    #
     # def test_import_with_arg(self, tmpdir):
     #     input_code = """
     #     import tempfile
@@ -97,22 +82,22 @@ class TestTempfileMktemp(BaseSemgrepCodemodTest):
     #     """
     #     self.run_and_assert(tmpdir, input_code, expected_output)
     #
-    # def test_from_import(self, tmpdir):
-    #     input_code = """
-    #     from tempfile import mktemp
-    #
-    #     filename = mktemp()
-    #     print(filename)
-    #     """
-    #     expected_output = """
-    #     import tempfile
-    #
-    #     with tempfile.NamedTemporaryFile(delete=False) as tf:
-    #         filename = tf.name
-    #     print(filename)
-    #     """
-    #     self.run_and_assert(tmpdir, input_code, expected_output)
-    #
+    def test_from_import(self, tmpdir):
+        input_code = """
+        from tempfile import mktemp
+
+        filename = mktemp()
+        print(filename)
+        """
+        expected_output = """
+        import tempfile
+
+        with tempfile.NamedTemporaryFile(delete=False) as tf:
+            filename = tf.name
+        print(filename)
+        """
+        self.run_and_assert(tmpdir, input_code, expected_output)
+
     # def test_import_alias(self, tmpdir):
     #     input_code = """
     #     import tempfile as _tempfile
@@ -164,76 +149,95 @@ class TestTempfileMktemp(BaseSemgrepCodemodTest):
     #     """
     #     self.run_and_assert(tmpdir, input_code, expected_output)
 
+    @pytest.mark.xfail(reason="Not currently supported")
+    def test_as_str_concat(self, tmpdir):
+        input_code = """
+        import tempfile
 
-# class TestOpenTempfileMktemp(BaseSemgrepCodemodTest):
-#     codemod = TempfileMktemp
-#
-#     def test_open_and_write(self, tmpdir):
-#         input_code = """
-#         import tempfile
-#
-#         tmp_file = open(tempfile.mktemp(), "w+")
-#         tmp_file.write("text")
-#         """
-#         expected_output = """
-#         import tempfile
-#
-#         with tempfile.NamedTemporaryFile("w+", delete=False) as tf:
-#             tf.write("text")
-#         """
-#         self.run_and_assert(tmpdir, input_code, expected_output)
-#
-#     def test_open_write_close(self, tmpdir):
-#         input_code = """
-#         import tempfile
-#
-#         tmp_file = open(tempfile.mktemp(), "w+")
-#         tmp_file.write("text")
-#         print(tmp_file.name)
-#         tmp_file.close()
-#         """
-#         expected_output = """
-#         import tempfile
-#
-#         with tempfile.NamedTemporaryFile("w+") as tf:
-#             tf.write("text")
-#             print(tmp_file.name)
-#         """
-#         self.run_and_assert(tmpdir, input_code, expected_output)
-#
-#     def test_make_name_then_open(self, tmpdir):
-#         input_code = """
-#         import tempfile
-#
-#         filename = tempfile.mktemp()
-#         print(filename)
-#         tmp_file = open(filename, "w+")
-#         tmp_file.write("text")
-#         print("hello")
-#         """
-#         expected_output = """
-#         import tempfile
-#
-#         with tempfile.NamedTemporaryFile("w+", delete=False) as tf:
-#             filename = tf.name
-#             print(filename)
-#             tf.write("text")
-#         print("hello")
-#         """
-#         self.run_and_assert(tmpdir, input_code, expected_output)
-#
-#     def test_open_context_manager(self, tmpdir):
-#         input_code = """
-#         import tempfile
-#
-#         filename = tempfile.mktemp()
-#         with open(filename, "w+") as tmp:
-#             tmp.write("text")
-#         """
-#         expected_output = """
-#         import tempfile
-#
-#         with tempfile.NamedTemporaryFile("w+") as tf:
-#             tf.write("text")
-#         """
-#         self.run_and_assert(tmpdir, input_code, expected_output)
+        var = "hello"
+        filename = tempfile.mktemp() + var
+        """
+        expected_output = """
+        import tempfile
+
+        var = "hello"
+
+        with tempfile.NamedTemporaryFile(delete=False) as tf:
+            filename = tf.name + var
+        """
+        self.run_and_assert(tmpdir, input_code, expected_output)
+
+
+@pytest.mark.xfail(reason="Not currently supported")
+class TestOpenTempfileMktemp(BaseSemgrepCodemodTest):
+    codemod = TempfileMktemp
+
+    def test_open_and_write(self, tmpdir):
+        input_code = """
+        import tempfile
+
+        tmp_file = open(tempfile.mktemp(), "w+")
+        tmp_file.write("text")
+        """
+        expected_output = """
+        import tempfile
+
+        with tempfile.NamedTemporaryFile("w+", delete=False) as tf:
+            tf.write("text")
+        """
+        self.run_and_assert(tmpdir, input_code, expected_output)
+
+    def test_open_write_close(self, tmpdir):
+        input_code = """
+        import tempfile
+
+        tmp_file = open(tempfile.mktemp(), "w+")
+        tmp_file.write("text")
+        print(tmp_file.name)
+        tmp_file.close()
+        """
+        expected_output = """
+        import tempfile
+
+        with tempfile.NamedTemporaryFile("w+") as tf:
+            tf.write("text")
+            print(tmp_file.name)
+        """
+        self.run_and_assert(tmpdir, input_code, expected_output)
+
+    def test_make_name_then_open(self, tmpdir):
+        input_code = """
+        import tempfile
+
+        filename = tempfile.mktemp()
+        print(filename)
+        tmp_file = open(filename, "w+")
+        tmp_file.write("text")
+        print("hello")
+        """
+        expected_output = """
+        import tempfile
+
+        with tempfile.NamedTemporaryFile("w+", delete=False) as tf:
+            filename = tf.name
+            print(filename)
+            tf.write("text")
+        print("hello")
+        """
+        self.run_and_assert(tmpdir, input_code, expected_output)
+
+    def test_open_context_manager(self, tmpdir):
+        input_code = """
+        import tempfile
+
+        filename = tempfile.mktemp()
+        with open(filename, "w+") as tmp:
+            tmp.write("text")
+        """
+        expected_output = """
+        import tempfile
+
+        with tempfile.NamedTemporaryFile("w+") as tf:
+            tf.write("text")
+        """
+        self.run_and_assert(tmpdir, input_code, expected_output)

--- a/tests/codemods/test_tempfile_mktemp.py
+++ b/tests/codemods/test_tempfile_mktemp.py
@@ -7,16 +7,16 @@ from core_codemods.tempfile_mktemp import TempfileMktemp
 class TestTempfileMktemp(BaseSemgrepCodemodTest):
     codemod = TempfileMktemp
 
-    # def test_name(self):
-    #     assert self.codemod.name == "secure-tempfile"
-    #
-    # def test_no_change(self, tmpdir):
-    #     input_code = """
-    #     import tempfile
-    #     tempfile.mktemp()
-    #     var = "hello"
-    #     """
-    #     self.run_and_assert(tmpdir, input_code, input_code)
+    def test_name(self):
+        assert self.codemod.name == "secure-tempfile"
+
+    def test_no_change(self, tmpdir):
+        input_code = """
+        import tempfile
+        tempfile.mktemp()
+        var = "hello"
+        """
+        self.run_and_assert(tmpdir, input_code, input_code)
 
     def test_import(self, tmpdir):
         input_code = """
@@ -54,34 +54,34 @@ class TestTempfileMktemp(BaseSemgrepCodemodTest):
         """
         self.run_and_assert(tmpdir, input_code, expected_output, num_changes=2)
 
-    # def test_import_with_arg(self, tmpdir):
-    #     input_code = """
-    #     import tempfile
-    #
-    #     filename = tempfile.mktemp('suffix')
-    #     filename = tempfile.mktemp('suffix', 'prefix')
-    #     filename = tempfile.mktemp('suffix', 'prefix', 'dir')
-    #     filename = tempfile.mktemp('suffix', prefix='prefix')
-    #     filename = tempfile.mktemp(suffix='suffix', prefix='prefix', dir='dir')
-    #     var = "hello"
-    #     """
-    #     expected_output = """
-    #     import tempfile
-    #
-    #     with tempfile.NamedTemporaryFile(suffix='suffix', delete=False) as tf:
-    #         filename = tf.name
-    #     with tempfile.NamedTemporaryFile(suffix='suffix', prefix='prefix', delete=False) as tf:
-    #         filename = tf.name
-    #     with tempfile.NamedTemporaryFile(suffix='suffix', prefix='prefix', dir='dir', delete=False) as tf:
-    #         filename = tf.name
-    #     with tempfile.NamedTemporaryFile(suffix='suffix', prefix='prefix', delete=False) as tf:
-    #         filename = tf.name
-    #     with tempfile.NamedTemporaryFile(suffix='suffix', prefix='prefix', dir='dir', delete=False) as tf:
-    #         filename = tf.name
-    #     var = "hello"
-    #     """
-    #     self.run_and_assert(tmpdir, input_code, expected_output)
-    #
+    def test_import_with_arg(self, tmpdir):
+        input_code = """
+        import tempfile
+
+        filename = tempfile.mktemp('suffix')
+        print(tempfile.mktemp('suffix', 'prefix'))
+        filename = tempfile.mktemp('suffix', 'prefix', 'dir')
+        filename = tempfile.mktemp('suffix', prefix='prefix')
+        filename = tempfile.mktemp(suffix='suffix', prefix='prefix', dir='dir')
+        var = "hello"
+        """
+        expected_output = """
+        import tempfile
+
+        with tempfile.NamedTemporaryFile(suffix='suffix', delete=False) as tf:
+            filename = tf.name
+        with tempfile.NamedTemporaryFile(suffix='suffix', prefix='prefix', delete=False) as tf:
+            print(tf.name)
+        with tempfile.NamedTemporaryFile(suffix='suffix', prefix='prefix', dir='dir', delete=False) as tf:
+            filename = tf.name
+        with tempfile.NamedTemporaryFile(suffix='suffix', prefix='prefix', delete=False) as tf:
+            filename = tf.name
+        with tempfile.NamedTemporaryFile(suffix='suffix', prefix='prefix', dir='dir', delete=False) as tf:
+            filename = tf.name
+        var = "hello"
+        """
+        self.run_and_assert(tmpdir, input_code, expected_output, 5)
+
     def test_from_import(self, tmpdir):
         input_code = """
         from tempfile import mktemp

--- a/tests/codemods/test_tempfile_mktemp.py
+++ b/tests/codemods/test_tempfile_mktemp.py
@@ -5,89 +5,235 @@ from core_codemods.tempfile_mktemp import TempfileMktemp
 class TestTempfileMktemp(BaseSemgrepCodemodTest):
     codemod = TempfileMktemp
 
-    def test_name(self):
-        assert self.codemod.name == "secure-tempfile"
+    # def test_name(self):
+    #     assert self.codemod.name == "secure-tempfile"
+    #
+    # def test_no_change(self, tmpdir):
+    #     input_code = """
+    #     import tempfile
+    #     tempfile.mktemp()
+    #     var = "hello"
+    #     """
+    #     self.run_and_assert(tmpdir, input_code, input_code)
 
     def test_import(self, tmpdir):
-        input_code = """import tempfile
-
-tempfile.mktemp()
-var = "hello"
-"""
-        expected_output = """import tempfile
-
-tempfile.mkstemp()
-var = "hello"
-"""
-
+        input_code = """
+        import tempfile
+        
+        name = tempfile.mktemp()
+        var = "hello"
+        """
+        expected_output = """
+        import tempfile
+        
+        with tempfile.NamedTemporaryFile(delete=False) as tf:
+            name = tf.name
+        var = "hello"
+        """
         self.run_and_assert(tmpdir, input_code, expected_output)
 
-    def test_import_with_arg(self, tmpdir):
-        input_code = """import tempfile
+    def test_as_sink(self, tmpdir):
+        input_code = """
+        import tempfile
 
-tempfile.mktemp('something')
-var = "hello"
-"""
-        expected_output = """import tempfile
+        print(tempfile.mktemp())
+        var = "hello"
+        bool(tempfile.mktemp())
+        """
+        expected_output = """
+        import tempfile
 
-tempfile.mkstemp('something')
-var = "hello"
-"""
+        with tempfile.NamedTemporaryFile(delete=False) as tf:
+            print(tf.name)
+        var = "hello"
 
-        self.run_and_assert(tmpdir, input_code, expected_output)
+        with tempfile.NamedTemporaryFile(delete=False) as tf:
+            bool(tf.name)
+        """
+        self.run_and_assert(tmpdir, input_code, expected_output, num_changes=2)
 
-    def test_from_import(self, tmpdir):
-        input_code = """from tempfile import mktemp
+    # def test_as_str_concat(self, tmpdir):
+    #     input_code = """
+    #     import tempfile
+    #
+    #     var = "hello"
+    #     filename = tempfile.mktemp() + var
+    #     """
+    #     expected_output = """
+    #     import tempfile
+    #
+    #     var = "hello"
+    #
+    #     with tempfile.NamedTemporaryFile(delete=False) as tf:
+    #         filename = tf.name + var
+    #     """
+    #     self.run_and_assert(tmpdir, input_code, expected_output)
+    #
+    # def test_import_with_arg(self, tmpdir):
+    #     input_code = """
+    #     import tempfile
+    #
+    #     filename = tempfile.mktemp('suffix')
+    #     filename = tempfile.mktemp('suffix', 'prefix')
+    #     filename = tempfile.mktemp('suffix', 'prefix', 'dir')
+    #     filename = tempfile.mktemp('suffix', prefix='prefix')
+    #     filename = tempfile.mktemp(suffix='suffix', prefix='prefix', dir='dir')
+    #     var = "hello"
+    #     """
+    #     expected_output = """
+    #     import tempfile
+    #
+    #     with tempfile.NamedTemporaryFile(suffix='suffix', delete=False) as tf:
+    #         filename = tf.name
+    #     with tempfile.NamedTemporaryFile(suffix='suffix', prefix='prefix', delete=False) as tf:
+    #         filename = tf.name
+    #     with tempfile.NamedTemporaryFile(suffix='suffix', prefix='prefix', dir='dir', delete=False) as tf:
+    #         filename = tf.name
+    #     with tempfile.NamedTemporaryFile(suffix='suffix', prefix='prefix', delete=False) as tf:
+    #         filename = tf.name
+    #     with tempfile.NamedTemporaryFile(suffix='suffix', prefix='prefix', dir='dir', delete=False) as tf:
+    #         filename = tf.name
+    #     var = "hello"
+    #     """
+    #     self.run_and_assert(tmpdir, input_code, expected_output)
+    #
+    # def test_from_import(self, tmpdir):
+    #     input_code = """
+    #     from tempfile import mktemp
+    #
+    #     filename = mktemp()
+    #     print(filename)
+    #     """
+    #     expected_output = """
+    #     import tempfile
+    #
+    #     with tempfile.NamedTemporaryFile(delete=False) as tf:
+    #         filename = tf.name
+    #     print(filename)
+    #     """
+    #     self.run_and_assert(tmpdir, input_code, expected_output)
+    #
+    # def test_import_alias(self, tmpdir):
+    #     input_code = """
+    #     import tempfile as _tempfile
+    #
+    #     filename = _tempfile.mktemp()
+    #     var = "hello"
+    #     """
+    #     expected_output = """
+    #     import tempfile as _tempfile
+    #
+    #     with _tempfile.NamedTemporaryFile(delete=False) as tf:
+    #         filename = tf.name
+    #     var = "hello"
+    #     """
+    #     self.run_and_assert(tmpdir, input_code, expected_output)
+    #
+    # def test_import_method_alias(self, tmpdir):
+    #     input_code = """
+    #     from tempfile import mktemp as get_temp_file
+    #
+    #     filename = get_temp_file()
+    #     var = "hello"
+    #     """
+    #     expected_output = """
+    #     import tempfile
+    #
+    #     with tempfile.NamedTemporaryFile(delete=False) as tf:
+    #         filename = tf.name
+    #     var = "hello"
+    #     """
+    #     self.run_and_assert(tmpdir, input_code, expected_output)
+    #
+    # def test_random_multifunctions(self, tmpdir):
+    #     input_code = """
+    #     from tempfile import mktemp, TemporaryFile
+    #
+    #     filename = mktemp()
+    #     TemporaryFile()
+    #     var = "hello"
+    #     """
+    #     expected_output = """
+    #     from tempfile import TemporaryFile
+    #     import tempfile
+    #
+    #     with tempfile.NamedTemporaryFile(delete=False) as tf:
+    #         filename = tf.name
+    #     TemporaryFile()
+    #     var = "hello"
+    #     """
+    #     self.run_and_assert(tmpdir, input_code, expected_output)
 
-mktemp()
-var = "hello"
-"""
-        expected_output = """import tempfile
 
-tempfile.mkstemp()
-var = "hello"
-"""
-        self.run_and_assert(tmpdir, input_code, expected_output)
-
-    def test_import_alias(self, tmpdir):
-        input_code = """import tempfile as _tempfile
-
-_tempfile.mktemp()
-var = "hello"
-"""
-        expected_output = """import tempfile as _tempfile
-
-_tempfile.mkstemp()
-var = "hello"
-"""
-        self.run_and_assert(tmpdir, input_code, expected_output)
-
-    def test_import_method_alias(self, tmpdir):
-        input_code = """from tempfile import mktemp as get_temp_file
-
-get_temp_file()
-var = "hello"
-"""
-        expected_output = """import tempfile
-
-tempfile.mkstemp()
-var = "hello"
-"""
-        self.run_and_assert(tmpdir, input_code, expected_output)
-
-    def test_random_multifunctions(self, tmpdir):
-        input_code = """from tempfile import mktemp, TemporaryFile
-
-mktemp()
-TemporaryFile()
-var = "hello"
-"""
-        expected_output = """from tempfile import TemporaryFile
-import tempfile
-
-tempfile.mkstemp()
-TemporaryFile()
-var = "hello"
-"""
-
-        self.run_and_assert(tmpdir, input_code, expected_output)
+# class TestOpenTempfileMktemp(BaseSemgrepCodemodTest):
+#     codemod = TempfileMktemp
+#
+#     def test_open_and_write(self, tmpdir):
+#         input_code = """
+#         import tempfile
+#
+#         tmp_file = open(tempfile.mktemp(), "w+")
+#         tmp_file.write("text")
+#         """
+#         expected_output = """
+#         import tempfile
+#
+#         with tempfile.NamedTemporaryFile("w+", delete=False) as tf:
+#             tf.write("text")
+#         """
+#         self.run_and_assert(tmpdir, input_code, expected_output)
+#
+#     def test_open_write_close(self, tmpdir):
+#         input_code = """
+#         import tempfile
+#
+#         tmp_file = open(tempfile.mktemp(), "w+")
+#         tmp_file.write("text")
+#         print(tmp_file.name)
+#         tmp_file.close()
+#         """
+#         expected_output = """
+#         import tempfile
+#
+#         with tempfile.NamedTemporaryFile("w+") as tf:
+#             tf.write("text")
+#             print(tmp_file.name)
+#         """
+#         self.run_and_assert(tmpdir, input_code, expected_output)
+#
+#     def test_make_name_then_open(self, tmpdir):
+#         input_code = """
+#         import tempfile
+#
+#         filename = tempfile.mktemp()
+#         print(filename)
+#         tmp_file = open(filename, "w+")
+#         tmp_file.write("text")
+#         print("hello")
+#         """
+#         expected_output = """
+#         import tempfile
+#
+#         with tempfile.NamedTemporaryFile("w+", delete=False) as tf:
+#             filename = tf.name
+#             print(filename)
+#             tf.write("text")
+#         print("hello")
+#         """
+#         self.run_and_assert(tmpdir, input_code, expected_output)
+#
+#     def test_open_context_manager(self, tmpdir):
+#         input_code = """
+#         import tempfile
+#
+#         filename = tempfile.mktemp()
+#         with open(filename, "w+") as tmp:
+#             tmp.write("text")
+#         """
+#         expected_output = """
+#         import tempfile
+#
+#         with tempfile.NamedTemporaryFile("w+") as tf:
+#             tf.write("text")
+#         """
+#         self.run_and_assert(tmpdir, input_code, expected_output)

--- a/tests/codemods/test_tempfile_mktemp.py
+++ b/tests/codemods/test_tempfile_mktemp.py
@@ -68,15 +68,19 @@ class TestTempfileMktemp(BaseSemgrepCodemodTest):
         expected_output = """
         import tempfile
 
-        with tempfile.NamedTemporaryFile(suffix='suffix', delete=False) as tf:
+        with tempfile.NamedTemporaryFile(suffix="suffix", delete=False) as tf:
             filename = tf.name
-        with tempfile.NamedTemporaryFile(suffix='suffix', prefix='prefix', delete=False) as tf:
+        
+        with tempfile.NamedTemporaryFile(suffix="suffix", prefix="prefix", delete=False) as tf:
             print(tf.name)
-        with tempfile.NamedTemporaryFile(suffix='suffix', prefix='prefix', dir='dir', delete=False) as tf:
+        
+        with tempfile.NamedTemporaryFile(suffix="suffix", prefix="prefix", dir="dir", delete=False) as tf:
             filename = tf.name
-        with tempfile.NamedTemporaryFile(suffix='suffix', prefix='prefix', delete=False) as tf:
+        
+        with tempfile.NamedTemporaryFile(suffix="suffix", prefix="prefix", delete=False) as tf:
             filename = tf.name
-        with tempfile.NamedTemporaryFile(suffix='suffix', prefix='prefix', dir='dir', delete=False) as tf:
+        
+        with tempfile.NamedTemporaryFile(suffix="suffix", prefix="prefix", dir="dir", delete=False) as tf:
             filename = tf.name
         var = "hello"
         """

--- a/tests/codemods/test_tempfile_mktemp.py
+++ b/tests/codemods/test_tempfile_mktemp.py
@@ -19,7 +19,7 @@ class TestTempfileMktemp(BaseSemgrepCodemodTest):
     def test_import(self, tmpdir):
         input_code = """
         import tempfile
-        
+
         name = tempfile.mktemp()
         var = "hello"
         """

--- a/tests/samples/tempfile_mktemp.py
+++ b/tests/samples/tempfile_mktemp.py
@@ -1,3 +1,3 @@
 import tempfile
 
-tempfile.mktemp()
+filename = tempfile.mktemp()


### PR DESCRIPTION
## Overview
*The original impl of this codemod incorrectly interpreted the docs and assumed `mktemp` could be directly replaced with `mkstemp` but that is not the case*

## Description

* `mktemp` calls cannot be directly replaced with `mkstemp` because the former returns a filename while the latter returns a filename and a pointer to a new file with that name. `mktemp` is insecure because it doesn't handle a potential race condition, but we cannot directly replace it with `mkstemp`
* We're going to then make more bold assumptions as to the code intent when someone calls `mktemp`, which is that they don't only want a filename for no reason, but that they actually want to use the file for something. For that, a more appropriate replacement is to call `with tempfile.NamedTemporaryFile(delete=False) as tf`
* But because we cannot directly know what the code may want the filename for, we're going to keep the file open and let the code author decide when to close it
* I've handled for most reasonable cases while leaving some good unit tests xfailed for more complex cases.

Closes #560
