### PR TITLE
remove -ID from sonar codemod n

### DIFF
--- a/src/codemodder/scripts/generate_docs.py
+++ b/src/codemodder/scripts/generate_docs.py
@@ -290,33 +290,31 @@ DEFECTDOJO_CODEMODS = {
 }
 
 SONAR_CODEMOD_NAMES = [
-    "numpy-nan-equality-S6725",
-    "literal-or-new-object-identity-S5796",
-    "django-receiver-on-top-S6552",
-    "exception-without-raise-S3984",
-    "fix-assert-tuple-S5905",
-    "remove-assertion-in-pytest-raises-S5915",
-    "flask-json-response-type-S5131",
-    "django-json-response-type-S5131",
-    "jwt-decode-verify-S5659",
-    "fix-missing-self-or-cls-S5719",
-    "secure-tempfile-S5445",
-    "secure-random-S2245",
-    "enable-jinja2-autoescape-S5247",
-    "url-sandbox-S5144",
-    "fix-float-equality-S1244",
-    "fix-math-isclose-S6727",
-    "sql-parameterization-S3649",
-    "django-model-without-dunder-str-S6554",
-    "break-or-continue-out-of-loop-S1716",
-    "disable-graphql-introspection-S6786",
+    "numpy-nan-equality",
+    "literal-or-new-object-identity",
+    "django-receiver-on-top",
+    "exception-without-raise",
+    "fix-assert-tuple",
+    "remove-assertion-in-pytest-raises",
+    "flask-json-response-type",
+    "django-json-response-type",
+    "jwt-decode-verify",
+    "fix-missing-self-or-cls",
+    "secure-tempfile",
+    "secure-random",
+    "enable-jinja2-autoescape",
+    "url-sandbox",
+    "fix-float-equality",
+    "fix-math-isclose",
+    "sql-parameterization",
+    "django-model-without-dunder-str",
+    "break-or-continue-out-of-loop",
+    "disable-graphql-introspection",
 ]
 SONAR_CODEMODS = {
     name: DocMetadata(
-        importance=CORE_CODEMODS[
-            core_codemod_name := "-".join(name.split("-")[:-1])
-        ].importance,
-        guidance_explained=CORE_CODEMODS[core_codemod_name].guidance_explained,
+        importance=CORE_CODEMODS[name].importance,
+        guidance_explained=CORE_CODEMODS[name].guidance_explained,
         need_sarif="Yes (Sonar)",
     )
     for name in SONAR_CODEMOD_NAMES

--- a/src/core_codemods/sonar/sonar_break_or_continue_out_of_loop.py
+++ b/src/core_codemods/sonar/sonar_break_or_continue_out_of_loop.py
@@ -2,7 +2,7 @@ from core_codemods.break_or_continue_out_of_loop import BreakOrContinueOutOfLoop
 from core_codemods.sonar.api import SonarCodemod
 
 SonarBreakOrContinueOutOfLoop = SonarCodemod.from_core_codemod(
-    name="break-or-continue-out-of-loop-S1716",
+    name="break-or-continue-out-of-loop",
     other=BreakOrContinueOutOfLoop,
     rule_id="python:S1716",
     rule_name='"break" and "continue" should not be used outside a loop',

--- a/src/core_codemods/sonar/sonar_disable_graphql_introspection.py
+++ b/src/core_codemods/sonar/sonar_disable_graphql_introspection.py
@@ -2,7 +2,7 @@ from core_codemods.disable_graphql_introspection import DisableGraphQLIntrospect
 from core_codemods.sonar.api import SonarCodemod
 
 SonarDisableGraphQLIntrospection = SonarCodemod.from_core_codemod(
-    name="disable-graphql-introspection-S6786",
+    name="disable-graphql-introspection",
     other=DisableGraphQLIntrospection,
     rule_id="python:S6786",
     rule_name="GraphQL introspection should be disabled in production",

--- a/src/core_codemods/sonar/sonar_django_json_response_type.py
+++ b/src/core_codemods/sonar/sonar_django_json_response_type.py
@@ -2,7 +2,7 @@ from core_codemods.django_json_response_type import DjangoJsonResponseType
 from core_codemods.sonar.api import SonarCodemod
 
 SonarDjangoJsonResponseType = SonarCodemod.from_core_codemod(
-    name="django-json-response-type-S5131",
+    name="django-json-response-type",
     other=DjangoJsonResponseType,
     rule_id="pythonsecurity:S5131",
     rule_name="Endpoints should not be vulnerable to reflected XSS attacks (Django)",

--- a/src/core_codemods/sonar/sonar_django_model_without_dunder_str.py
+++ b/src/core_codemods/sonar/sonar_django_model_without_dunder_str.py
@@ -2,7 +2,7 @@ from core_codemods.django_model_without_dunder_str import DjangoModelWithoutDund
 from core_codemods.sonar.api import SonarCodemod
 
 SonarDjangoModelWithoutDunderStr = SonarCodemod.from_core_codemod(
-    name="django-model-without-dunder-str-S6554",
+    name="django-model-without-dunder-str",
     other=DjangoModelWithoutDunderStr,
     rule_id="python:S6554",
     rule_name='Django models should define a "__str__" method',

--- a/src/core_codemods/sonar/sonar_django_receiver_on_top.py
+++ b/src/core_codemods/sonar/sonar_django_receiver_on_top.py
@@ -2,7 +2,7 @@ from core_codemods.django_receiver_on_top import DjangoReceiverOnTop
 from core_codemods.sonar.api import SonarCodemod
 
 SonarDjangoReceiverOnTop = SonarCodemod.from_core_codemod(
-    name="django-receiver-on-top-S6552",
+    name="django-receiver-on-top",
     other=DjangoReceiverOnTop,
     rule_id="python:S6552",
     rule_name="Django signal handler functions should have the `@receiver` decorator on top of all other decorators",

--- a/src/core_codemods/sonar/sonar_enable_jinja2_autoescape.py
+++ b/src/core_codemods/sonar/sonar_enable_jinja2_autoescape.py
@@ -2,7 +2,7 @@ from core_codemods.enable_jinja2_autoescape import EnableJinja2Autoescape
 from core_codemods.sonar.api import SonarCodemod
 
 SonarEnableJinja2Autoescape = SonarCodemod.from_core_codemod(
-    name="enable-jinja2-autoescape-S5247",
+    name="enable-jinja2-autoescape",
     other=EnableJinja2Autoescape,
     rule_id="python:S5247",
     rule_name="Disabling auto-escaping in template engines is security-sensitive",

--- a/src/core_codemods/sonar/sonar_exception_without_raise.py
+++ b/src/core_codemods/sonar/sonar_exception_without_raise.py
@@ -2,7 +2,7 @@ from core_codemods.exception_without_raise import ExceptionWithoutRaise
 from core_codemods.sonar.api import SonarCodemod
 
 SonarExceptionWithoutRaise = SonarCodemod.from_core_codemod(
-    name="exception-without-raise-S3984",
+    name="exception-without-raise",
     other=ExceptionWithoutRaise,
     rule_id="python:S3984",
     rule_name="Exceptions should not be created without being raised",

--- a/src/core_codemods/sonar/sonar_fix_assert_tuple.py
+++ b/src/core_codemods/sonar/sonar_fix_assert_tuple.py
@@ -2,7 +2,7 @@ from core_codemods.fix_assert_tuple import FixAssertTuple
 from core_codemods.sonar.api import SonarCodemod
 
 SonarFixAssertTuple = SonarCodemod.from_core_codemod(
-    name="fix-assert-tuple-S5905",
+    name="fix-assert-tuple",
     other=FixAssertTuple,
     rule_id="python:S5905",
     rule_name="Assert should not be called on a tuple literal",

--- a/src/core_codemods/sonar/sonar_fix_float_equality.py
+++ b/src/core_codemods/sonar/sonar_fix_float_equality.py
@@ -2,7 +2,7 @@ from core_codemods.fix_float_equality import FixFloatEquality
 from core_codemods.sonar.api import SonarCodemod
 
 SonarFixFloatEquality = SonarCodemod.from_core_codemod(
-    name="fix-float-equality-S1244",
+    name="fix-float-equality",
     other=FixFloatEquality,
     rule_id="python:S1244",
     rule_name="Floating point numbers should not be tested for equality",

--- a/src/core_codemods/sonar/sonar_fix_math_isclose.py
+++ b/src/core_codemods/sonar/sonar_fix_math_isclose.py
@@ -29,7 +29,7 @@ class FixMathIsCloseSonarTransformer(FixMathIsCloseTransformer):
 
 
 SonarFixMathIsClose = SonarCodemod.from_core_codemod(
-    name="fix-math-isclose-S6727",
+    name="fix-math-isclose",
     other=FixMathIsClose,
     rule_id="python:S6727",
     rule_name="The abs_tol parameter should be provided when using math.isclose to compare values to 0",

--- a/src/core_codemods/sonar/sonar_fix_missing_self_or_cls.py
+++ b/src/core_codemods/sonar/sonar_fix_missing_self_or_cls.py
@@ -2,7 +2,7 @@ from core_codemods.fix_missing_self_or_cls import FixMissingSelfOrCls
 from core_codemods.sonar.api import SonarCodemod
 
 SonarFixMissingSelfOrCls = SonarCodemod.from_core_codemod(
-    name="fix-missing-self-or-cls-S5719",
+    name="fix-missing-self-or-cls",
     other=FixMissingSelfOrCls,
     rule_id="python:S5719",
     rule_name="Instance and class methods should have at least one positional parameter",

--- a/src/core_codemods/sonar/sonar_flask_json_response_type.py
+++ b/src/core_codemods/sonar/sonar_flask_json_response_type.py
@@ -2,7 +2,7 @@ from core_codemods.flask_json_response_type import FlaskJsonResponseType
 from core_codemods.sonar.api import SonarCodemod
 
 SonarFlaskJsonResponseType = SonarCodemod.from_core_codemod(
-    name="flask-json-response-type-S5131",
+    name="flask-json-response-type",
     other=FlaskJsonResponseType,
     rule_id="pythonsecurity:S5131",
     rule_name="Endpoints should not be vulnerable to reflected XSS attacks (Flask)",

--- a/src/core_codemods/sonar/sonar_jwt_decode_verify.py
+++ b/src/core_codemods/sonar/sonar_jwt_decode_verify.py
@@ -30,7 +30,7 @@ class JwtDecodeVerifySonarTransformer(JwtDecodeVerifyTransformer):
 
 
 SonarJwtDecodeVerify = SonarCodemod.from_core_codemod(
-    name="jwt-decode-verify-S5659",
+    name="jwt-decode-verify",
     other=JwtDecodeVerify,
     rule_id="python:S5659",
     rule_name="JWT should be signed and verified",

--- a/src/core_codemods/sonar/sonar_literal_or_new_object_identity.py
+++ b/src/core_codemods/sonar/sonar_literal_or_new_object_identity.py
@@ -2,7 +2,7 @@ from core_codemods.literal_or_new_object_identity import LiteralOrNewObjectIdent
 from core_codemods.sonar.api import SonarCodemod
 
 SonarLiteralOrNewObjectIdentity = SonarCodemod.from_core_codemod(
-    name="literal-or-new-object-identity-S5796",
+    name="literal-or-new-object-identity",
     other=LiteralOrNewObjectIdentity,
     rule_id="python:S5796",
     rule_name="New objects should not be created only to check their identity",

--- a/src/core_codemods/sonar/sonar_numpy_nan_equality.py
+++ b/src/core_codemods/sonar/sonar_numpy_nan_equality.py
@@ -2,7 +2,7 @@ from core_codemods.numpy_nan_equality import NumpyNanEquality
 from core_codemods.sonar.api import SonarCodemod
 
 SonarNumpyNanEquality = SonarCodemod.from_core_codemod(
-    name="numpy-nan-equality-S6725",
+    name="numpy-nan-equality",
     other=NumpyNanEquality,
     rule_id="python:S6725",
     rule_name="Equality checks should not be made against `numpy.nan`",

--- a/src/core_codemods/sonar/sonar_remove_assertion_in_pytest_raises.py
+++ b/src/core_codemods/sonar/sonar_remove_assertion_in_pytest_raises.py
@@ -4,7 +4,7 @@ from core_codemods.remove_assertion_in_pytest_raises import (
 from core_codemods.sonar.api import SonarCodemod
 
 SonarRemoveAssertionInPytestRaises = SonarCodemod.from_core_codemod(
-    name="remove-assertion-in-pytest-raises-S5915",
+    name="remove-assertion-in-pytest-raises",
     other=RemoveAssertionInPytestRaises,
     rule_id="python:S5915",
     rule_name="Assertions should not be made at the end of blocks expecting an exception",

--- a/src/core_codemods/sonar/sonar_secure_random.py
+++ b/src/core_codemods/sonar/sonar_secure_random.py
@@ -2,7 +2,7 @@ from core_codemods.secure_random import SecureRandom
 from core_codemods.sonar.api import SonarCodemod
 
 SonarSecureRandom = SonarCodemod.from_core_codemod(
-    name="secure-random-S2245",
+    name="secure-random",
     other=SecureRandom,
     rule_id="python:S2245",
     rule_name="Using pseudorandom number generators (PRNGs) is security-sensitive",

--- a/src/core_codemods/sonar/sonar_sql_parameterization.py
+++ b/src/core_codemods/sonar/sonar_sql_parameterization.py
@@ -2,7 +2,7 @@ from core_codemods.sonar.api import SonarCodemod
 from core_codemods.sql_parameterization import SQLQueryParameterization
 
 SonarSQLParameterization = SonarCodemod.from_core_codemod(
-    name="sql-parameterization-S3649",
+    name="sql-parameterization",
     other=SQLQueryParameterization,
     rule_id="pythonsecurity:S3649",
     rule_name="Database queries should not be vulnerable to injection attacks",

--- a/src/core_codemods/sonar/sonar_tempfile_mktemp.py
+++ b/src/core_codemods/sonar/sonar_tempfile_mktemp.py
@@ -2,7 +2,7 @@ from core_codemods.sonar.api import SonarCodemod
 from core_codemods.tempfile_mktemp import TempfileMktemp
 
 SonarTempfileMktemp = SonarCodemod.from_core_codemod(
-    name="secure-tempfile-S5445",
+    name="secure-tempfile",
     other=TempfileMktemp,
     rule_id="python:S5445",
     rule_name="Insecure temporary file creation methods should not be used",

--- a/src/core_codemods/sonar/sonar_url_sandbox.py
+++ b/src/core_codemods/sonar/sonar_url_sandbox.py
@@ -2,7 +2,7 @@ from core_codemods.sonar.api import SonarCodemod
 from core_codemods.url_sandbox import UrlSandbox
 
 SonarUrlSandbox = SonarCodemod.from_core_codemod(
-    name="url-sandbox-S5144",
+    name="url-sandbox",
     other=UrlSandbox,
     rule_id="pythonsecurity:S5144",
     rule_name="Server-side requests should not be vulnerable to forging attacks",

--- a/tests/codemods/sonar/test_sonar_break_or_continue_out_of_loop.py
+++ b/tests/codemods/sonar/test_sonar_break_or_continue_out_of_loop.py
@@ -11,7 +11,7 @@ class TestSonarSQLParameterization(BaseSASTCodemodTest):
     tool = "sonar"
 
     def test_name(self):
-        assert self.codemod.name == "break-or-continue-out-of-loop-S1716"
+        assert self.codemod.name == "break-or-continue-out-of-loop"
 
     def test_simple(self, tmpdir):
         input_code = """

--- a/tests/codemods/sonar/test_sonar_disable_graphql_introspection.py
+++ b/tests/codemods/sonar/test_sonar_disable_graphql_introspection.py
@@ -11,7 +11,7 @@ class TestSonarDisableGraphQLIntrospection(BaseSASTCodemodTest):
     tool = "sonar"
 
     def test_name(self):
-        assert self.codemod.name == "disable-graphql-introspection-S6786"
+        assert self.codemod.name == "disable-graphql-introspection"
 
     def test_simple(self, tmpdir):
         input_code = """

--- a/tests/codemods/sonar/test_sonar_django_json_response_type.py
+++ b/tests/codemods/sonar/test_sonar_django_json_response_type.py
@@ -11,7 +11,7 @@ class TestDjangoJsonResponseType(BaseSASTCodemodTest):
     tool = "sonar"
 
     def test_name(self):
-        assert self.codemod.name == "django-json-response-type-S5131"
+        assert self.codemod.name == "django-json-response-type"
 
     def test_simple(self, tmpdir):
         rule_id = "pythonsecurity:S5131"

--- a/tests/codemods/sonar/test_sonar_django_model_without_dunder_str.py
+++ b/tests/codemods/sonar/test_sonar_django_model_without_dunder_str.py
@@ -11,8 +11,8 @@ class TestSonarDjangoModelWithoutDunderStr(BaseSASTCodemodTest):
     tool = "sonar"
 
     def test_name(self):
-        assert self.codemod.name == "django-model-without-dunder-str-S6554"
-        assert self.codemod.id == "sonar:python/django-model-without-dunder-str-S6554"
+        assert self.codemod.name == "django-model-without-dunder-str"
+        assert self.codemod.id == "sonar:python/django-model-without-dunder-str"
 
     def test_simple(self, tmpdir):
         input_code = """

--- a/tests/codemods/sonar/test_sonar_django_receiver_on_top.py
+++ b/tests/codemods/sonar/test_sonar_django_receiver_on_top.py
@@ -9,7 +9,7 @@ class TestSonarDjangoReceiverOnTop(BaseSASTCodemodTest):
     tool = "sonar"
 
     def test_name(self):
-        assert self.codemod.name == "django-receiver-on-top-S6552"
+        assert self.codemod.name == "django-receiver-on-top"
 
     def test_simple(self, tmpdir):
         input_code = """

--- a/tests/codemods/sonar/test_sonar_enable_jinja2_autoescape.py
+++ b/tests/codemods/sonar/test_sonar_enable_jinja2_autoescape.py
@@ -11,7 +11,7 @@ class TestEnableJinja2Autoescape(BaseSASTCodemodTest):
     tool = "sonar"
 
     def test_name(self):
-        assert self.codemod.name == "enable-jinja2-autoescape-S5247"
+        assert self.codemod.name == "enable-jinja2-autoescape"
 
     def test_simple(self, tmpdir):
         input_code = """

--- a/tests/codemods/sonar/test_sonar_exception_without_raise.py
+++ b/tests/codemods/sonar/test_sonar_exception_without_raise.py
@@ -9,7 +9,7 @@ class TestSonarExceptionWithoutRaise(BaseSASTCodemodTest):
     tool = "sonar"
 
     def test_name(self):
-        assert self.codemod.name == "exception-without-raise-S3984"
+        assert self.codemod.name == "exception-without-raise"
 
     def test_simple(self, tmpdir):
         input_code = """

--- a/tests/codemods/sonar/test_sonar_fix_assert_tuple.py
+++ b/tests/codemods/sonar/test_sonar_fix_assert_tuple.py
@@ -9,7 +9,7 @@ class TestSonarFixAssertTuple(BaseSASTCodemodTest):
     tool = "sonar"
 
     def test_name(self):
-        assert self.codemod.name == "fix-assert-tuple-S5905"
+        assert self.codemod.name == "fix-assert-tuple"
 
     def test_simple(self, tmpdir):
         input_code = """

--- a/tests/codemods/sonar/test_sonar_fix_float_equality.py
+++ b/tests/codemods/sonar/test_sonar_fix_float_equality.py
@@ -9,7 +9,7 @@ class TestSonarFixFloatEquality(BaseSASTCodemodTest):
     tool = "sonar"
 
     def test_name(self):
-        assert self.codemod.name == "fix-float-equality-S1244"
+        assert self.codemod.name == "fix-float-equality"
 
     def test_simple(self, tmpdir):
         input_code = """

--- a/tests/codemods/sonar/test_sonar_fix_math_isclose.py
+++ b/tests/codemods/sonar/test_sonar_fix_math_isclose.py
@@ -9,7 +9,7 @@ class TestSonarFixMathIsClose(BaseSASTCodemodTest):
     tool = "sonar"
 
     def test_name(self):
-        assert self.codemod.name == "fix-math-isclose-S6727"
+        assert self.codemod.name == "fix-math-isclose"
 
     def test_simple(self, tmpdir):
         input_code = """

--- a/tests/codemods/sonar/test_sonar_fix_missing_self_or_cls.py
+++ b/tests/codemods/sonar/test_sonar_fix_missing_self_or_cls.py
@@ -9,7 +9,7 @@ class TestSonarFixMissingSelfOrCls(BaseSASTCodemodTest):
     tool = "sonar"
 
     def test_name(self):
-        assert self.codemod.name == "fix-missing-self-or-cls-S5719"
+        assert self.codemod.name == "fix-missing-self-or-cls"
 
     def test_simple(self, tmpdir):
         input_code = """

--- a/tests/codemods/sonar/test_sonar_flask_json_response_type.py
+++ b/tests/codemods/sonar/test_sonar_flask_json_response_type.py
@@ -11,7 +11,7 @@ class TestSonarFlaskJsonResponseType(BaseSASTCodemodTest):
     tool = "sonar"
 
     def test_name(self):
-        assert self.codemod.name == "flask-json-response-type-S5131"
+        assert self.codemod.name == "flask-json-response-type"
 
     def test_simple(self, tmpdir):
         input_code = """

--- a/tests/codemods/sonar/test_sonar_jwt_decode_verify.py
+++ b/tests/codemods/sonar/test_sonar_jwt_decode_verify.py
@@ -9,7 +9,7 @@ class TestSonarJwtDecodeVerify(BaseSASTCodemodTest):
     tool = "sonar"
 
     def test_name(self):
-        assert self.codemod.name == "jwt-decode-verify-S5659"
+        assert self.codemod.name == "jwt-decode-verify"
 
     def test_simple(self, tmpdir):
         input_code = """

--- a/tests/codemods/sonar/test_sonar_literal_or_new_object_identity.py
+++ b/tests/codemods/sonar/test_sonar_literal_or_new_object_identity.py
@@ -11,7 +11,7 @@ class TestSonarLiteralOrNewObjectIdentity(BaseSASTCodemodTest):
     tool = "sonar"
 
     def test_name(self):
-        assert self.codemod.name == "literal-or-new-object-identity-S5796"
+        assert self.codemod.name == "literal-or-new-object-identity"
 
     def test_list(self, tmpdir):
         input_code = """

--- a/tests/codemods/sonar/test_sonar_numpy_nan_equality.py
+++ b/tests/codemods/sonar/test_sonar_numpy_nan_equality.py
@@ -9,7 +9,7 @@ class TestSonarNumpyNanEquality(BaseSASTCodemodTest):
     tool = "sonar"
 
     def test_name(self):
-        assert self.codemod.name == "numpy-nan-equality-S6725"
+        assert self.codemod.name == "numpy-nan-equality"
 
     def test_simple(self, tmpdir):
         input_code = """

--- a/tests/codemods/sonar/test_sonar_remove_assertion_in_pytest_raises.py
+++ b/tests/codemods/sonar/test_sonar_remove_assertion_in_pytest_raises.py
@@ -11,7 +11,7 @@ class TestRemoveAssertionInPytestRaises(BaseSASTCodemodTest):
     tool = "sonar"
 
     def test_name(self):
-        assert self.codemod.name == "remove-assertion-in-pytest-raises-S5915"
+        assert self.codemod.name == "remove-assertion-in-pytest-raises"
 
     def test_simple(self, tmpdir):
         input_code = """

--- a/tests/codemods/sonar/test_sonar_secure_random.py
+++ b/tests/codemods/sonar/test_sonar_secure_random.py
@@ -9,7 +9,7 @@ class TestSonarSecureRandom(BaseSASTCodemodTest):
     tool = "sonar"
 
     def test_name(self):
-        assert self.codemod.name == "secure-random-S2245"
+        assert self.codemod.name == "secure-random"
 
     def test_simple(self, tmpdir):
         input_code = """

--- a/tests/codemods/sonar/test_sonar_sql_parameterization.py
+++ b/tests/codemods/sonar/test_sonar_sql_parameterization.py
@@ -15,7 +15,7 @@ class TestSonarSQLParameterization(BaseSASTCodemodTest):
     tool = "sonar"
 
     def test_name(self):
-        assert self.codemod.name == "sql-parameterization-S3649"
+        assert self.codemod.name == "sql-parameterization"
 
     def test_simple(self, tmpdir):
         input_code = """

--- a/tests/codemods/sonar/test_sonar_tempfile_mktemp.py
+++ b/tests/codemods/sonar/test_sonar_tempfile_mktemp.py
@@ -9,7 +9,7 @@ class TestSonarTempfileMktemp(BaseSASTCodemodTest):
     tool = "sonar"
 
     def test_name(self):
-        assert self.codemod.name == "secure-tempfile-S5445"
+        assert self.codemod.name == "secure-tempfile"
 
     def test_simple(self, tmpdir):
         input_code = """

--- a/tests/codemods/sonar/test_sonar_url_sandbox.py
+++ b/tests/codemods/sonar/test_sonar_url_sandbox.py
@@ -9,7 +9,7 @@ class TestSonarUrlSandbox(BaseSASTCodemodTest):
     tool = "sonar"
 
     def test_name(self):
-        assert self.codemod.name == "url-sandbox-S5144"
+        assert self.codemod.name == "url-sandbox"
 
     def test_simple(self, tmpdir):
         input_code = """

--- a/tests/codemods/test_include_exclude.py
+++ b/tests/codemods/test_include_exclude.py
@@ -148,9 +148,3 @@ class TestMatchCodemods:
             for c in self.registry.codemods
             if not c.origin == "pixee" and c.id in self.all_ids
         ]
-
-    def test_non_pixee_name_no_match(self):
-        assert self.registry.match_codemods(["secure-random-S2245"], None) == []
-        assert self.registry.match_codemods(None, ["secure-random-S2245"]) == [
-            c for c in self.registry.codemods if c.id in self.all_ids
-        ]


### PR DESCRIPTION
Closes #703

since now codemods can only be requested by id, names don't have to be unique 