### PR TITLE
LLM and test refactor

### DIFF
--- a/src/codemodder/codemodder.py
+++ b/src/codemodder/codemodder.py
@@ -12,8 +12,9 @@ from codemodder.code_directory import match_files
 from codemodder.codemods.api import BaseCodemod
 from codemodder.codemods.semgrep import SemgrepRuleDetector
 from codemodder.codetf import CodeTF
-from codemodder.context import CodemodExecutionContext, MisconfiguredAIClient
+from codemodder.context import CodemodExecutionContext
 from codemodder.dependency import Dependency
+from codemodder.llm import MisconfiguredAIClient
 from codemodder.logging import configure_logger, log_list, log_section, logger
 from codemodder.project_analysis.file_parsers.package_store import PackageStore
 from codemodder.project_analysis.python_repo_manager import PythonRepoManager

--- a/src/codemodder/codemods/test/__init__.py
+++ b/src/codemodder/codemods/test/__init__.py
@@ -5,4 +5,5 @@ from .utils import (
     BaseDjangoCodemodTest,
     BaseSASTCodemodTest,
     BaseSemgrepCodemodTest,
+    DiffError,
 )

--- a/src/codemodder/llm.py
+++ b/src/codemodder/llm.py
@@ -13,6 +13,12 @@ if TYPE_CHECKING:
 
 from codemodder.logging import logger
 
+__all__ = [
+    "MODELS",
+    "setup_llm_client",
+    "MisconfiguredAIClient",
+]
+
 models = ["gpt-4-turbo-2024-04-09", "gpt-4o-2024-05-13"]
 DEFAULT_AZURE_OPENAI_API_VERSION = "2024-02-01"
 

--- a/src/codemodder/llm.py
+++ b/src/codemodder/llm.py
@@ -1,0 +1,77 @@
+import os
+from typing import TYPE_CHECKING
+
+try:
+    from openai import AzureOpenAI, OpenAI
+except ImportError:
+    OpenAI = None
+    AzureOpenAI = None
+
+
+if TYPE_CHECKING:
+    from openai import OpenAI
+
+from codemodder.logging import logger
+
+models = ["gpt-4-turbo-2024-04-09", "gpt-4o-2024-05-13"]
+DEFAULT_AZURE_OPENAI_API_VERSION = "2024-02-01"
+
+
+class ModelRegistry(dict):
+    def __init__(self, models):
+        super().__init__()
+        self.models = models
+        for model in models:
+            attribute_name = model.replace("-", "_")
+            self[attribute_name] = model
+
+    def __getattr__(self, name):
+        if name in self:
+            return os.getenv(
+                f"CODEMODDER_AZURE_OPENAI_{self[name].upper()}_DEPLOYMENT", self[name]
+            )
+        raise AttributeError(
+            f"'{self.__class__.__name__}' object has no attribute '{name}'"
+        )
+
+
+MODELS = ModelRegistry(models)
+
+
+def setup_llm_client() -> OpenAI | None:
+    if not AzureOpenAI:
+        logger.info("Azure OpenAI API client not available")
+        return None
+
+    azure_openapi_key = os.getenv("CODEMODDER_AZURE_OPENAI_API_KEY")
+    azure_openapi_endpoint = os.getenv("CODEMODDER_AZURE_OPENAI_ENDPOINT")
+    if bool(azure_openapi_key) ^ bool(azure_openapi_endpoint):
+        raise MisconfiguredAIClient(
+            "Azure OpenAI API key and endpoint must both be set or unset"
+        )
+
+    if azure_openapi_key and azure_openapi_endpoint:
+        logger.info("Using Azure OpenAI API client")
+        return AzureOpenAI(
+            api_key=azure_openapi_key,
+            api_version=os.getenv(
+                "CODEMODDER_AZURE_OPENAI_API_VERSION",
+                DEFAULT_AZURE_OPENAI_API_VERSION,
+            ),
+            azure_endpoint=azure_openapi_endpoint,
+        )
+
+    if not OpenAI:
+        logger.info("OpenAI API client not available")
+        return None
+
+    if not (api_key := os.getenv("CODEMODDER_OPENAI_API_KEY")):
+        logger.info("OpenAI API key not found")
+        return None
+
+    logger.info("Using OpenAI API client")
+    return OpenAI(api_key=api_key)
+
+
+class MisconfiguredAIClient(ValueError):
+    pass

--- a/tests/test_context.py
+++ b/tests/test_context.py
@@ -3,10 +3,9 @@ import os
 import pytest
 from openai import AzureOpenAI, OpenAI
 
-from codemodder.context import DEFAULT_AZURE_OPENAI_API_VERSION
 from codemodder.context import CodemodExecutionContext as Context
-from codemodder.context import MisconfiguredAIClient
 from codemodder.dependency import Security
+from codemodder.llm import DEFAULT_AZURE_OPENAI_API_VERSION, MisconfiguredAIClient
 from codemodder.project_analysis.python_repo_manager import PythonRepoManager
 from codemodder.registry import load_registered_codemods
 
@@ -145,38 +144,6 @@ class TestContext:
                 [],
                 [],
             )
-
-    def test_get_model_name(self, mocker):
-        context = Context(
-            mocker.Mock(),
-            True,
-            False,
-            load_registered_codemods(),
-            PythonRepoManager(mocker.Mock()),
-            [],
-            [],
-        )
-        assert context.gpt_4_turbo_2024_04_09 == "gpt-4-turbo-2024-04-09"
-
-    @pytest.mark.parametrize("model", ["gpt-4-turbo-2024-04-09", "gpt-4o-2024-05-13"])
-    def test_model_get_name_from_env(self, mocker, model):
-        name = "my-awesome-deployment"
-        mocker.patch.dict(
-            os.environ,
-            {
-                f"CODEMODDER_AZURE_OPENAI_{model.upper()}_DEPLOYMENT": name,
-            },
-        )
-        context = Context(
-            mocker.Mock(),
-            True,
-            False,
-            load_registered_codemods(),
-            PythonRepoManager(mocker.Mock()),
-            [],
-            [],
-        )
-        assert getattr(context, model.replace("-", "_")) == name
 
     def test_get_api_version_from_env(self, mocker):
         version = "fake-version"

--- a/tests/test_llm.py
+++ b/tests/test_llm.py
@@ -1,0 +1,21 @@
+import os
+
+import pytest
+
+from codemodder.llm import MODELS
+
+
+class TestModels:
+    def test_get_model_name(self):
+        assert MODELS.gpt_4_turbo_2024_04_09 == "gpt-4-turbo-2024-04-09"
+
+    @pytest.mark.parametrize("model", ["gpt-4-turbo-2024-04-09", "gpt-4o-2024-05-13"])
+    def test_model_get_name_from_env(self, mocker, model):
+        name = "my-awesome-deployment"
+        mocker.patch.dict(
+            os.environ,
+            {
+                f"CODEMODDER_AZURE_OPENAI_{model.upper()}_DEPLOYMENT": name,
+            },
+        )
+        assert getattr(MODELS, model.replace("-", "_")) == name


### PR DESCRIPTION
## Overview
*This PR moves LLM initialization into its own module and updates tests for easier api*

## Description

* We want to be able to initialize an LLM client in testing, outside of codemodder context, so moving it out to its own module so it can be used
* updated tests to create a DiffError class so we can differentiate (and catch) code errors versus codemodder diff output errors. This will help LLM codemods mostly.

