### PR TITLE
do not raise ValueError if no resource

### DIFF
--- a/src/codemodder/providers.py
+++ b/src/codemodder/providers.py
@@ -25,7 +25,7 @@ class BaseProvider(metaclass=ABCMeta):
     @property
     def resource(self) -> Any:
         if self._resource is None:
-            raise ValueError(f"Resource for provider {self.name} is not available")
+            logger.debug("Resource for provider %s is not available", self.name)
         return self._resource
 
 


### PR DESCRIPTION
The _apply method already checks if resource is None and doesn't indicate we should completely crash if a provider resource isn't loaded, so we should not raise this error

I'll create a release for this.