### PR TITLE
Add `--sonar-json` CLI flag; deprecate existing sonar flags

### DIFF
--- a/src/codemodder/cli.py
+++ b/src/codemodder/cli.py
@@ -175,6 +175,11 @@ def parse_args(argv, codemod_registry: CodemodRegistry):
         help="Comma-separated set of path(s) to Sonar hotspots JSON file(s) to feed to the codemods",
     )
     parser.add_argument(
+        "--sonar-json",
+        action=CsvListAction,
+        help="Comma-separated set of path(s) to Sonar JSON file(s) to feed to the codemods",
+    )
+    parser.add_argument(
         "--defectdojo-findings-json",
         action=CsvListAction,
         help="Comma-separated set of path(s) to DefectDojo's v2 Findings JSON file(s) to feed to the codemods",

--- a/src/codemodder/codemodder.py
+++ b/src/codemodder/codemodder.py
@@ -239,8 +239,20 @@ def _run_cli(original_args) -> int:
         logger.error(err)
         return 1
 
+    if argv.sonar_issues_json:
+        print(
+            "NOTE: --sonar-issues-json is deprecated, use --sonar-json instead",
+            file=sys.stderr,
+        )
+    if argv.sonar_hotspots_json:
+        print(
+            "NOTE: --sonar-hotspots-json is deprecated, use --sonar-json instead",
+            file=sys.stderr,
+        )
+
     tool_result_files_map["sonar"].extend(argv.sonar_issues_json or [])
     tool_result_files_map["sonar"].extend(argv.sonar_hotspots_json or [])
+    tool_result_files_map["sonar"].extend(argv.sonar_json or [])
     tool_result_files_map["defectdojo"].extend(argv.defectdojo_findings_json or [])
 
     logger.info("command: %s %s", Path(sys.argv[0]).name, " ".join(original_args))

--- a/tests/test_sonar_results.py
+++ b/tests/test_sonar_results.py
@@ -1,3 +1,4 @@
+import json
 from pathlib import Path
 
 from core_codemods.sonar.results import SonarResult, SonarResultSet
@@ -43,6 +44,17 @@ def test_parse_issues_json():
 def test_parse_hotspots_json():
     results = SonarResultSet.from_json(SAMPLE_DIR / "sonar_hotspots.json")
     assert len(results) == 2
+
+
+def test_combined_json(tmpdir):
+    issues = json.loads(SAMPLE_DIR.joinpath("sonar_issues.json").read_text())
+    hotspots = json.loads(SAMPLE_DIR.joinpath("sonar_hotspots.json").read_text())
+    Path(tmpdir).joinpath("combined.json").write_text(
+        json.dumps({"issues": issues["issues"] + hotspots["hotspots"]})
+    )
+
+    results = SonarResultSet.from_json(Path(tmpdir).joinpath("combined.json"))
+    assert len(results) == 36
 
 
 def test_empty_issues(tmpdir, caplog):


### PR DESCRIPTION
## Overview
*Add `--sonar-json` CLI flag; deprecate existing sonar flags*

## Description

* It turns out that there is no compelling reason to differentiate Issues and Hotspots inputs on the command line
* This new flag takes advantage of the preexisting behavior that enables processing of synthetically combined files that may contain both issues _and_ hotspots