### PR TITLE
Remove redundant Sonar prefix in CodeTF summary

### DIFF
--- a/src/core_codemods/sonar/api.py
+++ b/src/core_codemods/sonar/api.py
@@ -28,7 +28,7 @@ class SonarCodemod(SASTCodemod):
         return SonarCodemod(
             metadata=Metadata(
                 name=name,
-                summary="Sonar: " + other.summary,
+                summary=other.summary,
                 review_guidance=other._metadata.review_guidance,
                 references=(
                     other.references + [Reference(url=rule_url, description=rule_name)]


### PR DESCRIPTION
## Overview
*Remove redundant "Sonar" prefix in CodeTF summary*

## Description

* In terms of presentation this is actually made redundant by the introduction of detection tool metadata in #366
