### PR TITLE
CodeQL: use "correlationGuid" for finding ID

### DIFF
--- a/src/codemodder/codeql.py
+++ b/src/codemodder/codeql.py
@@ -56,7 +56,7 @@ class CodeQLResult(SarifResult):
             finding=Finding(
                 id=rule_id,
                 rule=Rule(
-                    id=rule_id,
+                    id=sarif_result.get("correlationGuid", rule_id),
                     name=rule_id,
                     # TODO: map to URL
                     # url=,


### PR DESCRIPTION
## Details
* This seems to be the correct value for uniquely identifying findings in CodeQL sarifs.
