### PR TITLE
Fix pytest warnings

### DIFF
--- a/src/codemodder/codemods/regex_transformer.py
+++ b/src/codemodder/codemods/regex_transformer.py
@@ -100,7 +100,7 @@ class SastRegexTransformerPipeline(RegexTransformerPipeline):
                 changed_line = self._apply_regex(line)
                 updated_lines.append(changed_line)
                 if line == changed_line:
-                    logger.warn("Unable to update html line: %s", line)
+                    logger.warning("Unable to update html line: %s", line)
                     self.report_unfixed(
                         file_context,
                         one_idx_lineno,

--- a/src/codemodder/logging.py
+++ b/src/codemodder/logging.py
@@ -3,7 +3,7 @@ import sys
 from enum import Enum
 from typing import Generator, Optional
 
-from pythonjsonlogger import jsonlogger
+from pythonjsonlogger import json
 
 logger = logging.getLogger("codemodder")
 
@@ -21,7 +21,7 @@ class OutputFormat(Enum):
         return self.value.lower()
 
 
-class CodemodderJsonFormatter(jsonlogger.JsonFormatter):
+class CodemodderJsonFormatter(json.JsonFormatter):
     project_name: Optional[str]
 
     def __init__(self, *args, project_name: Optional[str] = None, **kwargs):

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -1,4 +1,4 @@
-from pythonjsonlogger import jsonlogger
+from pythonjsonlogger import json
 
 from codemodder.logging import OutputFormat, configure_logger
 
@@ -10,7 +10,7 @@ def test_json_logger(mocker):
     assert basic_config.call_args[1]["format"] == "%(message)s"
     assert isinstance(
         basic_config.call_args[1]["handlers"][0].formatter,
-        jsonlogger.JsonFormatter,
+        json.JsonFormatter,
     )
     assert (
         basic_config.call_args[1]["handlers"][0].formatter.project_name


### PR DESCRIPTION
```
  /opt/hostedtoolcache/Python/3.12.9/x64/lib/python3.12/site-packages/pythonjsonlogger/jsonlogger.py:11: DeprecationWarning: pythonjsonlogger.jsonlogger has been moved to pythonjsonlogger.json
    warnings.warn(
```

```
add_html_integrity_attr.py:138: DeprecationWarning: The 'warn' method is deprecated, use 'warning' instead
    logger.warn("Unable to update html line: %s", line)


```