### PR TITLE
dependency type stubs

### DIFF
--- a/src/codemodder/dependency.py
+++ b/src/codemodder/dependency.py
@@ -17,6 +17,8 @@ class Dependency:
     oss_link: str
     package_link: str
     hashes: list[str] = field(default_factory=list)
+    # Forward reference
+    type_stubs: list["Dependency"] = field(default_factory=list)
 
     @property
     def name(self) -> str:
@@ -56,6 +58,24 @@ FlaskWTF = Dependency(
     ),
     oss_link="https://github.com/wtforms/flask-wtf/",
     package_link="https://pypi.org/project/Flask-WTF/",
+    type_stubs=[
+        Dependency(
+            Requirement("types-WTForms==3.1.0.20240425"),
+            hashes=[
+                "449b6e3756b2bc70657e98d989bdbf572a25466428774be96facf9debcbf6c4e",
+                "49ffc1fe5576ea0735b763fff77e7060dd39ecc661276cbd0b47099921b3a6f2",
+            ],
+            description="""\
+                    This is a type stub package for the WTForms package.
+        """,
+            _license=License(
+                "Apache-2.0",
+                "https://opensource.org/license/apache-2-0",
+            ),
+            oss_link="https://github.com/python/typeshed",
+            package_link="https://pypi.org/project/types-WTForms/",
+        ),
+    ],
 )
 
 DefusedXML = Dependency(
@@ -74,6 +94,24 @@ to protect against XML vulnerabilities.\
     ),
     oss_link="https://github.com/tiran/defusedxml",
     package_link="https://pypi.org/project/defusedxml/",
+    type_stubs=[
+        Dependency(
+            Requirement("types-defusedxml==0.7.0.20240218"),
+            hashes=[
+                "2b7f3c5ca14fdbe728fab0b846f5f7eb98c4bd4fd2b83d25f79e923caa790ced",
+                "05688a7724dc66ea74c4af5ca0efc554a150c329cb28c13a64902cab878d06ed",
+            ],
+            description="""\
+                This is a type stub package for the defusedxml package.
+    """,
+            _license=License(
+                "Apache-2.0",
+                "https://opensource.org/license/apache-2-0",
+            ),
+            oss_link="https://github.com/python/typeshed",
+            package_link="https://pypi.org/project/types-defusedxml/",
+        ),
+    ],
 )
 
 Security = Dependency(

--- a/src/codemodder/dependency_management/codemod_dependencies.txt
+++ b/src/codemodder/dependency_management/codemod_dependencies.txt
@@ -5,6 +5,8 @@
 # dependency in dependency.py. Be sure to update the version AND the hashes.
 # Run `get-hashes pkg==version` to get the hashes.
 defusedxml==0.7.1
+types-defusedxml==0.7.0.20240218
 flask-wtf==1.2.0
+types-WTForms==3.1.0.20240425
 security==1.2.1
 fickling==0.1.3

--- a/tests/dependency_management/test_pyproject_writer.py
+++ b/tests/dependency_management/test_pyproject_writer.py
@@ -4,7 +4,10 @@ import pytest
 
 from codemodder.codetf import DiffSide
 from codemodder.dependency import DefusedXML, Security
-from codemodder.dependency_management.pyproject_writer import PyprojectWriter
+from codemodder.dependency_management.pyproject_writer import (
+    TYPE_CHECKER_LIBRARIES,
+    PyprojectWriter,
+)
 from codemodder.project_analysis.file_parsers.package_store import (
     FileType,
     PackageStore,
@@ -410,7 +413,7 @@ def test_pyproject_poetry_no_declared_deps(tmpdir):
     assert pyproject_toml.read() == dedent(updated_pyproject)
 
 
-@pytest.mark.parametrize("type_checker", ["mypy", "pyright"])
+@pytest.mark.parametrize("type_checker", TYPE_CHECKER_LIBRARIES)
 def test_pyproject_poetry_with_type_checker_tool(tmpdir, type_checker):
     orig_pyproject = f"""\
         [tool.poetry]
@@ -480,7 +483,7 @@ def test_pyproject_poetry_with_type_checker_tool(tmpdir, type_checker):
         "[tool.poetry.group.test.dependencies]",
     ],
 )
-@pytest.mark.parametrize("type_checker", ["mypy", "pyright"])
+@pytest.mark.parametrize("type_checker", TYPE_CHECKER_LIBRARIES)
 def test_pyproject_poetry_with_type_checker_tool_without_poetry_deps_section(
     tmpdir, type_checker, dependency_section
 ):
@@ -530,6 +533,71 @@ def test_pyproject_poetry_with_type_checker_tool_without_poetry_deps_section(
         build-backend = "poetry.core.masonry.api"
         
         {dependency_section}
+        {type_checker} = "==1.0"
+        {defusedxml_type_stub.requirement.name} = "{str(defusedxml_type_stub.requirement.specifier)}"
+    """
+
+    assert pyproject_toml.read() == dedent(updated_pyproject)
+
+
+@pytest.mark.parametrize("type_checker", TYPE_CHECKER_LIBRARIES)
+def test_pyproject_poetry_with_type_checker_tool_multiple(tmpdir, type_checker):
+    orig_pyproject = f"""\
+        [build-system]
+        requires = ["poetry-core>=1.0.0"]
+        build-backend = "poetry.core.masonry.api"
+        
+        [tool.poetry]
+        name = "example-project"
+        version = "0.1.0"
+        description = "An example project to demonstrate Poetry configuration."
+        authors = ["Your Name <your.email@example.com>"]
+
+        [tool.poetry.dependencies]
+        python = "~=3.11.0"
+        requests = ">=2.25.1,<3.0.0"
+        pandas = "^1.2.3"
+        libcst = ">1.0"
+        
+        [tool.poetry.group.test.dependencies]
+        {type_checker} = "==1.0"
+    """
+
+    pyproject_toml = tmpdir.join("pyproject.toml")
+    pyproject_toml.write(dedent(orig_pyproject))
+
+    store = PackageStore(
+        type=FileType.TOML,
+        file=pyproject_toml,
+        dependencies=set(),
+        py_versions=["~=3.11.0"],
+    )
+
+    writer = PyprojectWriter(store, tmpdir)
+    dependencies = [Security, DefusedXML]
+    writer.write(dependencies)
+
+    defusedxml_type_stub = DefusedXML.type_stubs[0]
+    updated_pyproject = f"""\
+        [build-system]
+        requires = ["poetry-core>=1.0.0"]
+        build-backend = "poetry.core.masonry.api"
+        
+        [tool.poetry]
+        name = "example-project"
+        version = "0.1.0"
+        description = "An example project to demonstrate Poetry configuration."
+        authors = ["Your Name <your.email@example.com>"]
+
+        [tool.poetry.dependencies]
+        python = "~=3.11.0"
+        requests = ">=2.25.1,<3.0.0"
+        pandas = "^1.2.3"
+        libcst = ">1.0"
+        {Security.requirement.name} = "{str(Security.requirement.specifier)}"
+        {DefusedXML.requirement.name} = "{str(DefusedXML.requirement.specifier)}"
+
+        [tool.poetry.group.test.dependencies]
         {type_checker} = "==1.0"
         {defusedxml_type_stub.requirement.name} = "{str(defusedxml_type_stub.requirement.specifier)}"
     """

--- a/tests/dependency_management/test_pyproject_writer.py
+++ b/tests/dependency_management/test_pyproject_writer.py
@@ -494,12 +494,6 @@ def test_pyproject_poetry_with_type_checker_tool_without_poetry_deps_section(
         [build-system]
         requires = ["poetry-core>=1.0.0"]
         build-backend = "poetry.core.masonry.api"
-
-        [tool.poetry.dependencies]
-        python = "~=3.11.0"
-        requests = ">=2.25.1,<3.0.0"
-        pandas = "^1.2.3"
-        libcst = ">1.0"
         
         {dependency_section}
         {type_checker} = "==1.0"
@@ -527,17 +521,13 @@ def test_pyproject_poetry_with_type_checker_tool_without_poetry_deps_section(
         description = "An example project to demonstrate Poetry configuration."
         authors = ["Your Name <your.email@example.com>"]
 
+        [tool.poetry.dependencies]
+        {Security.requirement.name} = "{str(Security.requirement.specifier)}"
+        {DefusedXML.requirement.name} = "{str(DefusedXML.requirement.specifier)}"
+
         [build-system]
         requires = ["poetry-core>=1.0.0"]
         build-backend = "poetry.core.masonry.api"
-
-        [tool.poetry.dependencies]
-        python = "~=3.11.0"
-        requests = ">=2.25.1,<3.0.0"
-        pandas = "^1.2.3"
-        libcst = ">1.0"
-        {Security.requirement.name} = "{str(Security.requirement.specifier)}"
-        {DefusedXML.requirement.name} = "{str(DefusedXML.requirement.specifier)}"
         
         {dependency_section}
         {type_checker} = "==1.0"


### PR DESCRIPTION
## Overview
*Add type stubs to our codemodder dependencies (those that have it) and write those stubs in pyproject.toml when poetry is used*

## Description

* the only dependencies codemodder may inject which have type stub libraries are defusedxml and flask-wtf. The latter has two potential type libraries, types-Flask, types-WTForms, but I decided not to add types-Flask because https://pypi.org/project/types-Flask/#description because  states if you use flask 2.0+ (out since 2021), the stubs are in Flask itself.
* otherwise, I used the latest types library versions
* From there, we want to be able to add these type stub libraries if defusedxml or flask-wtf are added by one of our codemods. At this time we will only add these when a project has a pyproject.toml using poetry. The logic for that is based on some reasonable heuristics. We will add the typing library in one of a few locations where it may be.

testing with pygoat looks like this
```
  - pyproject.toml
    diff:
      ---
      +++
      @@ -15,6 +15,7 @@
       requests = "^2.25.1"
       pandas = "^1.2.3"
       libcst = ">1.0"
      +defusedxml = "==0.7.1"


       [tool.poetry.dev-dependencies]
      @@ -22,4 +23,5 @@
       black = "2^0.8b1"
       flake8 = "^3.8.4"
       mypy = "~0.800"
      +types-defusedxml = "==0.7.0.20240218"

```
Closes #635
