### PR TITLE
Remove restriction on duplicate sarif tools

### DIFF
--- a/src/codemodder/codemodder.py
+++ b/src/codemodder/codemodder.py
@@ -19,7 +19,7 @@ from codemodder.logging import configure_logger, log_list, log_section, logger
 from codemodder.project_analysis.file_parsers.package_store import PackageStore
 from codemodder.project_analysis.python_repo_manager import PythonRepoManager
 from codemodder.result import ResultSet
-from codemodder.sarifs import DuplicateToolError, detect_sarif_tools
+from codemodder.sarifs import detect_sarif_tools
 from codemodder.semgrep import run as run_semgrep
 
 
@@ -235,7 +235,7 @@ def _run_cli(original_args) -> int:
         tool_result_files_map: DefaultDict[str, list[Path]] = detect_sarif_tools(
             [Path(name) for name in argv.sarif or []]
         )
-    except (DuplicateToolError, FileNotFoundError) as err:
+    except FileNotFoundError as err:
         logger.error(err)
         return 1
 

--- a/src/codemodder/sarifs.py
+++ b/src/codemodder/sarifs.py
@@ -15,9 +15,6 @@ class AbstractSarifToolDetector(metaclass=ABCMeta):
         pass
 
 
-class DuplicateToolError(ValueError): ...
-
-
 def detect_sarif_tools(filenames: list[Path]) -> DefaultDict[str, list[Path]]:
     results: DefaultDict[str, list[Path]] = defaultdict(list)
 
@@ -42,15 +39,7 @@ def detect_sarif_tools(filenames: list[Path]) -> DefaultDict[str, list[Path]]:
                 try:
                     if det.detect(run):
                         logger.debug("detected %s sarif: %s", name, fname)
-                        # According to the Codemodder spec, it is invalid to have multiple SARIF results for the same tool
-                        # https://github.com/pixee/codemodder-specs/pull/36
-                        if name in results:
-                            raise DuplicateToolError(
-                                f"duplicate tool sarif detected: {name}"
-                            )
                         results[name].append(Path(fname))
-                except DuplicateToolError as err:
-                    raise err
                 except (KeyError, AttributeError, ValueError):
                     continue
 

--- a/tests/test_sarif_processing.py
+++ b/tests/test_sarif_processing.py
@@ -4,7 +4,7 @@ from pathlib import Path
 
 import pytest
 
-from codemodder.sarifs import DuplicateToolError, detect_sarif_tools
+from codemodder.sarifs import detect_sarif_tools
 from codemodder.semgrep import SemgrepResult, SemgrepResultSet
 
 
@@ -102,15 +102,14 @@ class TestSarifProcessing:
             check=False,
             capture_output=True,
         )
-        assert completed_process.returncode == 1
-        assert (
-            "duplicate tool sarif detected: codeql" in completed_process.stderr.decode()
-        )
+        assert completed_process.returncode == 0
 
     def test_two_sarifs_same_tool(self):
-        with pytest.raises(DuplicateToolError) as exc:
-            detect_sarif_tools([Path("tests/samples/webgoat_v8.2.0_codeql.sarif")] * 2)
-        assert "duplicate tool sarif detected: codeql" in str(exc.value)
+        results = detect_sarif_tools(
+            [Path("tests/samples/webgoat_v8.2.0_codeql.sarif")] * 2
+        )
+        assert len(results) == 1
+        assert len(results["codeql"]) == 2
 
     def test_bad_sarif(self, tmpdir, caplog):
         sarif_file = Path("tests") / "samples" / "semgrep.sarif"


### PR DESCRIPTION
This effectively reverts #742. It was based on an assumption that does not hold in a polyglot environment for tools that may scan each language separately (e.g. CodeQL).