### PR TITLE
Prevent duplicate codemod catalog entry points

### DIFF
--- a/src/codemodder/registry.py
+++ b/src/codemodder/registry.py
@@ -128,7 +128,8 @@ class CodemodRegistry:
 def load_registered_codemods(ep_filter: Optional[Callable[[EntryPoint], bool]] = None):
     registry = CodemodRegistry()
     logger.debug("loading registered codemod collections")
-    for entry_point in entry_points().select(group="codemods"):
+
+    for entry_point in set(entry_points().select(group="codemods")):
         if ep_filter and not ep_filter(entry_point):
             logger.debug(
                 '- skipping codemod collection "%s" from "%s as requested"',


### PR DESCRIPTION
This is a bit of an edge case, but when doing an editable install, the `core` entry point seems to get registered multiple times. We are only just now noticing this due to the registry validation added in #787.