### PR TITLE
All places when a Change() is created should report findings

### DIFF
--- a/src/codemodder/codemods/libcst_transformer.py
+++ b/src/codemodder/codemods/libcst_transformer.py
@@ -109,6 +109,7 @@ class LibcstResultTransformer(BaseTransformer):
             Change(
                 lineNumber=lineno,
                 description=description,
+                findings=self.file_context.get_findings_for_location(lineno),
             )
         )
 

--- a/src/codemodder/codemods/test/utils.py
+++ b/src/codemodder/codemods/test/utils.py
@@ -211,7 +211,7 @@ class BaseSASTCodemodTest(BaseCodemodTest):
 
         self.assert_num_changes(changes, num_changes, min_num_changes)
 
-        self.assert_findings(all_changes)
+        self.assert_findings(changes[0].changes)
 
         self.assert_changes(
             tmpdir,
@@ -224,4 +224,6 @@ class BaseSASTCodemodTest(BaseCodemodTest):
         return changes
 
     def assert_findings(self, changes: list[Change]):
-        assert all(x.findings is not None for x in changes), changes
+        assert all(
+            x.findings is not None for x in changes
+        ), f"Expected all changes to have findings: {changes}"

--- a/src/codemodder/codemods/test/utils.py
+++ b/src/codemodder/codemods/test/utils.py
@@ -7,6 +7,7 @@ import mock
 
 from codemodder import registry
 from codemodder.codemods.api import BaseCodemod
+from codemodder.codetf import Change
 from codemodder.context import CodemodExecutionContext
 from codemodder.diff import create_diff
 from codemodder.providers import load_providers
@@ -210,6 +211,8 @@ class BaseSASTCodemodTest(BaseCodemodTest):
 
         self.assert_num_changes(changes, num_changes, min_num_changes)
 
+        self.assert_findings(all_changes)
+
         self.assert_changes(
             tmpdir,
             tmp_file_path,
@@ -219,3 +222,6 @@ class BaseSASTCodemodTest(BaseCodemodTest):
         )
 
         return changes
+
+    def assert_findings(self, changes: list[Change]):
+        assert all(x.findings is not None for x in changes), changes

--- a/src/core_codemods/fix_assert_tuple.py
+++ b/src/core_codemods/fix_assert_tuple.py
@@ -49,8 +49,9 @@ class FixAssertTupleTransform(LibcstResultTransformer, NameResolutionMixin):
         for idx in range(newlines_count):
             self.file_context.codemod_changes.append(
                 Change(
-                    lineNumber=start_line + idx,
+                    lineNumber=(line_number := start_line + idx),
                     description=self.change_description,
+                    findings=self.file_context.get_findings_for_location(line_number),
                 )
             )
 

--- a/src/core_codemods/sql_parameterization.py
+++ b/src/core_codemods/sql_parameterization.py
@@ -253,6 +253,9 @@ class SQLQueryParameterizationTransformer(
                     Change(
                         lineNumber=line_number,
                         description=SQLQueryParameterizationTransformer.change_description,
+                        findings=self.file_context.get_findings_for_location(
+                            line_number
+                        ),
                     )
                 )
                 # Normalization and cleanup

--- a/src/core_codemods/url_sandbox.py
+++ b/src/core_codemods/url_sandbox.py
@@ -71,6 +71,7 @@ class FindRequestCallsAndImports(ContextAwareVisitor, UtilsMixin):
             cst.CSTNode, Union[cst.CSTNode, cst.FlattenSentinel, cst.RemovalSentinel]
         ] = {}
         self.changes_in_file: List[Change] = []
+        self.file_context = file_context
         ContextAwareVisitor.__init__(self, codemod_context)
         UtilsMixin.__init__(
             self,
@@ -109,6 +110,9 @@ class FindRequestCallsAndImports(ContextAwareVisitor, UtilsMixin):
                             Change(
                                 lineNumber=line_number,
                                 description=UrlSandboxTransformer.change_description,
+                                findings=self.file_context.get_findings_for_location(
+                                    line_number
+                                ),
                             )
                         )
 
@@ -126,6 +130,9 @@ class FindRequestCallsAndImports(ContextAwareVisitor, UtilsMixin):
                     Change(
                         lineNumber=line_number,
                         description=UrlSandboxTransformer.change_description,
+                        findings=self.file_context.get_findings_for_location(
+                            line_number
+                        ),
                     )
                 )
 

--- a/tests/test_xml_transformer.py
+++ b/tests/test_xml_transformer.py
@@ -2,6 +2,7 @@ from io import StringIO
 from textwrap import dedent
 from xml.sax import handler
 
+import mock
 import pytest
 from defusedxml import ExternalReferenceForbidden
 from defusedxml.sax import make_parser
@@ -19,7 +20,7 @@ class TestXMLTransformer:
     def run_and_assert(self, input_code, expected_output):
         with StringIO() as result, StringIO(dedent(input_code)) as input_stream:
             result = StringIO()
-            transformer = XMLTransformer(result)
+            transformer = XMLTransformer(result, mock.MagicMock())
             parser = make_parser()
             parser.setContentHandler(transformer)
             parser.setProperty(handler.property_lexical_handler, transformer)
@@ -58,7 +59,7 @@ class TestElementAttributeXMLTransformer:
     def run_and_assert(self, name_attr_map, input_code, expected_output):
         with StringIO() as result, StringIO(dedent(input_code)) as input_stream:
             transformer = ElementAttributeXMLTransformer(
-                result, name_attributes_map=name_attr_map
+                result, mock.MagicMock(), name_attributes_map=name_attr_map
             )
             parser = make_parser()
             parser.setContentHandler(transformer)
@@ -101,7 +102,9 @@ class TestNewElementXMLTransformer:
 
     def run_and_assert(self, new_elements, input_code, expected_output):
         with StringIO() as result, StringIO(dedent(input_code)) as input_stream:
-            transformer = NewElementXMLTransformer(result, new_elements=new_elements)
+            transformer = NewElementXMLTransformer(
+                result, mock.MagicMock(), new_elements=new_elements
+            )
             parser = make_parser()
             parser.setContentHandler(transformer)
             parser.setProperty(handler.property_lexical_handler, transformer)


### PR DESCRIPTION
In working on a different codemod I discovered we didn't yet have `findings=...` in all locations. I also added a testing assertion `assert_findings` to `BaseSASTCodemodTest`. This enforces that we always correctly link findings. However it can be overridden in cases we may not be able to correctly link findings.