### PR TITLE
Fix sonar issues and hotspots parsing

### DIFF
--- a/src/codemodder/codetf.py
+++ b/src/codemodder/codetf.py
@@ -12,7 +12,7 @@ from enum import Enum
 from pathlib import Path
 from typing import TYPE_CHECKING, Optional
 
-from pydantic import BaseModel, model_validator
+from pydantic import BaseModel, ConfigDict, model_validator
 
 from codemodder import __version__
 from codemodder.logging import logger
@@ -138,16 +138,14 @@ class Rule(BaseModel):
     name: str
     url: Optional[str] = None
 
-    class Config:
-        frozen = True
+    model_config = ConfigDict(frozen=True)
 
 
 class Finding(BaseModel):
     id: Optional[str] = None
     rule: Rule
 
-    class Config:
-        frozen = True
+    model_config = ConfigDict(frozen=True)
 
     def to_unfixed_finding(
         self,

--- a/src/core_codemods/sonar/results.py
+++ b/src/core_codemods/sonar/results.py
@@ -99,7 +99,7 @@ class SonarResultSet(ResultSet):
                 data = json.load(file)
 
             result_set = cls()
-            for result in data.get("issues") or [] + data.get("hotspots") or []:
+            for result in data.get("issues", []) + data.get("hotspots", []):
                 if result["status"].lower() in ("open", "to_review"):
                     result_set.add_result(SonarResult.from_result(result))
 

--- a/tests/test_sonar_results.py
+++ b/tests/test_sonar_results.py
@@ -1,4 +1,8 @@
-from core_codemods.sonar.results import SonarResult
+from pathlib import Path
+
+from core_codemods.sonar.results import SonarResult, SonarResultSet
+
+SAMPLE_DIR = Path(__file__).parent / "samples"
 
 
 def test_result_without_textrange():
@@ -29,3 +33,33 @@ def test_result_without_textrange():
     assert sonar_result.finding_id == "AZJnP4pZPJb5bI8DP25Y"
     assert sonar_result.locations == ()
     assert sonar_result.codeflows == ()
+
+
+def test_parse_issues_json():
+    results = SonarResultSet.from_json(SAMPLE_DIR / "sonar_issues.json")
+    assert len(results) == 34
+
+
+def test_parse_hotspots_json():
+    results = SonarResultSet.from_json(SAMPLE_DIR / "sonar_hotspots.json")
+    assert len(results) == 2
+
+
+def test_empty_issues(tmpdir, caplog):
+    empty_json = tmpdir / "empty.json"
+    empty_json.write_text('{"issues": []}', encoding="utf-8")
+
+    results = SonarResultSet.from_json(empty_json)
+
+    assert len(results) == 0
+    assert "Could not parse sonar json" not in caplog.text
+
+
+def test_empty_hotspots(tmpdir, caplog):
+    empty_json = tmpdir / "empty.json"
+    empty_json.write_text('{"hotspots": []}', encoding="utf-8")
+
+    results = SonarResultSet.from_json(empty_json)
+
+    assert len(results) == 0
+    assert "Could not parse sonar json" not in caplog.text


### PR DESCRIPTION
## Overview
*Fixes a relatively small bug related to parsing empty sonar issues files*

## Description

* This problem was already handled safely but I think it's best to clarify/simplify the logic here
* As far as I can tell, this would only occur with an empty and/or malformed Sonar issues input
* Also cleaned up a few noisy deprecation warnings