### PR TITLE
Enable downstream extensibility of UseDefusedXML codemod

### DIFF
--- a/integration_tests/test_use_defusedxml.py
+++ b/integration_tests/test_use_defusedxml.py
@@ -1,6 +1,6 @@
 from codemodder.codemods.test import BaseIntegrationTest
 from codemodder.dependency import DefusedXML
-from core_codemods.use_defused_xml import UseDefusedXml
+from core_codemods.use_defused_xml import UseDefusedXml, UseDefusedXmlTransformer
 
 
 class TestUseDefusedXml(BaseIntegrationTest):
@@ -36,7 +36,7 @@ class TestUseDefusedXml(BaseIntegrationTest):
 +et = defusedxml.ElementTree.parse(xml)"""
 
     expected_line_change = "5"
-    change_description = UseDefusedXml.change_description
+    change_description = UseDefusedXmlTransformer.change_description
     requirements_file_name = "requirements.txt"
     original_requirements = (
         "# file used to test dependency management\n"

--- a/src/codemodder/codemods/import_modifier_codemod.py
+++ b/src/codemodder/codemods/import_modifier_codemod.py
@@ -1,10 +1,10 @@
 from abc import ABCMeta, abstractmethod
-from typing import Mapping
+from typing import Callable, Mapping
 
 import libcst as cst
 from libcst.codemod.visitors import AddImportsVisitor, RemoveImportsVisitor
 
-from codemodder.codemods.api import SimpleCodemod
+from codemodder.codemods.api import LibcstResultTransformer
 from codemodder.codemods.imported_call_modifier import ImportedCallModifier
 from codemodder.dependency import Dependency
 
@@ -41,7 +41,9 @@ class MappingImportedCallModifier(ImportedCallModifier[Mapping[str, str]]):
         )
 
 
-class ImportModifierCodemod(SimpleCodemod, metaclass=ABCMeta):
+class ImportModifierCodemod(LibcstResultTransformer, metaclass=ABCMeta):
+    result_filter: Callable[[cst.CSTNode], bool] | None = None
+
     @property
     def dependency(self) -> Dependency | None:
         return None
@@ -58,6 +60,7 @@ class ImportModifierCodemod(SimpleCodemod, metaclass=ABCMeta):
             self.mapping,
             self.change_description,
             self.results,
+            self.result_filter,
         )
         result_tree = visitor.transform_module(tree)
         self.file_context.codemod_changes.extend(visitor.changes_in_file)

--- a/src/core_codemods/api/__init__.py
+++ b/src/core_codemods/api/__init__.py
@@ -1,4 +1,4 @@
 # ruff: noqa: F401
 from codemodder.codemods.api import Metadata, Reference, ReviewGuidance
 
-from .core_codemod import CoreCodemod, ImportModifierCodemod, SASTCodemod, SimpleCodemod
+from .core_codemod import CoreCodemod, SASTCodemod, SimpleCodemod

--- a/src/core_codemods/api/core_codemod.py
+++ b/src/core_codemods/api/core_codemod.py
@@ -5,9 +5,6 @@ from codemodder.codemods.api import SimpleCodemod as _SimpleCodemod
 from codemodder.codemods.base_codemod import Metadata
 from codemodder.codemods.base_detector import BaseDetector
 from codemodder.codemods.base_transformer import BaseTransformerPipeline
-from codemodder.codemods.import_modifier_codemod import (
-    ImportModifierCodemod as _ImportModifierCodemod,
-)
 from codemodder.context import CodemodExecutionContext
 
 
@@ -61,7 +58,3 @@ class SimpleCodemod(_SimpleCodemod):
     """
 
     codemod_base = CoreCodemod
-
-
-class ImportModifierCodemod(SimpleCodemod, _ImportModifierCodemod):
-    pass

--- a/src/core_codemods/harden_pickle_load.py
+++ b/src/core_codemods/harden_pickle_load.py
@@ -1,10 +1,11 @@
 from typing import Mapping
 
+from codemodder.codemods.import_modifier_codemod import ImportModifierCodemod
 from codemodder.dependency import Dependency, Fickling
-from core_codemods.api import ImportModifierCodemod, Metadata, Reference, ReviewGuidance
+from core_codemods.api import Metadata, Reference, ReviewGuidance, SimpleCodemod
 
 
-class HardenPickleLoad(ImportModifierCodemod):
+class HardenPickleLoad(SimpleCodemod, ImportModifierCodemod):
     metadata = Metadata(
         name="harden-pickle-load",
         summary="Harden `pickle.load()` against deserialization attacks",

--- a/src/core_codemods/semgrep/api.py
+++ b/src/core_codemods/semgrep/api.py
@@ -1,7 +1,5 @@
-from codemodder.codemods.api import SimpleCodemod
 from codemodder.codemods.base_codemod import Metadata, Reference, ToolMetadata, ToolRule
 from codemodder.codemods.base_transformer import BaseTransformerPipeline
-from codemodder.codemods.libcst_transformer import LibcstTransformerPipeline
 from codemodder.codemods.semgrep import SemgrepSarifFileDetector
 from core_codemods.api.core_codemod import CoreCodemod, SASTCodemod
 
@@ -46,43 +44,4 @@ class SemgrepCodemod(SASTCodemod):
             transformer=transformer if transformer else other.transformer,
             detector=SemgrepSarifFileDetector(),
             requested_rules=[rule.id for rule in rules],
-        )
-
-    @classmethod
-    def from_import_modifier_codemod(
-        cls,
-        name: str,
-        other: type[SimpleCodemod],
-        rule_id: str,
-        rule_name: str,
-    ):
-        metadata = other.metadata
-        return SemgrepCodemod(
-            metadata=Metadata(
-                name=name,
-                summary=metadata.summary,
-                review_guidance=metadata.review_guidance,
-                references=(
-                    metadata.references
-                    + [
-                        Reference(
-                            url=semgrep_url_from_id(rule_id), description=rule_name
-                        )
-                    ]
-                ),
-                description=other.change_description,
-                tool=ToolMetadata(
-                    name="Semgrep",
-                    rules=[
-                        ToolRule(
-                            id=rule_id,
-                            name=rule_name,
-                            url=semgrep_url_from_id(rule_id),
-                        )
-                    ],
-                ),
-            ),
-            transformer=LibcstTransformerPipeline(other),
-            detector=SemgrepSarifFileDetector(),
-            requested_rules=[rule_id],
         )

--- a/src/core_codemods/semgrep/semgrep_use_defused_xml.py
+++ b/src/core_codemods/semgrep/semgrep_use_defused_xml.py
@@ -1,9 +1,16 @@
-from core_codemods.semgrep.api import SemgrepCodemod
+from core_codemods.semgrep.api import SemgrepCodemod, ToolRule, semgrep_url_from_id
 from core_codemods.use_defused_xml import UseDefusedXml
 
-SemgrepUseDefusedXml = SemgrepCodemod.from_import_modifier_codemod(
+SemgrepUseDefusedXml = SemgrepCodemod.from_core_codemod(
     name="use-defusedxml",
     other=UseDefusedXml,
-    rule_id="python.lang.security.use-defused-xml-parse.use-defused-xml-parse",
-    rule_name="use-defused-xml-parse",
+    rules=[
+        ToolRule(
+            id=(
+                rule_id := "python.lang.security.use-defused-xml-parse.use-defused-xml-parse"
+            ),
+            name="use-defused-xml-parse",
+            url=semgrep_url_from_id(rule_id),
+        )
+    ],
 )

--- a/src/core_codemods/use_defused_xml.py
+++ b/src/core_codemods/use_defused_xml.py
@@ -1,7 +1,9 @@
 from functools import cached_property
 
+from codemodder.codemods.import_modifier_codemod import ImportModifierCodemod
+from codemodder.codemods.libcst_transformer import LibcstTransformerPipeline
 from codemodder.dependency import DefusedXML, Dependency
-from core_codemods.api import ImportModifierCodemod, Metadata, Reference, ReviewGuidance
+from core_codemods.api import CoreCodemod, Metadata, Reference, ReviewGuidance
 
 ETREE_METHODS = ["parse", "fromstring", "iterparse", "XMLParser"]
 SAX_METHODS = ["parse", "make_parser", "parseString"]
@@ -9,25 +11,7 @@ DOM_METHODS = ["parse", "parseString"]
 # TODO: add expat methods?
 
 
-class UseDefusedXml(ImportModifierCodemod):
-    metadata = Metadata(
-        name="use-defusedxml",
-        summary="Use `defusedxml` for Parsing XML",
-        review_guidance=ReviewGuidance.MERGE_AFTER_REVIEW,
-        references=[
-            Reference(
-                url="https://docs.python.org/3/library/xml.html#xml-vulnerabilities"
-            ),
-            Reference(
-                url="https://docs.python.org/3/library/xml.html#the-defusedxml-package"
-            ),
-            Reference(url="https://pypi.org/project/defusedxml/"),
-            Reference(
-                url="https://cheatsheetseries.owasp.org/cheatsheets/XML_External_Entity_Prevention_Cheat_Sheet.html"
-            ),
-        ],
-    )
-
+class UseDefusedXmlTransformer(ImportModifierCodemod):
     change_description = "Replace builtin XML method with safe `defusedxml` method"
 
     @cached_property
@@ -49,3 +33,25 @@ class UseDefusedXml(ImportModifierCodemod):
     @property
     def dependency(self) -> Dependency:
         return DefusedXML
+
+
+UseDefusedXml = CoreCodemod(
+    metadata=Metadata(
+        name="use-defusedxml",
+        summary="Use `defusedxml` for Parsing XML",
+        review_guidance=ReviewGuidance.MERGE_AFTER_REVIEW,
+        references=[
+            Reference(
+                url="https://docs.python.org/3/library/xml.html#xml-vulnerabilities"
+            ),
+            Reference(
+                url="https://docs.python.org/3/library/xml.html#the-defusedxml-package"
+            ),
+            Reference(url="https://pypi.org/project/defusedxml/"),
+            Reference(
+                url="https://cheatsheetseries.owasp.org/cheatsheets/XML_External_Entity_Prevention_Cheat_Sheet.html"
+            ),
+        ],
+    ),
+    transformer=LibcstTransformerPipeline(UseDefusedXmlTransformer),
+)


### PR DESCRIPTION
## Overview
*Enable downstream extensibility of `UseDefusedXML` codemod*

## Description

* Untying the transformer from the `SimpleCodemod` implementation allows for more customization and extensibility
