### PR TITLE
Handle detection of SARIFs that have UTF-8 BOMs

### DIFF
--- a/src/codemodder/sarifs.py
+++ b/src/codemodder/sarifs.py
@@ -23,7 +23,7 @@ def detect_sarif_tools(filenames: list[Path]) -> DefaultDict[str, list[str]]:
         ent.name: ent.load() for ent in entry_points().select(group="sarif_detectors")
     }
     for fname in filenames:
-        data = json.loads(fname.read_text())
+        data = json.loads(fname.read_text(encoding="utf-8-sig"))
         for name, det in detectors.items():
             # TODO: handle malformed sarif?
             for run in data["runs"]:

--- a/tests/test_sarif_processing.py
+++ b/tests/test_sarif_processing.py
@@ -4,6 +4,7 @@ from pathlib import Path
 
 import pytest
 
+from codemodder.sarifs import detect_sarif_tools
 from codemodder.semgrep import SemgrepResult, SemgrepResultSet
 
 
@@ -33,6 +34,17 @@ class TestSarifProcessing:
             result, sarif_run, truncate_rule_id=True
         )
         assert rule_id == "secure-random"
+
+    def test_detect_sarif_with_bom_encoding(self, tmpdir):
+        sarif_file = Path("tests") / "samples" / "semgrep.sarif"
+        sarif_file_bom = tmpdir / "semgrep_bom.sarif"
+
+        with open(sarif_file_bom, "w") as f:
+            f.write("\ufeff")
+            f.write(sarif_file.read_text(encoding="utf-8"))
+
+        results = detect_sarif_tools([sarif_file_bom])
+        assert len(results) == 1
 
     @pytest.mark.parametrize("truncate", [True, False])
     def test_results_by_rule_id(self, truncate):


### PR DESCRIPTION
## Overview
*Handle detection of SARIFs  that have UTF-8 byte order marks*

## Description

* Apparently some UTF-8 files can have [byte order marks](https://en.wikipedia.org/wiki/Byte_order_mark)
* Using the `utf-8-sig` encoding tells Python to ignore these byte order marks when reading files
* This PR fixes the SARIF detection logic. Each individual SARIF result parser will need to handle this on a case-by-case basis