### PR TITLE
Remove additional redundant remediation text

### DIFF
--- a/src/core_codemods/defectdojo/api.py
+++ b/src/core_codemods/defectdojo/api.py
@@ -53,13 +53,12 @@ class DefectDojoCodemod(SASTCodemod):
         return DefectDojoCodemod(
             metadata=Metadata(
                 name=name,
-                summary="DefectDojo: " + other.summary,
+                summary=other.summary,
                 review_guidance=other._metadata.review_guidance,
                 references=(
                     other.references + [Reference(url=rule_url, description=rule_name)]
                 ),
-                description=f"This codemod acts upon the following DefectDojo rules: {rule_id}.\n\n"
-                + other.description,
+                description=other.description,
                 tool=ToolMetadata(
                     name="DefectDojo",
                     rules=[

--- a/src/core_codemods/sonar/api.py
+++ b/src/core_codemods/sonar/api.py
@@ -33,8 +33,7 @@ class SonarCodemod(SASTCodemod):
                 references=(
                     other.references + [Reference(url=rule_url, description=rule_name)]
                 ),
-                description=f"This codemod acts upon the following Sonar rules: {rule_id}.\n\n"
-                + other.description,
+                description=other.description,
                 tool=ToolMetadata(
                     name="Sonar",
                     rules=[


### PR DESCRIPTION
This is a follow-up to #606. It removes more metadata that is made redundant by #366.
