### PR TITLE
Add Azure Llama client support

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,7 +49,7 @@ get-hashes = 'codemodder.scripts.get_hashes:main'
 
 [project.optional-dependencies]
 test = [
-    "azure-ai-inference<2",
+    "azure-ai-inference>=1.0.0b1,<2.0",
     "coverage>=7.6,<7.7",
     "coverage-threshold~=0.4",
     "defusedxml==0.7.1",
@@ -88,7 +88,7 @@ openai = [
     "openai>=1.50,<1.52",
 ]
 azure = [
-    "azure-ai-inference<2",
+    "azure-ai-inference>=1.0.0b1,<2.0",
 ]
 
 all = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,6 +49,7 @@ get-hashes = 'codemodder.scripts.get_hashes:main'
 
 [project.optional-dependencies]
 test = [
+    "azure-ai-inference<2",
     "coverage>=7.6,<7.7",
     "coverage-threshold~=0.4",
     "defusedxml==0.7.1",
@@ -86,6 +87,10 @@ complexity = [
 openai = [
     "openai>=1.50,<1.52",
 ]
+azure = [
+    "azure-ai-inference<2",
+]
+
 all = [
     "codemodder[test]",
     "codemodder[complexity]",

--- a/src/codemodder/context.py
+++ b/src/codemodder/context.py
@@ -17,7 +17,7 @@ from codemodder.dependency import (
     build_failed_dependency_notification,
 )
 from codemodder.file_context import FileContext
-from codemodder.llm import setup_openai_llm_client
+from codemodder.llm import setup_azure_llama_llm_client, setup_openai_llm_client
 from codemodder.logging import log_list, logger
 from codemodder.project_analysis.file_parsers.package_store import PackageStore
 from codemodder.project_analysis.python_repo_manager import PythonRepoManager
@@ -83,6 +83,7 @@ class CodemodExecutionContext:
         self.tool_result_files_map = tool_result_files_map or {}
         self.semgrep_prefilter_results = None
         self.openai_llm_client = setup_openai_llm_client()
+        self.azure_llama_llm_client = setup_azure_llama_llm_client()
 
     def add_changesets(self, codemod_name: str, change_sets: List[ChangeSet]):
         self._changesets_by_codemod.setdefault(codemod_name, []).extend(change_sets)

--- a/src/codemodder/context.py
+++ b/src/codemodder/context.py
@@ -17,7 +17,7 @@ from codemodder.dependency import (
     build_failed_dependency_notification,
 )
 from codemodder.file_context import FileContext
-from codemodder.llm import setup_llm_client
+from codemodder.llm import setup_openai_llm_client
 from codemodder.logging import log_list, logger
 from codemodder.project_analysis.file_parsers.package_store import PackageStore
 from codemodder.project_analysis.python_repo_manager import PythonRepoManager
@@ -82,7 +82,7 @@ class CodemodExecutionContext:
         self.max_workers = max_workers
         self.tool_result_files_map = tool_result_files_map or {}
         self.semgrep_prefilter_results = None
-        self.llm_client = setup_llm_client()
+        self.openai_llm_client = setup_openai_llm_client()
 
     def add_changesets(self, codemod_name: str, change_sets: List[ChangeSet]):
         self._changesets_by_codemod.setdefault(codemod_name, []).extend(change_sets)

--- a/src/codemodder/llm.py
+++ b/src/codemodder/llm.py
@@ -26,6 +26,7 @@ from codemodder.logging import logger
 __all__ = [
     "MODELS",
     "setup_openai_llm_client",
+    "setup_azure_llama_llm_client",
     "MisconfiguredAIClient",
 ]
 

--- a/src/codemodder/llm.py
+++ b/src/codemodder/llm.py
@@ -17,7 +17,7 @@ from codemodder.logging import logger
 
 __all__ = [
     "MODELS",
-    "setup_llm_client",
+    "setup_openai_llm_client",
     "MisconfiguredAIClient",
 ]
 
@@ -46,7 +46,7 @@ class ModelRegistry(dict):
 MODELS = ModelRegistry(models)
 
 
-def setup_llm_client() -> OpenAI | None:
+def setup_openai_llm_client() -> OpenAI | None:
     if not AzureOpenAI:
         logger.info("Azure OpenAI API client not available")
         return None

--- a/src/codemodder/llm.py
+++ b/src/codemodder/llm.py
@@ -9,9 +9,17 @@ except ImportError:
     OpenAI = None
     AzureOpenAI = None
 
+try:
+    from azure.ai.inference import ChatCompletionsClient
+    from azure.core.credentials import AzureKeyCredential
+except ImportError:
+    ChatCompletionsClient = None
+    AzureKeyCredential = None
 
 if TYPE_CHECKING:
     from openai import OpenAI
+    from azure.ai.inference import ChatCompletionsClient
+    from azure.core.credentials import AzureKeyCredential
 
 from codemodder.logging import logger
 
@@ -47,6 +55,7 @@ MODELS = ModelRegistry(models)
 
 
 def setup_openai_llm_client() -> OpenAI | None:
+    """Configure either the Azure OpenAI LLM client or the OpenAI client, in that order."""
     if not AzureOpenAI:
         logger.info("Azure OpenAI API client not available")
         return None
@@ -79,6 +88,28 @@ def setup_openai_llm_client() -> OpenAI | None:
 
     logger.info("Using OpenAI API client")
     return OpenAI(api_key=api_key)
+
+
+def setup_azure_llama_llm_client() -> ChatCompletionsClient | None:
+    """Configure the Azure Llama LLM client."""
+    if not ChatCompletionsClient:
+        logger.info("Azure API client not available")
+        return None
+
+    azure_llama_key = os.getenv("CODEMODDER_AZURE_LLAMA_API_KEY")
+    azure_llama_endpoint = os.getenv("CODEMODDER_AZURE_LLAMA_ENDPOINT")
+    if bool(azure_llama_key) ^ bool(azure_llama_endpoint):
+        raise MisconfiguredAIClient(
+            "Azure Llama API key and endpoint must both be set or unset"
+        )
+
+    if azure_llama_key and azure_llama_endpoint:
+        logger.info("Using Azure Llama API client")
+        return ChatCompletionsClient(
+            credential=AzureKeyCredential(azure_llama_key),
+            endpoint=azure_llama_endpoint,
+        )
+    return None
 
 
 class MisconfiguredAIClient(ValueError):

--- a/tests/test_context.py
+++ b/tests/test_context.py
@@ -90,7 +90,7 @@ class TestContext:
             in description
         )
 
-    def test_setup_llm_client_no_env_vars(self, mocker):
+    def test_setup_openai_llm_client_no_env_vars(self, mocker):
         mocker.patch.dict(os.environ, clear=True)
         context = Context(
             mocker.Mock(),
@@ -102,7 +102,7 @@ class TestContext:
             [],
             [],
         )
-        assert context.llm_client is None
+        assert context.openai_llm_client is None
 
     def test_setup_openai_llm_client(self, mocker):
         mocker.patch.dict(os.environ, {"CODEMODDER_OPENAI_API_KEY": "test"})
@@ -116,7 +116,7 @@ class TestContext:
             [],
             [],
         )
-        assert isinstance(context.llm_client, OpenAI)
+        assert isinstance(context.openai_llm_client, OpenAI)
 
     def test_setup_azure_llm_client(self, mocker):
         mocker.patch.dict(
@@ -136,8 +136,10 @@ class TestContext:
             [],
             [],
         )
-        assert isinstance(context.llm_client, AzureOpenAI)
-        assert context.llm_client._api_version == DEFAULT_AZURE_OPENAI_API_VERSION
+        assert isinstance(context.openai_llm_client, AzureOpenAI)
+        assert (
+            context.openai_llm_client._api_version == DEFAULT_AZURE_OPENAI_API_VERSION
+        )
 
     @pytest.mark.parametrize(
         "env_var",
@@ -177,5 +179,5 @@ class TestContext:
             [],
             [],
         )
-        assert isinstance(context.llm_client, AzureOpenAI)
-        assert context.llm_client._api_version == version
+        assert isinstance(context.openai_llm_client, AzureOpenAI)
+        assert context.openai_llm_client._api_version == version


### PR DESCRIPTION
## Overview
*Codemodder can run codemods with Azure LLama models*

## Description

* This is a breaking change because I thought it best to change `context.llm_client > context.openai_llm_client` for clarity
* now there can be both clients enabled.
* it's not necessary to add the model to the ModelRegistry, since the model used is encoded in whatever endpoint is used in `CODEMODDER_AZURE_LLAMA_ENDPOINT`
I tested this out with
```
        from azure.ai.inference.models import SystemMessage, UserMessage

        response = self.azure_llama_llm_client.complete(
            messages=[
                SystemMessage(content="You are a helpful assistant."),
                UserMessage(content="How many feet are in a mile?"),
            ]
        )
```

and got the expected response
```
(Pdb) print(response.choices[0].message.content)
There are 5,280 feet in a mile.
```

Close #871