### PR TITLE
Prevent multiple SARIF inputs from the same tool

### DIFF
--- a/src/codemodder/codemodder.py
+++ b/src/codemodder/codemodder.py
@@ -19,7 +19,7 @@ from codemodder.logging import configure_logger, log_list, log_section, logger
 from codemodder.project_analysis.file_parsers.package_store import PackageStore
 from codemodder.project_analysis.python_repo_manager import PythonRepoManager
 from codemodder.result import ResultSet
-from codemodder.sarifs import detect_sarif_tools
+from codemodder.sarifs import DuplicateToolError, detect_sarif_tools
 from codemodder.semgrep import run as run_semgrep
 
 
@@ -162,7 +162,7 @@ def run(original_args) -> int:
         tool_result_files_map: DefaultDict[str, list[str]] = detect_sarif_tools(
             [Path(name) for name in argv.sarif or []]
         )
-    except FileNotFoundError as err:
+    except (DuplicateToolError, FileNotFoundError) as err:
         logger.error(err)
         return 1
 

--- a/src/codemodder/sarifs.py
+++ b/src/codemodder/sarifs.py
@@ -15,6 +15,9 @@ class AbstractSarifToolDetector(metaclass=ABCMeta):
         pass
 
 
+class DuplicateToolError(ValueError): ...
+
+
 def detect_sarif_tools(filenames: list[Path]) -> DefaultDict[str, list[str]]:
     results: DefaultDict[str, list[str]] = defaultdict(list)
 
@@ -30,7 +33,15 @@ def detect_sarif_tools(filenames: list[Path]) -> DefaultDict[str, list[str]]:
                 try:
                     if det.detect(run):
                         logger.debug("detected %s sarif: %s", name, fname)
+                        # According to the Codemodder spec, it is invalid to have multiple SARIF results for the same tool
+                        # https://github.com/pixee/codemodder-specs/pull/36
+                        if name in results:
+                            raise DuplicateToolError(
+                                f"duplicate tool sarif detected: {name}"
+                            )
                         results[name].append(str(fname))
+                except DuplicateToolError as err:
+                    raise err
                 except (KeyError, AttributeError, ValueError):
                     continue
 


### PR DESCRIPTION
## Overview
*Prevent multiple SARIF inputs from the same tool*

## Description

* The SARIF data model encodes a single "run" so it would be invalid to support multiple inputs for the same tool for a given invocation of codemodder
* The spec has been updated to explicitly disallow this behavior: https://github.com/pixee/codemodder-specs/pull/36