### PR TITLE
Enable running codemodder as a library import

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,9 +30,11 @@ To install the package from source, use `pip`:
 $ pip install /path/to/codemodder-python
 ```
 
-## Running Locally
+## Running `codemodder`
 
-The codemodder package provides an executable called `codemodder`. This should be available on your path by default after installation.
+### CLI
+
+Codemodder can be run as a CLI. The codemodder package provides an executable called `codemodder`. This should be available on your path by default after installation.
 
 For basic usage, run the `codemodder` command with a target directory path:
 
@@ -54,6 +56,19 @@ For a full list of options, use the `--help` flag:
 ```
 $ codemodder --help
 ```
+
+### Library
+
+You can also run `codemodder` as a library by importing the module and running `run`. For basic usage, pass a target directory path and the `dry_run` argument:
+
+```python
+import codemodder
+
+output, exit_code = codemodder.run("/path/to/my-project", dry_run=True)
+```
+
+Unlike the CLI which has a default `dry_run` of `False`, when calling `codemodder` as a library you must indicate if you want `codemodder` to make changes to your files.
+
 
 ## Architecture
 

--- a/src/codemodder/__init__.py
+++ b/src/codemodder/__init__.py
@@ -2,3 +2,7 @@ try:
     from ._version import __version__
 except ImportError:  # pragma: no cover
     __version__ = "unknown"
+
+from codemodder.codemodder import run
+
+__all__ = ["run", "__version__"]

--- a/src/codemodder/cli.py
+++ b/src/codemodder/cli.py
@@ -121,6 +121,7 @@ def parse_args(argv, codemod_registry: CodemodRegistry):
     parser.add_argument(
         "--dry-run",
         action=argparse.BooleanOptionalAction,
+        default=False,
         help="do everything except make changes to files",
     )
     parser.add_argument(

--- a/src/codemodder/codemodder.py
+++ b/src/codemodder/codemodder.py
@@ -120,7 +120,7 @@ def record_dependency_update(dependency_results: dict[Dependency, PackageStore |
 
 def run(
     directory: Path | str,
-    output: str | None = None,  # TODO: this should be a Path
+    output: Path | str | None = None,
     output_format: str = "codetf",
     dry_run: bool = True,
     verbose: bool = False,

--- a/src/codemodder/codemodder.py
+++ b/src/codemodder/codemodder.py
@@ -120,9 +120,9 @@ def record_dependency_update(dependency_results: dict[Dependency, PackageStore |
 
 def run(
     directory: Path | str,
+    dry_run: bool,
     output: Path | str | None = None,
     output_format: str = "codetf",
-    dry_run: bool = True,
     verbose: bool = False,
     log_format: OutputFormat = OutputFormat.JSON,
     project_name: str | None = None,
@@ -254,9 +254,9 @@ def _run_cli(original_args) -> int:
 
     _, status = run(
         argv.directory,
+        argv.dry_run,
         argv.output,
         argv.output_format,
-        argv.dry_run,
         argv.verbose,
         argv.log_format,
         argv.project_name,

--- a/src/codemodder/codemodder.py
+++ b/src/codemodder/codemodder.py
@@ -175,7 +175,7 @@ def run(
         logger.error(e)
         return 3  # Codemodder instructions conflicted (according to spec)
 
-    repo_manager.parse_project()
+    context.repo_manager.parse_project()
 
     # TODO: this should be a method of CodemodExecutionContext
     codemods_to_run = codemod_registry.match_codemods(

--- a/src/codemodder/codemodder.py
+++ b/src/codemodder/codemodder.py
@@ -134,6 +134,7 @@ def run(
     max_workers: int = 1,
     original_cli_args: list[str] | None = None,
     codemod_registry: registry.CodemodRegistry | None = None,
+    sast_only: bool = False,
 ) -> tuple[CodeTF | None, int]:
     start = datetime.datetime.now()
 
@@ -183,6 +184,7 @@ def run(
     codemods_to_run = codemod_registry.match_codemods(
         codemod_include,
         codemod_exclude,
+        sast_only=sast_only,
     )
 
     log_section("setup")
@@ -268,6 +270,7 @@ def _run_cli(original_args) -> int:
         max_workers=argv.max_workers,
         original_cli_args=original_args,
         codemod_registry=codemod_registry,
+        sast_only=argv.sonar_issues_json or argv.sarif,
     )
     return status
 

--- a/src/codemodder/codetf.py
+++ b/src/codemodder/codetf.py
@@ -165,7 +165,7 @@ class CodeTF(BaseModel):
         cls,
         context: CodemodExecutionContext,
         elapsed_ms,
-        original_args,
+        original_args: list,
         results: list[Result],
     ):
         command_name = os.path.basename(sys.argv[0])

--- a/src/codemodder/codetf.py
+++ b/src/codemodder/codetf.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 import os
 import sys
 from enum import Enum
+from pathlib import Path
 from typing import TYPE_CHECKING, Optional
 
 from pydantic import BaseModel, model_validator
@@ -183,10 +184,9 @@ class CodeTF(BaseModel):
         )
         return cls(run=run, results=results)
 
-    def write_report(self, outfile):
+    def write_report(self, outfile: Path | str):
         try:
-            with open(outfile, "w", encoding="utf-8") as f:
-                f.write(self.model_dump_json(exclude_none=True))
+            Path(outfile).write_text(self.model_dump_json(exclude_none=True))
         except Exception:
             logger.exception("failed to write report file.")
             # Any issues with writing the output file should exit status 2.

--- a/src/codemodder/context.py
+++ b/src/codemodder/context.py
@@ -173,7 +173,9 @@ class CodemodExecutionContext:
             unfixed_findings
         )
 
-    def process_results(self, codemod_id: str, results: Iterator[FileContext]):
+    def process_results(
+        self, codemod_id: str, results: Iterator[FileContext] | list[FileContext]
+    ):
         for file_context in results:
             self.add_changesets(codemod_id, file_context.changesets)
             self.add_failures(codemod_id, file_context.failures)

--- a/src/codemodder/context.py
+++ b/src/codemodder/context.py
@@ -57,7 +57,7 @@ class CodemodExecutionContext:
     def __init__(
         self,
         directory: Path,
-        dry_run: bool = False,
+        dry_run: bool,
         verbose: bool = False,
         registry: CodemodRegistry | None = None,
         providers: ProviderRegistry | None = None,

--- a/tests/test_codemodder.py
+++ b/tests/test_codemodder.py
@@ -395,7 +395,7 @@ class TestRun:
     def test_run_basic_call(self, mock_parse, dir_structure):
         code_dir, codetf = dir_structure
 
-        codetf_output, status = run(code_dir)
+        codetf_output, status = run(code_dir, dry_run=True)
         assert status == 0
         assert codetf_output
         assert codetf_output.run.directory == str(code_dir)
@@ -407,7 +407,10 @@ class TestRun:
         code_dir, codetf = dir_structure
 
         codetf_output, status = run(
-            code_dir, output=codetf, codemod_include=["pixee:python/url-sandbox"]
+            code_dir,
+            output=codetf,
+            dry_run=True,
+            codemod_include=["pixee:python/url-sandbox"],
         )
         assert status == 0
         assert codetf_output

--- a/tests/test_codemodder.py
+++ b/tests/test_codemodder.py
@@ -407,7 +407,7 @@ class TestRun:
         code_dir, codetf = dir_structure
 
         codetf_output, status = run(
-            code_dir, output=str(codetf), codemod_include=["pixee:python/url-sandbox"]
+            code_dir, output=codetf, codemod_include=["pixee:python/url-sandbox"]
         )
         assert status == 0
         assert codetf_output


### PR DESCRIPTION
## Overview
*Be able to run codemodder as a library API*

## Description

* The README update explains what the result here is.
* the testing additions are very minimal, since we already heavily unit test most of the functionality.

## Additional Details
* Later on we could have this kind of thing, but I don't think it's necessary now

```
import codemodder
context = CodemodExecutionContext("/path/to/my-project", dry_run=True, ...)
output, exit_code = codemodder.run(context)
```
* later on we could also make `import codemodder; codemodder.list()` to match all CLI functionality.

/close #work