### PR TITLE
Gather results by rules

### DIFF
--- a/tests/test_results.py
+++ b/tests/test_results.py
@@ -55,6 +55,11 @@ class TestResults:
             in combined["python:S5659"][Path("code.py")]
         )
 
+        assert combined.results_for_rules(["python:S5659"]) == [
+            result1["python:S5659"][Path("code.py")][0],
+            result2["python:S5659"][Path("code.py")][0],
+        ]
+
     def test_sonar_only_open_issues(self, tmpdir):
         issues = {
             "issues": [


### PR DESCRIPTION
## Description

* For multi-file codemods we need a finding-oriented view rather than a file-oriented view of results. This is because fixing a single finding could potentially require changes to multiple files