### PR TITLE
Add new CodeTF metadata for "strategy" and "provisional"

### DIFF
--- a/src/codemodder/codetf.py
+++ b/src/codemodder/codetf.py
@@ -83,6 +83,12 @@ class AIMetadata(BaseModel):
     tokens: Optional[int] = None
 
 
+class Strategy(Enum):
+    ai = "ai"
+    hybrid = "hybrid"
+    deterministic = "deterministic"
+
+
 class ChangeSet(BaseModel):
     """A set of changes made to a file at `path`"""
 
@@ -90,6 +96,8 @@ class ChangeSet(BaseModel):
     diff: str
     changes: list[Change] = []
     ai: Optional[AIMetadata] = None
+    strategy: Optional[Strategy] = None
+    provisional: Optional[bool] = False
 
 
 class Reference(BaseModel):


### PR DESCRIPTION
Add "strategy" and "provisional" metadata to reflect updates to CodeTF spec: https://github.com/pixee/codemodder-specs/pull/41