### PR TITLE
change test assertion to bypass python argparse bug

### DIFF
--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -137,10 +137,9 @@ class TestParseArgs:
                 self.registry,
             )
         assert err.value.args[0] == 3
-        assert (
-            "CLI error: ambiguous option: --codemod=url-sandbox could match --codemod-exclude, --codemod-include"
-            in caplog.messages
-        )
+        msg = caplog.messages[0]
+        assert "CLI error: ambiguous option: " in msg
+        assert " could match --codemod-exclude, --codemod-include" in msg
 
     @pytest.mark.parametrize("codemod", ["secure-random", "pixee:python/secure-random"])
     def test_codemod_name_or_id(self, codemod):


### PR DESCRIPTION
## Overview
*Update log test assertion*

There is a [bug in python argparse](https://github.com/python/cpython/issues/107620) starting in python3.12.7, which our pipeline has just now run across.
Argparse is incorrectly logging 
```
            in caplog.messages
        )
E       AssertionError: assert 'CLI error: ambiguous option: --codemod=url-sandbox could match --codemod-exclude, --codemod-include' in ['CLI error: ambiguous option: *request.py could match --codemod-exclude, --codemod-include']
```
the ambiguous option the test passed is `--codemod`, not `request.py` which is what argparse is incorrectly logging

Updating this assertion is minimal impact for us.