### PR TITLE
Update `openai` and test codemodder without it

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -38,6 +38,24 @@ jobs:
         run: python -m build .
       - name: Twine Check
         run: twine check dist/*
+  test-minimal:
+    # Test that a codemodder run doesn't require any optional dependencies.
+    name: Run codemodder list
+    runs-on: ubuntu-22.04
+    timeout-minutes: 5
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v4
+      - name: Set Up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+          cache: 'pip'
+      - name: Install Codemodder Package
+        # Only install what most users would, not optional dependencies
+        run: pip install .
+      - name: Run codemodder
+        run: codemodder --list
   test:
     name: Run pytest
     runs-on: ubuntu-22.04

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,7 +56,7 @@ test = [
     "Jinja2~=3.1.2",
     "jsonschema~=4.22.0",
     "lxml>=4.9.3,<5.3.0",
-    "openai~=1.30.2",
+    "openai>=1.0,<1.33",
     "mock==5.1.*",
     "pre-commit<4",
     "Pyjwt~=2.8.0",
@@ -80,7 +80,7 @@ complexity = [
     "xenon==0.9.*",
 ]
 openai = [
-    "openai>=1.0,<1.31",
+    "openai>=1.0,<1.33",
 ]
 all = [
     "codemodder[test]",

--- a/src/codemodder/llm.py
+++ b/src/codemodder/llm.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import os
 from typing import TYPE_CHECKING
 


### PR DESCRIPTION
~I noticed we had openai declared both as a project dependency ( but that was not defined in  `all = ...` and as a test dependency. I think just making it a project dependency this was is the correct way, but perhaps there was a different intention here?~

Fixes a bug in codemodder if openai is not installed and test in CI to prevent it. Also updated the dependency.

Can currently open dependabot PR if this is merged.