### PR TITLE
add tokens fields to codetf

### DIFF
--- a/src/codemodder/codetf.py
+++ b/src/codemodder/codetf.py
@@ -91,6 +91,8 @@ class AIMetadata(BaseModel):
     provider: Optional[str] = None
     model: Optional[str] = None
     tokens: Optional[int] = None
+    completion_tokens: Optional[int] = None
+    prompt_tokens: Optional[int] = None
 
 
 class Strategy(Enum):


### PR DESCRIPTION
We would like to store both completion tokens and prompt tokens for AI metadata. To not touch the spec and anything upstream, I've added 2 new fields instead of using the existing tokens field, which could be the total of both completion and prompt tokens