### PR TITLE
Code transformers populate fix quality metadata

### DIFF
--- a/src/codemodder/codemods/libcst_transformer.py
+++ b/src/codemodder/codemods/libcst_transformer.py
@@ -9,7 +9,7 @@ from libcst.codemod.visitors import AddImportsVisitor, RemoveImportsVisitor
 from codemodder.codemods.base_transformer import BaseTransformerPipeline
 from codemodder.codemods.base_visitor import BaseTransformer
 from codemodder.codemods.utils import get_call_name
-from codemodder.codetf import Change, ChangeSet, Finding
+from codemodder.codetf import Change, ChangeSet, Finding, Strategy
 from codemodder.context import CodemodExecutionContext
 from codemodder.dependency import Dependency
 from codemodder.diff import create_diff_from_tree
@@ -291,6 +291,8 @@ class LibcstTransformerPipeline(BaseTransformerPipeline):
             path=str(file_context.file_path.relative_to(context.directory)),
             diff=diff,
             changes=file_context.codemod_changes,
+            strategy=Strategy.deterministic,
+            provisional=False,
         )
 
         if not context.dry_run:

--- a/src/codemodder/codemods/regex_transformer.py
+++ b/src/codemodder/codemods/regex_transformer.py
@@ -2,7 +2,7 @@ import re
 from typing import Pattern
 
 from codemodder.codemods.base_transformer import BaseTransformerPipeline
-from codemodder.codetf import Change, ChangeSet
+from codemodder.codetf import Change, ChangeSet, Strategy
 from codemodder.context import CodemodExecutionContext
 from codemodder.diff import create_diff
 from codemodder.file_context import FileContext
@@ -73,6 +73,8 @@ class RegexTransformerPipeline(BaseTransformerPipeline):
             path=str(file_context.file_path.relative_to(context.directory)),
             diff=diff,
             changes=changes,
+            strategy=Strategy.deterministic,
+            provisional=False,
         )
 
 

--- a/src/codemodder/codemods/xml_transformer.py
+++ b/src/codemodder/codemods/xml_transformer.py
@@ -8,7 +8,7 @@ from xml.sax.xmlreader import AttributesImpl, Locator
 from defusedxml.sax import make_parser
 
 from codemodder.codemods.base_transformer import BaseTransformerPipeline
-from codemodder.codetf import Change, ChangeSet
+from codemodder.codetf import Change, ChangeSet, Strategy
 from codemodder.context import CodemodExecutionContext
 from codemodder.diff import create_diff
 from codemodder.file_context import FileContext
@@ -209,9 +209,9 @@ class XMLTransformerPipeline(BaseTransformerPipeline):
                 output_file.seek(0)
             except Exception:
                 file_context.add_failure(
-                    file_path, reason := "Failed to parse XML file"
+                    file_context.file_path, reason := "Failed to parse XML file"
                 )
-                logger.exception("%s %s", reason, file_path)
+                logger.exception("%s %s", reason, file_context.file_path)
                 return None
 
             if not changes:
@@ -236,4 +236,6 @@ class XMLTransformerPipeline(BaseTransformerPipeline):
                 path=str(file_path.relative_to(context.directory)),
                 diff=diff,
                 changes=changes,
+                strategy=Strategy.deterministic,
+                provisional=False,
             )


### PR DESCRIPTION
* Populate new fix quality metadata fields recently introduced to the CodeTF spec
* The dependency transformers deliberately do not populate this metadata since it seems irrelevant to fix quality
