### PR TITLE
Enable customizable call modifier logic

### DIFF
--- a/src/codemodder/codemods/import_modifier_codemod.py
+++ b/src/codemodder/codemods/import_modifier_codemod.py
@@ -1,5 +1,5 @@
 from abc import ABCMeta, abstractmethod
-from typing import Callable, Mapping
+from typing import Mapping
 
 import libcst as cst
 from libcst.codemod.visitors import AddImportsVisitor, RemoveImportsVisitor
@@ -42,7 +42,7 @@ class MappingImportedCallModifier(ImportedCallModifier[Mapping[str, str]]):
 
 
 class ImportModifierCodemod(LibcstResultTransformer, metaclass=ABCMeta):
-    result_filter: Callable[[cst.CSTNode], bool] | None = None
+    call_modifier: type[MappingImportedCallModifier] = MappingImportedCallModifier
 
     @property
     def dependency(self) -> Dependency | None:
@@ -54,13 +54,12 @@ class ImportModifierCodemod(LibcstResultTransformer, metaclass=ABCMeta):
         pass
 
     def transform_module_impl(self, tree: cst.Module) -> cst.Module:
-        visitor = MappingImportedCallModifier(
+        visitor = self.call_modifier(
             self.context,
             self.file_context,
             self.mapping,
             self.change_description,
             self.results,
-            self.result_filter,
         )
         result_tree = visitor.transform_module(tree)
         self.file_context.codemod_changes.extend(visitor.changes_in_file)

--- a/src/codemodder/codemods/utils_mixin.py
+++ b/src/codemodder/codemods/utils_mixin.py
@@ -100,7 +100,7 @@ class NameResolutionMixin(MetadataDependent):
         # it is a from import
         return _get_name(import_node) + "." + get_full_name_for_node(import_alias.name)
 
-    def _is_direct_call_from_imported_module(
+    def is_direct_call_from_imported_module(
         self, call: cst.Call
     ) -> Optional[tuple[Union[cst.Import, cst.ImportFrom], cst.ImportAlias]]:
         for nodo in iterate_left_expressions(call):


### PR DESCRIPTION
## Overview
*Enable customizable call modifier logic*

## Description

* This will help provide flexibility for downstream implementers, particularly those that might need different node/result filtering logic
* This supersedes some of the (unreleased) changes made in #735 