### PR TITLE
Fix walrus codemod to wrap comp conditions in parens

### DIFF
--- a/src/core_codemods/use_walrus_if.py
+++ b/src/core_codemods/use_walrus_if.py
@@ -49,8 +49,6 @@ class UseWalrusIf(SimpleCodemod, NameResolutionMixin):
         self.assigns = {}
 
     def _build_named_expr(self, target, value, parens=True):
-        if isinstance(value, cst.Comparison):
-            value = value.with_changes(lpar=[cst.LeftParen()], rpar=[cst.RightParen()])
         return cst.NamedExpr(
             target=target,
             value=value,
@@ -124,6 +122,9 @@ class UseWalrusIf(SimpleCodemod, NameResolutionMixin):
                 case cst.UnaryOperation(
                     operator=cst.Not(), expression=cst.Name() as name
                 ):
+                    value = value.with_changes(
+                        lpar=[cst.LeftParen()], rpar=[cst.RightParen()]
+                    )
                     if name.value == target.value:
                         named_expr = self._build_named_expr(target, value, parens=True)
                         self.assigns[assign] = named_expr

--- a/src/core_codemods/use_walrus_if.py
+++ b/src/core_codemods/use_walrus_if.py
@@ -49,6 +49,8 @@ class UseWalrusIf(SimpleCodemod, NameResolutionMixin):
         self.assigns = {}
 
     def _build_named_expr(self, target, value, parens=True):
+        if isinstance(value, cst.Comparison):
+            value = value.with_changes(lpar=[cst.LeftParen()], rpar=[cst.RightParen()])
         return cst.NamedExpr(
             target=target,
             value=value,

--- a/tests/codemods/test_walrus_if.py
+++ b/tests/codemods/test_walrus_if.py
@@ -269,3 +269,19 @@ if val is not None:
             print("hi")
         """
         self.run_and_assert(tmpdir, input_code, expected_output)
+
+    def test_walrus_bools_list(self, tmpdir):
+        input_code = """
+        successes = [False, True]
+        all_success = False not in successes
+
+        if not all_success:
+            return
+        """
+        expected_output = """
+        successes = [False, True]
+
+        if not (False not in successes):
+            return
+        """
+        self.run_and_assert(tmpdir, input_code, expected_output)

--- a/tests/codemods/test_walrus_if.py
+++ b/tests/codemods/test_walrus_if.py
@@ -275,6 +275,22 @@ if val is not None:
         successes = [False, True]
         all_success = False not in successes
 
+        if all_success:
+            return
+        """
+        expected_output = """
+        successes = [False, True]
+
+        if False not in successes:
+            return
+        """
+        self.run_and_assert(tmpdir, input_code, expected_output)
+
+    def test_walrus_bools_list_not(self, tmpdir):
+        input_code = """
+        successes = [False, True]
+        all_success = False not in successes
+
         if not all_success:
             return
         """


### PR DESCRIPTION
## Overview
*walrus if codemod  should add parens in cases of `if not (something contains something)*


see unit tests, which should explain. If you think of other tests I should had, I can do so.
Closes #728
