### PR TITLE
Semgrep Nan Injection codemod

### DIFF
--- a/src/codemodder/scripts/generate_docs.py
+++ b/src/codemodder/scripts/generate_docs.py
@@ -352,6 +352,11 @@ SEMGREP_CODEMODS = {
         guidance_explained="This codemod removes the `@csrf_exempt` decorator from a Django view to ensure it's protected against CSRF attacks. However, there are valid cases for using this decorator so make sure to review your application to determine if this is the case.",
         need_sarif="Yes (Semgrep)",
     ),
+    "nan-injection": DocMetadata(
+        importance="Medium",
+        guidance_explained="We believe that this codemod fixes an unsafe typecast call and that the changes are safe and reliable.",
+        need_sarif="Yes (Semgrep)",
+    ),
 }
 ALL_CODEMODS_METADATA = (
     CORE_CODEMODS | DEFECTDOJO_CODEMODS | SONAR_CODEMODS | SEMGREP_CODEMODS

--- a/src/core_codemods/__init__.py
+++ b/src/core_codemods/__init__.py
@@ -58,6 +58,7 @@ from .semgrep.semgrep_django_secure_set_cookie import SemgrepDjangoSecureSetCook
 from .semgrep.semgrep_enable_jinja2_autoescape import SemgrepEnableJinja2Autoescape
 from .semgrep.semgrep_harden_pyyaml import SemgrepHardenPyyaml
 from .semgrep.semgrep_jwt_decode_verify import SemgrepJwtDecodeVerify
+from .semgrep.semgrep_nan_injection import SemgrepNanInjection
 from .semgrep.semgrep_no_csrf_exempt import SemgrepNoCsrfExempt
 from .semgrep.semgrep_rsa_key_size import SemgrepRsaKeySize
 from .semgrep.semgrep_sql_parameterization import SemgrepSQLParameterization
@@ -216,5 +217,6 @@ semgrep_registry = CodemodCollection(
         SemgrepHardenPyyaml,
         SemgrepRsaKeySize,
         SemgrepSQLParameterization,
+        SemgrepNanInjection,
     ],
 )

--- a/src/core_codemods/fix_assert_tuple.py
+++ b/src/core_codemods/fix_assert_tuple.py
@@ -7,7 +7,6 @@ from codemodder.codemods.libcst_transformer import (
     LibcstTransformerPipeline,
 )
 from codemodder.codemods.utils_mixin import NameResolutionMixin
-from codemodder.codetf import Change
 from core_codemods.api import Metadata, ReviewGuidance
 from core_codemods.api.core_codemod import CoreCodemod
 
@@ -47,14 +46,7 @@ class FixAssertTupleTransform(LibcstResultTransformer, NameResolutionMixin):
     ):
         start_line = self.node_position(original_node).start.line
         for idx in range(newlines_count):
-            self.file_context.codemod_changes.append(
-                Change(
-                    lineNumber=(line_number := start_line + idx),
-                    description=self.change_description,
-                    # For now we can only link the finding to the first line changed
-                    findings=self.file_context.get_findings_for_location(line_number),
-                )
-            )
+            self.report_change_for_line(start_line + idx)
 
 
 FixAssertTuple = CoreCodemod(

--- a/src/core_codemods/semgrep/semgrep_nan_injection.py
+++ b/src/core_codemods/semgrep/semgrep_nan_injection.py
@@ -44,8 +44,7 @@ class NanInjectionTransformer(LibcstResultTransformer):
         original_node: cst.SimpleStatementLine,
         updated_node: cst.SimpleStatementLine,
     ):
-        var_name = self._get_var_in_call(node)
-        if not var_name:
+        if not (var_name := self._get_var_in_call(node)):
             return original_node
 
         code = dedent(

--- a/src/core_codemods/semgrep/semgrep_nan_injection.py
+++ b/src/core_codemods/semgrep/semgrep_nan_injection.py
@@ -19,7 +19,7 @@ from core_codemods.semgrep.api import SemgrepCodemod, semgrep_url_from_id
 
 
 class NanInjectionTransformer(LibcstResultTransformer):
-    change_description = "Wrap typecast in if statement to check for `nan`"
+    change_description = "Add validation to untrusted numerical input to disallow `nan`"
 
     def leave_SimpleStatementLine(
         self,

--- a/src/core_codemods/semgrep/semgrep_nan_injection.py
+++ b/src/core_codemods/semgrep/semgrep_nan_injection.py
@@ -1,0 +1,115 @@
+from textwrap import dedent
+
+import libcst as cst
+from libcst.codemod import ContextAwareVisitor
+
+from codemodder.codemods.base_codemod import (
+    Metadata,
+    ReviewGuidance,
+    ToolMetadata,
+    ToolRule,
+)
+from codemodder.codemods.base_visitor import UtilsMixin
+from codemodder.codemods.libcst_transformer import (
+    LibcstResultTransformer,
+    LibcstTransformerPipeline,
+)
+from codemodder.codemods.semgrep import SemgrepSarifFileDetector
+from core_codemods.semgrep.api import SemgrepCodemod, semgrep_url_from_id
+
+
+class NanInjectionTransformer(LibcstResultTransformer):
+    change_description = "Wrap typecast in if statement to check for `nan`"
+
+    def leave_SimpleStatementLine(
+        self,
+        original_node: cst.SimpleStatementLine,
+        updated_node: cst.SimpleStatementLine,
+    ):
+
+        visitor = MatchNodesInLineVisitor(
+            self.context, file_context=self.file_context, results=self.results
+        )
+        original_node.body[0].visit(visitor)
+        if visitor.matched_nodes:
+            # For now only handle one matched Call node in a line
+            return self.replace_with_if_else(
+                visitor.matched_nodes[0], original_node, updated_node
+            )
+        return original_node
+
+    def replace_with_if_else(
+        self,
+        node: cst.Call,
+        original_node: cst.SimpleStatementLine,
+        updated_node: cst.SimpleStatementLine,
+    ):
+        # We assume the call node's argument is a variable, otherwise semgrep
+        # wouldn't have created a finding.
+        try:
+            var = node.args[0].value.value
+        except Exception:
+            return updated_node
+
+        code = dedent(
+            f"""\
+        if {var}.lower() == "nan":
+            raise ValueError
+        else:
+            {self.code(original_node).strip()}
+        """
+        )
+        self.report_change(original_node)
+        new_statement = cst.parse_statement(code)
+        return new_statement.with_changes(leading_lines=updated_node.leading_lines)
+
+
+class MatchNodesInLineVisitor(ContextAwareVisitor, UtilsMixin):
+    """Visit Call nodes and match if node location matches results."""
+
+    def __init__(
+        self,
+        context,
+        file_context,
+        results,
+    ) -> None:
+        self.file_context = file_context
+        ContextAwareVisitor.__init__(self, context)
+        UtilsMixin.__init__(
+            self,
+            results=results,
+            line_include=file_context.line_include,
+            line_exclude=file_context.line_exclude,
+        )
+
+        self.matched_nodes: list[cst.Call] = []
+
+    def visit_Call(self, node: cst.Call) -> None:
+        if self.node_is_selected(node):
+            self.matched_nodes.append(node)
+
+
+SemgrepNanInjection = SemgrepCodemod(
+    metadata=Metadata(
+        name="nan-injection",
+        summary=NanInjectionTransformer.change_description.title(),
+        description=NanInjectionTransformer.change_description.title(),
+        review_guidance=ReviewGuidance.MERGE_AFTER_CURSORY_REVIEW,
+        tool=ToolMetadata(
+            name="Semgrep",
+            rules=[
+                ToolRule(
+                    id=(
+                        rule_id := "python.django.security.nan-injection.nan-injection"
+                    ),
+                    name="nan-injection",
+                    url=semgrep_url_from_id(rule_id),
+                )
+            ],
+        ),
+        references=[],
+    ),
+    transformer=LibcstTransformerPipeline(NanInjectionTransformer),
+    detector=SemgrepSarifFileDetector(),
+    requested_rules=[rule_id],
+)

--- a/src/core_codemods/semgrep/semgrep_nan_injection.py
+++ b/src/core_codemods/semgrep/semgrep_nan_injection.py
@@ -59,9 +59,16 @@ class NanInjectionTransformer(LibcstResultTransformer):
             {self.code(original_node).strip()}
         """
         )
-        self.report_change(original_node)
+        self._report_new_lines(original_node)
         new_statement = cst.parse_statement(code)
         return new_statement.with_changes(leading_lines=updated_node.leading_lines)
+
+    def _report_new_lines(self, original_node: cst.SimpleStatementLine):
+        self.report_change(original_node)
+        line_number = self.lineno_for_node(original_node)
+        findings = self.file_context.get_findings_for_location(line_number)
+        for lineno in range(line_number + 1, line_number + 4):
+            self.report_change_for_line(lineno, findings=findings)
 
 
 class MatchNodesInLineVisitor(ContextAwareVisitor, UtilsMixin):

--- a/src/core_codemods/semgrep/semgrep_nan_injection.py
+++ b/src/core_codemods/semgrep/semgrep_nan_injection.py
@@ -70,10 +70,8 @@ class NanInjectionTransformer(LibcstResultTransformer):
             ):
                 # bool(float(var)), complex(float(var)), bool(float(var)), etc
                 return self._get_target_in_call(wrapped_node)
-            case cst.Call():
+            case cst.Call() | cst.BinaryOperation():
                 return wrapped_node
-            # case cst.BinaryOperation():#
-            #     return node.args[0].value.left.args[0].value.value
 
     def _report_new_lines(self, original_node: cst.SimpleStatementLine):
         self.report_change(original_node)

--- a/src/core_codemods/sql_parameterization.py
+++ b/src/core_codemods/sql_parameterization.py
@@ -31,7 +31,6 @@ from codemodder.codemods.utils import (
     infer_expression_type,
 )
 from codemodder.codemods.utils_mixin import NameAndAncestorResolutionMixin
-from codemodder.codetf import Change
 from codemodder.utils.clean_code import (
     NormalizeFStrings,
     RemoveEmptyExpressionsFormatting,
@@ -249,15 +248,10 @@ class SQLQueryParameterizationTransformer(
                 result = tree.visit(ReplaceNodes(new_changed_nodes))
                 self.changed_nodes = {}
                 line_number = self.get_metadata(PositionProvider, call).start.line
-                self.file_context.codemod_changes.append(
-                    Change(
-                        lineNumber=line_number,
-                        description=SQLQueryParameterizationTransformer.change_description,
-                        findings=self.file_context.get_findings_for_location(
-                            line_number
-                        ),
-                    )
+                self.report_change_for_line(
+                    line_number, SQLQueryParameterizationTransformer.change_description
                 )
+
                 # Normalization and cleanup
                 result = CleanCode(self.context).transform_module(result)
 

--- a/tests/codemods/semgrep/test_semgrep_nan_injection.py
+++ b/tests/codemods/semgrep/test_semgrep_nan_injection.py
@@ -1,0 +1,71 @@
+import json
+
+from codemodder.codemods.test import BaseSASTCodemodTest
+from core_codemods.semgrep.semgrep_nan_injection import SemgrepNanInjection
+
+
+class TestSemgrepNanInjection(BaseSASTCodemodTest):
+    codemod = SemgrepNanInjection
+    tool = "semgrep"
+
+    def test_name(self):
+        assert self.codemod.name == "nan-injection"
+
+    def test_wrap_if_statement(self, tmpdir):
+        input_code = """\
+        def home(request):
+            uuid = request.POST.get("uuid")
+        
+            x = float(uuid)
+            print(x)
+        """
+        expected_output = """\
+        def home(request):
+            uuid = request.POST.get("uuid")
+        
+            if uuid.lower() == "nan":
+                raise ValueError
+            else:
+                x = float(uuid)
+            print(x)
+        """
+
+        results = {
+            "runs": [
+                {
+                    "results": [
+                        {
+                            "fingerprints": {"matchBasedId/v1": "1932"},
+                            "locations": [
+                                {
+                                    "physicalLocation": {
+                                        "artifactLocation": {
+                                            "uri": "code.py",
+                                            "uriBaseId": "%SRCROOT%",
+                                        },
+                                        "region": {
+                                            "endColumn": 20,
+                                            "endLine": 4,
+                                            "snippet": {"text": "    x = float(uuid)"},
+                                            "startColumn": 9,
+                                            "startLine": 4,
+                                        },
+                                    }
+                                }
+                            ],
+                            "message": {
+                                "text": "Found user input going directly into typecast for bool(), float(), or complex(). This allows an attacker to inject Python's not-a-number (NaN) into the typecast. This results in undefind behavior, particularly when doing comparisons. Either cast to a different type, or add a guard checking for all capitalizations of the string 'nan'."
+                            },
+                            "ruleId": "python.django.security.nan-injection.nan-injection",
+                        }
+                    ],
+                }
+            ]
+        }
+        self.run_and_assert(
+            tmpdir,
+            input_code,
+            expected_output,
+            results=json.dumps(results),
+            # num_changes=4,
+        )

--- a/tests/codemods/semgrep/test_semgrep_nan_injection.py
+++ b/tests/codemods/semgrep/test_semgrep_nan_injection.py
@@ -67,5 +67,5 @@ class TestSemgrepNanInjection(BaseSASTCodemodTest):
             input_code,
             expected_output,
             results=json.dumps(results),
-            # num_changes=4,
+            num_changes=4,
         )


### PR DESCRIPTION
This codemod replaces typecast call at a line reported by semgrep (which is a sink of a request source)
`x = float(uuid)`
and wraps it in an if/else statement to check if the value could be nan.

Notice that this new transformer is specific to semgrep results. It wouldn't work stand-alone. I also decided to not handle other edge cases since this is likely a codemod that won't be used much. If you think of something absolutely necessary we do need, I can add it.

Closes #691