### PR TITLE
Core codemods should ignore site-packages directories

### DIFF
--- a/src/codemodder/code_directory.py
+++ b/src/codemodder/code_directory.py
@@ -15,6 +15,7 @@ DEFAULT_EXCLUDED_PATHS = [
     "build/**",
     "dist/**",
     "venv/**",
+    "**/site-packages/**",
     ".venv/**",
     ".tox/**",
     ".nox/**",


### PR DESCRIPTION
While looking at some logs I noticed that we sometimes encounter repositories that have commited virtual environment subdirectories with atypical names (i.e. not `venv`). This change is an effort to avoid processing `site-packages` directories in such cases.