### PR TITLE
Use proper finding IDs for sonar and semgrep SARIF

### DIFF
--- a/src/codemodder/result.py
+++ b/src/codemodder/result.py
@@ -105,6 +105,7 @@ class SarifResult(SASTResult, ABCDataclass):
         )
 
     @classmethod
+    @abstractmethod
     def rule_url_from_id(cls, result: dict, run: dict, rule_id: str) -> str:
         raise NotImplementedError
 

--- a/src/core_codemods/sonar/results.py
+++ b/src/core_codemods/sonar/results.py
@@ -69,7 +69,7 @@ class SonarResult(SASTResult):
             locations=locations,
             codeflows=all_flows,
             finding=Finding(
-                id=rule_id,
+                id=finding_id,
                 rule=Rule(
                     id=rule_id,
                     name=name,


### PR DESCRIPTION
Use unique finding IDs (where available) for results from Sonar JSONs and Semgrep SARIF