### PR TITLE
Support parsing/writing pyproject.toml with `poetry`

### DIFF
--- a/src/codemodder/dependency_management/pyproject_writer.py
+++ b/src/codemodder/dependency_management/pyproject_writer.py
@@ -21,6 +21,9 @@ class PyprojectWriter(DependencyWriter):
         pyproject = self._parse_file()
         original = deepcopy(pyproject)
 
+        # It's unlikely and bad practice to declare dependencies under [project].dependencies
+        # and [tool.poetry.dependencies] but if it happens, prioritize poetry
+
         try:
             pyproject["project"]["dependencies"].extend(
                 [f"{dep.requirement}" for dep in dependencies]

--- a/src/codemodder/dependency_management/pyproject_writer.py
+++ b/src/codemodder/dependency_management/pyproject_writer.py
@@ -22,11 +22,13 @@ class PyprojectWriter(DependencyWriter):
         original = deepcopy(pyproject)
 
         if poetry_data := pyproject.get("tool", {}).get("poetry", {}):
+            add_newline = False
             # It's unlikely and bad practice to declare dependencies under [project].dependencies
             # and [tool.poetry.dependencies] but if it happens, we will give priority to poetry
             # and add dependencies under its system.
             if poetry_data.get("dependencies") is None:
                 pyproject["tool"]["poetry"].append("dependencies", {})
+                add_newline = True
 
             for dep in dependencies:
                 try:
@@ -35,6 +37,9 @@ class PyprojectWriter(DependencyWriter):
                     )
                 except tomlkit.exceptions.KeyAlreadyPresent:
                     pass
+
+            if add_newline:
+                pyproject["tool"]["poetry"]["dependencies"].add(tomlkit.nl())
 
         else:
             try:

--- a/src/codemodder/dependency_management/pyproject_writer.py
+++ b/src/codemodder/dependency_management/pyproject_writer.py
@@ -21,10 +21,13 @@ class PyprojectWriter(DependencyWriter):
         pyproject = self._parse_file()
         original = deepcopy(pyproject)
 
-        if pyproject.get("tool", {}).get("poetry", {}).get("dependencies"):
+        if poetry_data := pyproject.get("tool", {}).get("poetry", {}):
             # It's unlikely and bad practice to declare dependencies under [project].dependencies
             # and [tool.poetry.dependencies] but if it happens, we will give priority to poetry
             # and add dependencies under its system.
+            if poetry_data.get("dependencies") is None:
+                pyproject["tool"]["poetry"].append("dependencies", {})
+
             for dep in dependencies:
                 try:
                     pyproject["tool"]["poetry"]["dependencies"].append(

--- a/src/codemodder/project_analysis/file_parsers/package_store.py
+++ b/src/codemodder/project_analysis/file_parsers/package_store.py
@@ -2,6 +2,8 @@ from dataclasses import dataclass
 from enum import Enum
 from pathlib import Path
 
+from packaging.requirements import InvalidRequirement
+
 from codemodder.dependency import Requirement
 
 
@@ -29,10 +31,38 @@ class PackageStore:
         self.type = type
         self.file = file
         self.dependencies = {
-            dep if isinstance(dep, Requirement) else Requirement(dep)
-            for dep in dependencies
+            x for x in {parse_requirement(dep) for dep in dependencies} if x
         }
         self.py_versions = py_versions
 
     def has_requirement(self, requirement: Requirement) -> bool:
         return requirement.name in {dep.name for dep in self.dependencies}
+
+
+def parse_requirement(requirement: str | Requirement) -> Requirement:
+    match requirement:
+        case Requirement():
+            return requirement
+        case _:
+            try:
+                return Requirement(convert_py_version(requirement))
+            except (InvalidRequirement, ValueError):
+                return None
+
+
+def convert_py_version(py_version: str) -> str:
+    """
+    Convert any dependency with ^ syntax to equivalent >=, < syntax.
+    packaging.requirements does not support parsing dependencies with `^` syntax
+    which is common in Poetry. For our internal representation we will convert it to
+
+    `pandas^1.2.31` is equivalent to `pandas>=1.2.3,< 2.0.0`
+    """
+    if "^" in py_version:
+        try:
+            name, version = py_version.split("^")
+            next_major_version = int(version.strip()[0]) + 1
+            return f"{name}>={version},<{next_major_version}.0.0"
+        except Exception:
+            raise ValueError
+    return py_version

--- a/src/codemodder/project_analysis/file_parsers/pyproject_toml_file_parser.py
+++ b/src/codemodder/project_analysis/file_parsers/pyproject_toml_file_parser.py
@@ -16,17 +16,35 @@ class PyprojectTomlParser(BaseParser):
         return FileType.TOML
 
     def _parse_file(self, file: Path) -> PackageStore | None:
+        """
+        Parse a pyproject.toml file which may or may not use poetry.
+        """
         data = toml.load(file)
+        project_data = data.get("project")
+        poetry_data = data.get("tool", {}).get("poetry")
 
-        if not (project := data.get("project")):
+        if not project_data and not poetry_data:
             return None
 
-        dependencies = project.get("dependencies", [])
-        version = project.get("requires-python", None)
+        version = None
+        project_dependencies, poetry_dependencies = [], []
+        if project_data:
+            project_dependencies = project_data.get("dependencies", [])
+            version = project_data.get("requires-python", None)
+
+        if poetry_data:
+            poetry_dependencies = [
+                f"{name}{version}"
+                for name, version in poetry_data.get("dependencies", {}).items()
+                if name != "python"
+            ]
+            # TODO: pandas^1.2.3 or similar needs to be changed to pip valid
+            # In poetry python version is declared within `[tool.poetry.dependencies]`
+            version = poetry_data.get("dependencies", {}).get("python", None)
 
         return PackageStore(
             type=self.file_type,
             file=file,
-            dependencies=set(dependencies),
+            dependencies=set(project_dependencies + poetry_dependencies),
             py_versions=[version] if version else [],
         )

--- a/src/codemodder/project_analysis/file_parsers/pyproject_toml_file_parser.py
+++ b/src/codemodder/project_analysis/file_parsers/pyproject_toml_file_parser.py
@@ -38,7 +38,7 @@ class PyprojectTomlParser(BaseParser):
                 for name, version in poetry_data.get("dependencies", {}).items()
                 if name != "python"
             ]
-            # TODO: pandas^1.2.3 or similar needs to be changed to pip valid
+
             # In poetry python version is declared within `[tool.poetry.dependencies]`
             version = poetry_data.get("dependencies", {}).get("python", None)
 

--- a/tests/dependency_management/test_pyproject_writer.py
+++ b/tests/dependency_management/test_pyproject_writer.py
@@ -36,7 +36,7 @@ def test_update_pyproject_dependencies(tmpdir, dry_run):
     pyproject_toml.write(dedent(orig_pyproject))
 
     store = PackageStore(
-        type=FileType.REQ_TXT,
+        type=FileType.TOML,
         file=pyproject_toml,
         dependencies=set(),
         py_versions=[">=3.10.0"],
@@ -127,7 +127,7 @@ def test_add_same_dependency_only_once(tmpdir):
     pyproject_toml.write(dedent(orig_pyproject))
 
     store = PackageStore(
-        type=FileType.REQ_TXT,
+        type=FileType.TOML,
         file=pyproject_toml,
         dependencies=set(),
         py_versions=[">=3.10.0"],
@@ -181,7 +181,7 @@ def test_dont_add_existing_dependency(tmpdir):
     pyproject_toml.write(dedent(orig_pyproject))
 
     store = PackageStore(
-        type=FileType.REQ_TXT,
+        type=FileType.TOML,
         file=pyproject_toml,
         dependencies=set([Security.requirement]),
         py_versions=[">=3.10.0"],
@@ -207,7 +207,7 @@ def test_pyproject_no_dependencies(tmpdir):
     pyproject_toml.write(dedent(orig_pyproject))
 
     store = PackageStore(
-        type=FileType.REQ_TXT,
+        type=FileType.TOML,
         file=pyproject_toml,
         dependencies=set(),
         py_versions=[">=3.10.0"],
@@ -219,3 +219,59 @@ def test_pyproject_no_dependencies(tmpdir):
     writer.write(dependencies)
 
     assert pyproject_toml.read() == dedent(orig_pyproject)
+
+
+def test_pyproject_poetry(tmpdir):
+    orig_pyproject = """\
+        [tool.poetry]
+        name = "example-project"
+        version = "0.1.0"
+        description = "An example project to demonstrate Poetry configuration."
+        authors = ["Your Name <your.email@example.com>"]
+        
+        [build-system]
+        requires = ["poetry-core>=1.0.0"]
+        build-backend = "poetry.core.masonry.api"
+        
+        [tool.poetry.dependencies]
+        python = "~=3.11.0"
+        requests = ">=2.25.1,<3.0.0"
+        pandas = "1.2.3"
+        libcst = ">1.0"
+    """
+
+    pyproject_toml = tmpdir.join("pyproject.toml")
+    pyproject_toml.write(dedent(orig_pyproject))
+
+    store = PackageStore(
+        type=FileType.TOML,
+        file=pyproject_toml,
+        dependencies=set(),
+        py_versions=["~=3.11.0"],
+    )
+
+    writer = PyprojectWriter(store, tmpdir)
+    dependencies = [Security, DefusedXML]
+    writer.write(dependencies)
+
+    updated_pyproject = f"""\
+        [tool.poetry]
+        name = "example-project"
+        version = "0.1.0"
+        description = "An example project to demonstrate Poetry configuration."
+        authors = ["Your Name <your.email@example.com>"]
+        
+        [build-system]
+        requires = ["poetry-core>=1.0.0"]
+        build-backend = "poetry.core.masonry.api"
+        
+        [tool.poetry.dependencies]
+        python = "~=3.11.0"
+        requests = ">=2.25.1,<3.0.0"
+        pandas = "1.2.3"
+        libcst = ">1.0"
+        {Security.requirement.name} = "{ str(Security.requirement.specifier)}"
+        {DefusedXML.requirement.name} = "{ str(DefusedXML.requirement.specifier)}"
+    """
+
+    assert pyproject_toml.read() == dedent(updated_pyproject)

--- a/tests/dependency_management/test_pyproject_writer.py
+++ b/tests/dependency_management/test_pyproject_writer.py
@@ -351,6 +351,7 @@ def test_pyproject_poetry_no_deps_section(tmpdir):
         [tool.poetry.dependencies]
         {Security.requirement.name} = "{str(Security.requirement.specifier)}"
         {DefusedXML.requirement.name} = "{str(DefusedXML.requirement.specifier)}"
+
         [build-system]
         requires = ["poetry-core>=1.0.0"]
         build-backend = "poetry.core.masonry.api"

--- a/tests/project_analysis/file_parsers/test_pyproject_toml_file_parser.py
+++ b/tests/project_analysis/file_parsers/test_pyproject_toml_file_parser.py
@@ -74,6 +74,34 @@ def pkg_with_poetry_pyproject(tmp_path_factory):
     return base_dir
 
 
+@pytest.fixture(scope="module")
+def pkg_with_poetry_multiple_dep_locations(tmp_path_factory):
+    base_dir = tmp_path_factory.mktemp("foo")
+    toml_file = base_dir / "pyproject.toml"
+    toml = """\
+    [project]
+    name = "example-project"
+    version = "0.1.0"
+    description = "An example project to demonstrate Poetry configuration."
+    authors = ["Your Name <your.email@example.com>"]
+    dependencies = [
+            "isort~=5.12.0"
+           ]
+
+    [build-system]
+    requires = ["poetry-core>=1.0.0"]
+    build-backend = "poetry.core.masonry.api"
+
+    [tool.poetry.dependencies]
+    python = "~=3.11.0"
+    requests = ">=2.25.1,<3.0.0"
+    pandas = "1.2.3"
+    libcst = ">1.0"
+    """
+    toml_file.write_text(toml)
+    return base_dir
+
+
 class TestPyprojectTomlParser:
     def test_parse(self, pkg_with_pyproject_toml):
         parser = PyprojectTomlParser(pkg_with_pyproject_toml)
@@ -118,3 +146,18 @@ class TestPyprojectTomlParser:
         assert store.file == pkg_with_poetry_pyproject / parser.file_type.value
         assert store.py_versions == ["~=3.11.0"]
         assert len(store.dependencies) == 3
+
+    def test_parse_poetry_and_project_dependencies(
+        self, pkg_with_poetry_multiple_dep_locations
+    ):
+        parser = PyprojectTomlParser(pkg_with_poetry_multiple_dep_locations)
+        found = parser.parse()
+        assert len(found) == 1
+        store = found[0]
+        assert store.type.value == "pyproject.toml"
+        assert (
+            store.file
+            == pkg_with_poetry_multiple_dep_locations / parser.file_type.value
+        )
+        assert store.py_versions == ["~=3.11.0"]
+        assert len(store.dependencies) == 4

--- a/tests/project_analysis/file_parsers/test_pyproject_toml_file_parser.py
+++ b/tests/project_analysis/file_parsers/test_pyproject_toml_file_parser.py
@@ -49,6 +49,31 @@ def pkg_with_pyproject_toml_no_python(tmp_path_factory):
     return base_dir
 
 
+@pytest.fixture(scope="module")
+def pkg_with_poetry_pyproject(tmp_path_factory):
+    base_dir = tmp_path_factory.mktemp("foo")
+    toml_file = base_dir / "pyproject.toml"
+    toml = """\
+    [tool.poetry]
+    name = "example-project"
+    version = "0.1.0"
+    description = "An example project to demonstrate Poetry configuration."
+    authors = ["Your Name <your.email@example.com>"]
+    
+    [build-system]
+    requires = ["poetry-core>=1.0.0"]
+    build-backend = "poetry.core.masonry.api"
+    
+    [tool.poetry.dependencies]
+    python = "~=3.11.0"
+    requests = ">=2.25.1,<3.0.0"
+    pandas = "1.2.3"
+    libcst = ">1.0"
+    """
+    toml_file.write_text(toml)
+    return base_dir
+
+
 class TestPyprojectTomlParser:
     def test_parse(self, pkg_with_pyproject_toml):
         parser = PyprojectTomlParser(pkg_with_pyproject_toml)
@@ -83,3 +108,13 @@ class TestPyprojectTomlParser:
         parser = PyprojectTomlParser(pkg_with_pyproject_toml)
         found = parser.parse()
         assert len(found) == 0
+
+    def test_parse_poetry(self, pkg_with_poetry_pyproject):
+        parser = PyprojectTomlParser(pkg_with_poetry_pyproject)
+        found = parser.parse()
+        assert len(found) == 1
+        store = found[0]
+        assert store.type.value == "pyproject.toml"
+        assert store.file == pkg_with_poetry_pyproject / parser.file_type.value
+        assert store.py_versions == ["~=3.11.0"]
+        assert len(store.dependencies) == 3


### PR DESCRIPTION
## Overview
*codemodder can now parse projects with poetry*

## Description

* poetry is a pretty common python dependency management tool
* it's declared within pyproject.toml, so I've updated that parser and writer to support poetry
* i've also handled some edge cases, such as rare case when dependencies are declared in multiple places.
* one interesting thing I had to account for is the caret `^` version declaration that's common in poetry but not parsable by `packaging.requirements`. We don't have to do much right now other than make sure we can at least parse these dependencies and store them. Our new dependencies won't use this format.

We don't currently have integration level testing for this kind of stuff so I tested this with a poetry pyproject.toml file in pygoat and it all worked as expected. `defusexml` was correctly added in the expected place.

Closes #634 
