### PR TITLE
Do not configure logger in `codemodder.run`

### DIFF
--- a/src/codemodder/codemodder.py
+++ b/src/codemodder/codemodder.py
@@ -15,13 +15,7 @@ from codemodder.codetf import CodeTF
 from codemodder.context import CodemodExecutionContext
 from codemodder.dependency import Dependency
 from codemodder.llm import MisconfiguredAIClient
-from codemodder.logging import (
-    OutputFormat,
-    configure_logger,
-    log_list,
-    log_section,
-    logger,
-)
+from codemodder.logging import configure_logger, log_list, log_section, logger
 from codemodder.project_analysis.file_parsers.package_store import PackageStore
 from codemodder.project_analysis.python_repo_manager import PythonRepoManager
 from codemodder.result import ResultSet
@@ -124,8 +118,6 @@ def run(
     output: Path | str | None = None,
     output_format: str = "codetf",
     verbose: bool = False,
-    log_format: OutputFormat = OutputFormat.JSON,
-    project_name: str | None = None,
     tool_result_files_map: DefaultDict[str, list[Path]] = defaultdict(list),
     path_include: list[str] | None = None,
     path_exclude: list[str] | None = None,
@@ -147,8 +139,6 @@ def run(
     codemod_exclude = codemod_exclude or []
 
     provider_registry = providers.load_providers()
-
-    configure_logger(verbose, log_format, project_name)
 
     log_section("startup")
     logger.info("codemodder: python/%s", __version__)
@@ -254,6 +244,7 @@ def _run_cli(original_args) -> int:
     tool_result_files_map["defectdojo"].extend(argv.defectdojo_findings_json or [])
 
     logger.info("command: %s %s", Path(sys.argv[0]).name, " ".join(original_args))
+    configure_logger(argv.verbose, argv.log_format, argv.project_name)
 
     _, status = run(
         argv.directory,
@@ -261,8 +252,6 @@ def _run_cli(original_args) -> int:
         argv.output,
         argv.output_format,
         argv.verbose,
-        argv.log_format,
-        argv.project_name,
         tool_result_files_map,
         argv.path_include,
         argv.path_exclude,

--- a/src/codemodder/logging.py
+++ b/src/codemodder/logging.py
@@ -85,6 +85,6 @@ def configure_logger(
 
     logging.basicConfig(
         format="%(message)s",
-        level=log_level,
         handlers=handlers,
     )
+    logger.setLevel(log_level)

--- a/tests/test_regex_transformer.py
+++ b/tests/test_regex_transformer.py
@@ -10,36 +10,36 @@ from codemodder.semgrep import SemgrepResult
 
 
 def test_transformer_no_change(mocker, caplog, tmp_path_factory):
-    caplog.set_level(logging.DEBUG)
-    base_dir = tmp_path_factory.mktemp("foo")
-    code = base_dir / "code.py"
-    code.write_text("# Something that won't match")
+    with caplog.at_level(logging.DEBUG):
+        base_dir = tmp_path_factory.mktemp("foo")
+        code = base_dir / "code.py"
+        code.write_text("# Something that won't match")
 
-    file_context = FileContext(
-        base_dir,
-        code,
-    )
-    execution_context = CodemodExecutionContext(
-        directory=base_dir,
-        dry_run=True,
-        verbose=False,
-        registry=mocker.MagicMock(),
-        providers=mocker.MagicMock(),
-        repo_manager=mocker.MagicMock(),
-        path_include=[],
-        path_exclude=[],
-    )
-    pipeline = RegexTransformerPipeline(
-        pattern=r"hello", replacement="bye", change_description="testing"
-    )
+        file_context = FileContext(
+            base_dir,
+            code,
+        )
+        execution_context = CodemodExecutionContext(
+            directory=base_dir,
+            dry_run=True,
+            verbose=False,
+            registry=mocker.MagicMock(),
+            providers=mocker.MagicMock(),
+            repo_manager=mocker.MagicMock(),
+            path_include=[],
+            path_exclude=[],
+        )
+        pipeline = RegexTransformerPipeline(
+            pattern=r"hello", replacement="bye", change_description="testing"
+        )
 
-    changeset = pipeline.apply(
-        context=execution_context,
-        file_context=file_context,
-        results=None,
-    )
-    assert changeset is None
-    assert "No changes produced for" in caplog.text
+        changeset = pipeline.apply(
+            context=execution_context,
+            file_context=file_context,
+            results=None,
+        )
+        assert changeset is None
+        assert "No changes produced for" in caplog.text
 
 
 def test_transformer(mocker, tmp_path_factory):

--- a/tests/test_regex_transformer.py
+++ b/tests/test_regex_transformer.py
@@ -6,10 +6,12 @@ from codemodder.codemods.regex_transformer import (
 )
 from codemodder.context import CodemodExecutionContext
 from codemodder.file_context import FileContext
+from codemodder.logging import OutputFormat, configure_logger
 from codemodder.semgrep import SemgrepResult
 
 
 def test_transformer_no_change(mocker, caplog, tmp_path_factory):
+    configure_logger(True, OutputFormat.HUMAN)
     with caplog.at_level(logging.DEBUG):
         base_dir = tmp_path_factory.mktemp("foo")
         code = base_dir / "code.py"


### PR DESCRIPTION
Instead the CLI is responsible for configuring the logger and any other clients can call `configure_logger` explicitly or use other means to configure.
