### PR TITLE
Added Independent Finding Execution Behavior

### DIFF
--- a/.github/workflows/codemod_pygoat.yml
+++ b/.github/workflows/codemod_pygoat.yml
@@ -38,6 +38,6 @@ jobs:
           repository: pixee/pygoat
           path: pygoat
       - name: Run Codemodder
-        run: codemodder_hardening --dry-run --output output.codetf pygoat
+        run: codemodder --dry-run --output output.codetf pygoat
       - name: Check PyGoat Findings
         run: make pygoat-test

--- a/.github/workflows/codemod_pygoat.yml
+++ b/.github/workflows/codemod_pygoat.yml
@@ -38,6 +38,6 @@ jobs:
           repository: pixee/pygoat
           path: pygoat
       - name: Run Codemodder
-        run: codemodder --dry-run --output output.codetf pygoat
+        run: codemodder_hardening --dry-run --output output.codetf pygoat
       - name: Check PyGoat Findings
         run: make pygoat-test

--- a/integration_tests/sonar/test_sonar_fix_missing_self_or_cls.py
+++ b/integration_tests/sonar/test_sonar_fix_missing_self_or_cls.py
@@ -1,38 +1,17 @@
-from codemodder.codemods.test import SonarIntegrationTest
+from codemodder.codemods.test.integration_utils import SonarRemediationIntegrationTest
 from core_codemods.fix_missing_self_or_cls import FixMissingSelfOrClsTransformer
 from core_codemods.sonar.sonar_fix_missing_self_or_cls import SonarFixMissingSelfOrCls
 
 
-class TestSonarFixMissingSelfOrCls(SonarIntegrationTest):
+class TestSonarFixMissingSelfOrCls(SonarRemediationIntegrationTest):
     codemod = SonarFixMissingSelfOrCls
     code_path = "tests/samples/fix_missing_self_or_cls.py"
-    replacement_lines = [
-        (
-            2,
-            """    def instance_method(self):\n""",
-        ),
-        (
-            6,
-            """    def class_method(cls):\n""",
-        ),
-    ]
-    # fmt: off
-    expected_diff = (
-    """--- \n"""
-    """+++ \n"""
-    """@@ -1,7 +1,7 @@\n"""
-    """ class MyClass:\n"""
-    """-    def instance_method():\n"""
-    """+    def instance_method(self):\n"""
-    """         print("instance_method")\n"""
-    """ \n"""
-    """     @classmethod\n"""
-    """-    def class_method():\n"""
-    """+    def class_method(cls):\n"""
-    """         print("class_method")\n"""
-    )
-    # fmt: on
 
-    expected_line_change = "2"
+    expected_diff_per_change = [
+        '--- \n+++ \n@@ -1,5 +1,5 @@\n class MyClass:\n-    def instance_method():\n+    def instance_method(self):\n         print("instance_method")\n \n     @classmethod\n',
+        '--- \n+++ \n@@ -3,5 +3,5 @@\n         print("instance_method")\n \n     @classmethod\n-    def class_method():\n+    def class_method(cls):\n         print("class_method")\n',
+    ]
+
+    expected_lines_changed = [2, 6]
     change_description = FixMissingSelfOrClsTransformer.change_description
     num_changes = 2

--- a/integration_tests/sonar/test_sonar_jinja2_autoescape.py
+++ b/integration_tests/sonar/test_sonar_jinja2_autoescape.py
@@ -1,18 +1,18 @@
-from codemodder.codemods.test import SonarIntegrationTest
+from codemodder.codemods.test.integration_utils import SonarRemediationIntegrationTest
 from core_codemods.enable_jinja2_autoescape import EnableJinja2AutoescapeTransformer
 from core_codemods.sonar.sonar_enable_jinja2_autoescape import (
     SonarEnableJinja2Autoescape,
 )
 
 
-class TestSonarEnableJinja2Autoescape(SonarIntegrationTest):
+class TestSonarEnableJinja2Autoescape(SonarRemediationIntegrationTest):
     codemod = SonarEnableJinja2Autoescape
     code_path = "tests/samples/jinja2_autoescape.py"
-    replacement_lines = [
-        (3, "env = Environment(autoescape=True)\n"),
-        (4, "env = Environment(autoescape=True)\n"),
+    expected_diff_per_change = [
+        "--- \n+++ \n@@ -1,4 +1,4 @@\n from jinja2 import Environment\n \n-env = Environment()\n+env = Environment(autoescape=True)\n env = Environment(autoescape=False)\n",
+        "--- \n+++ \n@@ -1,4 +1,4 @@\n from jinja2 import Environment\n \n env = Environment()\n-env = Environment(autoescape=False)\n+env = Environment(autoescape=True)\n",
     ]
-    expected_diff = "--- \n+++ \n@@ -1,4 +1,4 @@\n from jinja2 import Environment\n \n-env = Environment()\n-env = Environment(autoescape=False)\n+env = Environment(autoescape=True)\n+env = Environment(autoescape=True)\n"
-    expected_line_change = "3"
+
+    expected_lines_changed = [3, 4]
     num_changes = 2
     change_description = EnableJinja2AutoescapeTransformer.change_description

--- a/integration_tests/sonar/test_sonar_jwt_decode_verify.py
+++ b/integration_tests/sonar/test_sonar_jwt_decode_verify.py
@@ -1,25 +1,19 @@
-from codemodder.codemods.test import SonarIntegrationTest
+from codemodder.codemods.test.integration_utils import SonarRemediationIntegrationTest
 from core_codemods.sonar.sonar_jwt_decode_verify import (
     JwtDecodeVerifySASTTransformer,
     SonarJwtDecodeVerify,
 )
 
 
-class TestJwtDecodeVerify(SonarIntegrationTest):
+class TestJwtDecodeVerify(SonarRemediationIntegrationTest):
     codemod = SonarJwtDecodeVerify
     code_path = "tests/samples/jwt_decode_verify.py"
-    replacement_lines = [
-        (
-            11,
-            """decoded_payload = jwt.decode(encoded_jwt, SECRET_KEY, algorithms=["HS256"], verify=True)\n""",
-        ),
-        (
-            12,
-            """decoded_payload = jwt.decode(encoded_jwt, SECRET_KEY, algorithms=["HS256"], options={"verify_signature": True})\n""",
-        ),
+
+    expected_diff_per_change = [
+        '--- \n+++ \n@@ -8,7 +8,7 @@\n \n encoded_jwt = jwt.encode(payload, SECRET_KEY, algorithm="HS256")\n \n-decoded_payload = jwt.decode(encoded_jwt, SECRET_KEY, algorithms=["HS256"], verify=False)\n+decoded_payload = jwt.decode(encoded_jwt, SECRET_KEY, algorithms=["HS256"], verify=True)\n decoded_payload = jwt.decode(encoded_jwt, SECRET_KEY, algorithms=["HS256"], options={"verify_signature": False})\n \n var = "something"\n',
+        '--- \n+++ \n@@ -9,6 +9,6 @@\n encoded_jwt = jwt.encode(payload, SECRET_KEY, algorithm="HS256")\n \n decoded_payload = jwt.decode(encoded_jwt, SECRET_KEY, algorithms=["HS256"], verify=False)\n-decoded_payload = jwt.decode(encoded_jwt, SECRET_KEY, algorithms=["HS256"], options={"verify_signature": False})\n+decoded_payload = jwt.decode(encoded_jwt, SECRET_KEY, algorithms=["HS256"], options={"verify_signature": True})\n \n var = "something"\n',
     ]
 
-    expected_diff = '--- \n+++ \n@@ -8,7 +8,7 @@\n \n encoded_jwt = jwt.encode(payload, SECRET_KEY, algorithm="HS256")\n \n-decoded_payload = jwt.decode(encoded_jwt, SECRET_KEY, algorithms=["HS256"], verify=False)\n-decoded_payload = jwt.decode(encoded_jwt, SECRET_KEY, algorithms=["HS256"], options={"verify_signature": False})\n+decoded_payload = jwt.decode(encoded_jwt, SECRET_KEY, algorithms=["HS256"], verify=True)\n+decoded_payload = jwt.decode(encoded_jwt, SECRET_KEY, algorithms=["HS256"], options={"verify_signature": True})\n \n var = "something"\n'
-    expected_line_change = "11"
+    expected_lines_changed = [11, 12]
     num_changes = 2
     change_description = JwtDecodeVerifySASTTransformer.change_description

--- a/integration_tests/sonar/test_sonar_secure_cookie.py
+++ b/integration_tests/sonar/test_sonar_secure_cookie.py
@@ -1,19 +1,18 @@
-from codemodder.codemods.test import SonarIntegrationTest
+from codemodder.codemods.test.integration_utils import SonarRemediationIntegrationTest
 from core_codemods.sonar.sonar_secure_cookie import (
     SonarSecureCookie,
     SonarSecureCookieTransformer,
 )
 
 
-class TestSonarSecureCookie(SonarIntegrationTest):
+class TestSonarSecureCookie(SonarRemediationIntegrationTest):
     codemod = SonarSecureCookie
     code_path = "tests/samples/secure_cookie.py"
-    replacement_lines = [
-        (
-            8,
-            """    resp.set_cookie('custom_cookie', 'value', secure=True, httponly=True, samesite='Lax')\n""",
-        ),
+    expected_diff_per_change = [
+        "--- \n+++ \n@@ -5,5 +5,5 @@\n @app.route('/')\n def index():\n     resp = make_response('Custom Cookie Set')\n-    resp.set_cookie('custom_cookie', 'value')\n+    resp.set_cookie('custom_cookie', 'value', secure=True, httponly=True, samesite='Lax')\n     return resp\n",
+        "--- \n+++ \n@@ -5,5 +5,5 @@\n @app.route('/')\n def index():\n     resp = make_response('Custom Cookie Set')\n-    resp.set_cookie('custom_cookie', 'value')\n+    resp.set_cookie('custom_cookie', 'value', secure=True, httponly=True, samesite='Lax')\n     return resp\n",
     ]
-    expected_diff = "--- \n+++ \n@@ -5,5 +5,5 @@\n @app.route('/')\n def index():\n     resp = make_response('Custom Cookie Set')\n-    resp.set_cookie('custom_cookie', 'value')\n+    resp.set_cookie('custom_cookie', 'value', secure=True, httponly=True, samesite='Lax')\n     return resp\n"
-    expected_line_change = "8"
+
+    expected_lines_changed = [8, 8]
+    num_changes = 2
     change_description = SonarSecureCookieTransformer.change_description

--- a/integration_tests/sonar/test_sonar_secure_random.py
+++ b/integration_tests/sonar/test_sonar_secure_random.py
@@ -1,29 +1,16 @@
-from codemodder.codemods.test import SonarIntegrationTest
+from codemodder.codemods.test.integration_utils import SonarRemediationIntegrationTest
 from core_codemods.secure_random import SecureRandomTransformer
 from core_codemods.sonar.sonar_secure_random import SonarSecureRandom
 
 
-class TestSonarDjangoJsonResponseType(SonarIntegrationTest):
+class TestSonarSecureRandom(SonarRemediationIntegrationTest):
     codemod = SonarSecureRandom
     code_path = "tests/samples/secure_random.py"
-    replacement_lines = [
-        (1, """import secrets\n"""),
-        (3, """secrets.SystemRandom().random()\n"""),
-        (4, """secrets.SystemRandom().getrandbits(1)\n"""),
+    expected_diff_per_change = [
+        "--- \n+++ \n@@ -1,4 +1,5 @@\n import random\n+import secrets\n \n-random.random()\n+secrets.SystemRandom().random()\n random.getrandbits(1)\n",
+        "--- \n+++ \n@@ -1,4 +1,5 @@\n import random\n+import secrets\n \n random.random()\n-random.getrandbits(1)\n+secrets.SystemRandom().getrandbits(1)\n",
     ]
-    # fmt: off
-    expected_diff = (
-        """--- \n"""
-        """+++ \n"""
-        """@@ -1,4 +1,4 @@\n"""
-        """-import random\n"""
-        """+import secrets\n"""
-        """ \n"""
-        """-random.random()\n"""
-        """-random.getrandbits(1)\n"""
-        """+secrets.SystemRandom().random()\n"""
-        """+secrets.SystemRandom().getrandbits(1)\n""")
-    # fmt: on
-    expected_line_change = "3"
+
+    expected_lines_changed = [3, 4]
     change_description = SecureRandomTransformer.change_description
     num_changes = 2

--- a/integration_tests/test_add_requests_timeout.py
+++ b/integration_tests/test_add_requests_timeout.py
@@ -1,13 +1,13 @@
 from requests.exceptions import ConnectionError
 
-from codemodder.codemods.test import BaseIntegrationTest
+from codemodder.codemods.test.integration_utils import BaseRemediationIntegrationTest
 from core_codemods.add_requests_timeouts import (
     AddRequestsTimeouts,
     TransformAddRequestsTimeouts,
 )
 
 
-class TestAddRequestsTimeouts(BaseIntegrationTest):
+class TestAddRequestsTimeouts(BaseRemediationIntegrationTest):
     codemod = AddRequestsTimeouts
     original_code = """
     import requests
@@ -18,27 +18,13 @@ class TestAddRequestsTimeouts(BaseIntegrationTest):
     requests.post("https://example.com", verify=False)
     """
 
-    replacement_lines = [
-        (3, 'requests.get("https://example.com", timeout=60)\n'),
-        (6, 'requests.post("https://example.com", verify=False, timeout=60)\n'),
+    expected_diff_per_change = [
+        '--- \n+++ \n@@ -1,6 +1,6 @@\n import requests\n \n-requests.get("https://example.com")\n+requests.get("https://example.com", timeout=60)\n requests.get("https://example.com", timeout=1)\n requests.get("https://example.com", timeout=(1, 10), verify=False)\n requests.post("https://example.com", verify=False)',
+        '--- \n+++ \n@@ -3,4 +3,4 @@\n requests.get("https://example.com")\n requests.get("https://example.com", timeout=1)\n requests.get("https://example.com", timeout=(1, 10), verify=False)\n-requests.post("https://example.com", verify=False)\n+requests.post("https://example.com", verify=False, timeout=60)',
     ]
 
-    expected_diff = """\
---- 
-+++ 
-@@ -1,6 +1,6 @@
- import requests
- 
--requests.get("https://example.com")
-+requests.get("https://example.com", timeout=60)
- requests.get("https://example.com", timeout=1)
- requests.get("https://example.com", timeout=(1, 10), verify=False)
--requests.post("https://example.com", verify=False)
-+requests.post("https://example.com", verify=False, timeout=60)
-"""
-
     num_changes = 2
-    expected_line_change = "3"
+    expected_lines_changed = [3, 6]
     change_description = TransformAddRequestsTimeouts.change_description
     # expected because requests are made
     allowed_exceptions = (ConnectionError,)

--- a/integration_tests/test_dependency_manager.py
+++ b/integration_tests/test_dependency_manager.py
@@ -136,7 +136,7 @@ class TestDependencyManager:
         os.chmod(tmp_repo / self.requirements_file, 0o400)
 
         command = [
-            "codemodder_hardening",
+            "codemodder",
             tmp_repo,
             "--output",
             self.output_path,

--- a/integration_tests/test_dependency_manager.py
+++ b/integration_tests/test_dependency_manager.py
@@ -136,7 +136,7 @@ class TestDependencyManager:
         os.chmod(tmp_repo / self.requirements_file, 0o400)
 
         command = [
-            "codemodder",
+            "codemodder_hardening",
             tmp_repo,
             "--output",
             self.output_path,

--- a/integration_tests/test_harden_ruamel.py
+++ b/integration_tests/test_harden_ruamel.py
@@ -1,8 +1,8 @@
-from codemodder.codemods.test import BaseIntegrationTest
+from codemodder.codemods.test.integration_utils import BaseRemediationIntegrationTest
 from core_codemods.harden_ruamel import HardenRuamel
 
 
-class TestHardenRuamel(BaseIntegrationTest):
+class TestHardenRuamel(BaseRemediationIntegrationTest):
     codemod = HardenRuamel
     original_code = """
     from ruamel.yaml import YAML
@@ -10,11 +10,11 @@ class TestHardenRuamel(BaseIntegrationTest):
     serializer = YAML(typ="unsafe")
     serializer = YAML(typ="base")
     """
-    replacement_lines = [
-        (3, 'serializer = YAML(typ="safe")\n'),
-        (4, 'serializer = YAML(typ="safe")\n'),
+    expected_diff_per_change = [
+        '--- \n+++ \n@@ -1,4 +1,4 @@\n from ruamel.yaml import YAML\n \n-serializer = YAML(typ="unsafe")\n+serializer = YAML(typ="safe")\n serializer = YAML(typ="base")',
+        '--- \n+++ \n@@ -1,4 +1,4 @@\n from ruamel.yaml import YAML\n \n serializer = YAML(typ="unsafe")\n-serializer = YAML(typ="base")\n+serializer = YAML(typ="safe")',
     ]
-    expected_diff = '--- \n+++ \n@@ -1,4 +1,4 @@\n from ruamel.yaml import YAML\n \n-serializer = YAML(typ="unsafe")\n-serializer = YAML(typ="base")\n+serializer = YAML(typ="safe")\n+serializer = YAML(typ="safe")\n'
-    expected_line_change = "3"
+
+    expected_lines_changed = [3, 4]
     num_changes = 2
     change_description = HardenRuamel.change_description

--- a/integration_tests/test_jinja2_autoescape.py
+++ b/integration_tests/test_jinja2_autoescape.py
@@ -1,11 +1,11 @@
-from codemodder.codemods.test import BaseIntegrationTest
+from codemodder.codemods.test.integration_utils import BaseRemediationIntegrationTest
 from core_codemods.enable_jinja2_autoescape import (
     EnableJinja2Autoescape,
     EnableJinja2AutoescapeTransformer,
 )
 
 
-class TestEnableJinja2Autoescape(BaseIntegrationTest):
+class TestEnableJinja2Autoescape(BaseRemediationIntegrationTest):
     codemod = EnableJinja2Autoescape
     original_code = """
     from jinja2 import Environment
@@ -13,11 +13,12 @@ class TestEnableJinja2Autoescape(BaseIntegrationTest):
     env = Environment()
     env = Environment(autoescape=False)
     """
-    replacement_lines = [
-        (3, "env = Environment(autoescape=True)\n"),
-        (4, "env = Environment(autoescape=True)\n"),
+
+    expected_diff_per_change = [
+        "--- \n+++ \n@@ -1,4 +1,4 @@\n from jinja2 import Environment\n \n-env = Environment()\n+env = Environment(autoescape=True)\n env = Environment(autoescape=False)",
+        "--- \n+++ \n@@ -1,4 +1,4 @@\n from jinja2 import Environment\n \n env = Environment()\n-env = Environment(autoescape=False)\n+env = Environment(autoescape=True)",
     ]
-    expected_diff = "--- \n+++ \n@@ -1,4 +1,4 @@\n from jinja2 import Environment\n \n-env = Environment()\n-env = Environment(autoescape=False)\n+env = Environment(autoescape=True)\n+env = Environment(autoescape=True)\n"
-    expected_line_change = "3"
+
+    expected_lines_changed = [3, 4]
     num_changes = 2
     change_description = EnableJinja2AutoescapeTransformer.change_description

--- a/integration_tests/test_jwt_decode_verify.py
+++ b/integration_tests/test_jwt_decode_verify.py
@@ -1,8 +1,8 @@
-from codemodder.codemods.test import BaseIntegrationTest
+from codemodder.codemods.test.integration_utils import BaseRemediationIntegrationTest
 from core_codemods.jwt_decode_verify import JwtDecodeVerify, JwtDecodeVerifyTransformer
 
 
-class TestJwtDecodeVerify(BaseIntegrationTest):
+class TestJwtDecodeVerify(BaseRemediationIntegrationTest):
     codemod = JwtDecodeVerify
     original_code = """
     import jwt
@@ -20,17 +20,11 @@ class TestJwtDecodeVerify(BaseIntegrationTest):
     
     var = "something"
     """
-    replacement_lines = [
-        (
-            11,
-            """decoded_payload = jwt.decode(encoded_jwt, SECRET_KEY, algorithms=["HS256"], verify=True)\n""",
-        ),
-        (
-            12,
-            """decoded_payload = jwt.decode(encoded_jwt, SECRET_KEY, algorithms=["HS256"], options={"verify_signature": True})\n""",
-        ),
+    expected_diff_per_change = [
+        '--- \n+++ \n@@ -8,7 +8,7 @@\n \n encoded_jwt = jwt.encode(payload, SECRET_KEY, algorithm="HS256")\n \n-decoded_payload = jwt.decode(encoded_jwt, SECRET_KEY, algorithms=["HS256"], verify=False)\n+decoded_payload = jwt.decode(encoded_jwt, SECRET_KEY, algorithms=["HS256"], verify=True)\n decoded_payload = jwt.decode(encoded_jwt, SECRET_KEY, algorithms=["HS256"], options={"verify_signature": False})\n \n var = "something"',
+        '--- \n+++ \n@@ -9,6 +9,6 @@\n encoded_jwt = jwt.encode(payload, SECRET_KEY, algorithm="HS256")\n \n decoded_payload = jwt.decode(encoded_jwt, SECRET_KEY, algorithms=["HS256"], verify=False)\n-decoded_payload = jwt.decode(encoded_jwt, SECRET_KEY, algorithms=["HS256"], options={"verify_signature": False})\n+decoded_payload = jwt.decode(encoded_jwt, SECRET_KEY, algorithms=["HS256"], options={"verify_signature": True})\n \n var = "something"',
     ]
-    expected_diff = '--- \n+++ \n@@ -8,7 +8,7 @@\n \n encoded_jwt = jwt.encode(payload, SECRET_KEY, algorithm="HS256")\n \n-decoded_payload = jwt.decode(encoded_jwt, SECRET_KEY, algorithms=["HS256"], verify=False)\n-decoded_payload = jwt.decode(encoded_jwt, SECRET_KEY, algorithms=["HS256"], options={"verify_signature": False})\n+decoded_payload = jwt.decode(encoded_jwt, SECRET_KEY, algorithms=["HS256"], verify=True)\n+decoded_payload = jwt.decode(encoded_jwt, SECRET_KEY, algorithms=["HS256"], options={"verify_signature": True})\n \n var = "something"\n'
-    expected_line_change = "11"
+
+    expected_lines_changed = [11, 12]
     num_changes = 2
     change_description = JwtDecodeVerifyTransformer.change_description

--- a/integration_tests/test_lazy_logging.py
+++ b/integration_tests/test_lazy_logging.py
@@ -1,8 +1,8 @@
-from codemodder.codemods.test import BaseIntegrationTest
+from codemodder.codemods.test.integration_utils import BaseRemediationIntegrationTest
 from core_codemods.lazy_logging import LazyLogging
 
 
-class TestLazyLogging(BaseIntegrationTest):
+class TestLazyLogging(BaseRemediationIntegrationTest):
     codemod = LazyLogging
     original_code = """
     import logging
@@ -10,23 +10,11 @@ class TestLazyLogging(BaseIntegrationTest):
     logging.error("Error occurred: %s" % e)
     logging.error("Error occurred: " + e)
     """
-    replacement_lines = [
-        (3, """logging.error("Error occurred: %s", e)\n"""),
-        (4, """logging.error("Error occurred: %s", e)\n"""),
+    expected_diff_per_change = [
+        '--- \n+++ \n@@ -1,4 +1,4 @@\n import logging\n e = "Some error"\n-logging.error("Error occurred: %s" % e)\n+logging.error("Error occurred: %s", e)\n logging.error("Error occurred: " + e)',
+        '--- \n+++ \n@@ -1,4 +1,4 @@\n import logging\n e = "Some error"\n logging.error("Error occurred: %s" % e)\n-logging.error("Error occurred: " + e)\n+logging.error("Error occurred: %s", e)',
     ]
-    # fmt: off
-    expected_diff = (
-    """--- \n"""
-    """+++ \n"""
-    """@@ -1,4 +1,4 @@\n"""
-    """ import logging\n"""
-    """ e = "Some error"\n"""
-    """-logging.error("Error occurred: %s" % e)\n"""
-    """-logging.error("Error occurred: " + e)\n"""
-    """+logging.error("Error occurred: %s", e)\n"""
-    """+logging.error("Error occurred: %s", e)\n""")
-    # fmt: on
 
-    expected_line_change = "3"
+    expected_lines_changed = [3, 4]
     change_description = LazyLogging.change_description
     num_changes = 2

--- a/integration_tests/test_lxml_safe_parsing.py
+++ b/integration_tests/test_lxml_safe_parsing.py
@@ -1,26 +1,19 @@
-from codemodder.codemods.test import BaseIntegrationTest
+from codemodder.codemods.test.integration_utils import BaseRemediationIntegrationTest
 from core_codemods.lxml_safe_parsing import LxmlSafeParsing
 
 
-class TestLxmlSafeParsing(BaseIntegrationTest):
+class TestLxmlSafeParsing(BaseRemediationIntegrationTest):
     codemod = LxmlSafeParsing
     original_code = """
     import lxml.etree
     lxml.etree.parse("path_to_file")
     lxml.etree.fromstring("xml_str")
     """
-    replacement_lines = [
-        (
-            2,
-            'lxml.etree.parse("path_to_file", parser=lxml.etree.XMLParser(resolve_entities=False))\n',
-        ),
-        (
-            3,
-            'lxml.etree.fromstring("xml_str", parser=lxml.etree.XMLParser(resolve_entities=False))\n',
-        ),
+    expected_lines_changed = [2, 3]
+    expected_diff_per_change = [
+        '--- \n+++ \n@@ -1,3 +1,3 @@\n import lxml.etree\n-lxml.etree.parse("path_to_file")\n+lxml.etree.parse("path_to_file", parser=lxml.etree.XMLParser(resolve_entities=False))\n lxml.etree.fromstring("xml_str")',
+        '--- \n+++ \n@@ -1,3 +1,3 @@\n import lxml.etree\n lxml.etree.parse("path_to_file")\n-lxml.etree.fromstring("xml_str")\n+lxml.etree.fromstring("xml_str", parser=lxml.etree.XMLParser(resolve_entities=False))',
     ]
-    expected_diff = '--- \n+++ \n@@ -1,3 +1,3 @@\n import lxml.etree\n-lxml.etree.parse("path_to_file")\n-lxml.etree.fromstring("xml_str")\n+lxml.etree.parse("path_to_file", parser=lxml.etree.XMLParser(resolve_entities=False))\n+lxml.etree.fromstring("xml_str", parser=lxml.etree.XMLParser(resolve_entities=False))\n'
-    expected_line_change = "2"
     num_changes = 2
     change_description = LxmlSafeParsing.change_description
     allowed_exceptions = (OSError,)

--- a/integration_tests/test_multiple_codemods.py
+++ b/integration_tests/test_multiple_codemods.py
@@ -25,7 +25,7 @@ class TestMultipleCodemods:
         shutil.copy(pathlib.Path(SAMPLES_DIR) / source_file_name, directory)
 
         command = [
-            "codemodder_hardening",
+            "codemodder",
             directory,
             "--output",
             str(codetf_path),

--- a/integration_tests/test_multiple_codemods.py
+++ b/integration_tests/test_multiple_codemods.py
@@ -25,7 +25,7 @@ class TestMultipleCodemods:
         shutil.copy(pathlib.Path(SAMPLES_DIR) / source_file_name, directory)
 
         command = [
-            "codemodder",
+            "codemodder_hardening",
             directory,
             "--output",
             str(codetf_path),

--- a/integration_tests/test_process_sandbox.py
+++ b/integration_tests/test_process_sandbox.py
@@ -1,9 +1,9 @@
-from codemodder.codemods.test import BaseIntegrationTest
+from codemodder.codemods.test.integration_utils import BaseRemediationIntegrationTest
 from codemodder.dependency import Security
 from core_codemods.process_creation_sandbox import ProcessSandbox
 
 
-class TestProcessSandbox(BaseIntegrationTest):
+class TestProcessSandbox(BaseRemediationIntegrationTest):
     codemod = ProcessSandbox
     original_code = """
     import subprocess
@@ -22,17 +22,15 @@ class TestProcessSandbox(BaseIntegrationTest):
 
     var = "hello"
     """
-    replacement_lines = [
-        (2, """from security import safe_command\n\n"""),
-        (5, """safe_command.run(subprocess.run, cmd, shell=True)\n"""),
-        (6, """safe_command.run(subprocess.run, [cmd, "-l"])\n"""),
-        (8, """safe_command.run(subprocess.call, cmd, shell=True)\n"""),
-        (9, """safe_command.run(subprocess.call, [cmd, "-l"])\n"""),
+    expected_diff_per_change = [
+        '--- \n+++ \n@@ -1,8 +1,9 @@\n import subprocess\n+from security import safe_command\n \n cmd = " ".join(["ls"])\n \n-subprocess.run(cmd, shell=True)\n+safe_command.run(subprocess.run, cmd, shell=True)\n subprocess.run([cmd, "-l"])\n \n subprocess.call(cmd, shell=True)\n',
+        '--- \n+++ \n@@ -1,9 +1,10 @@\n import subprocess\n+from security import safe_command\n \n cmd = " ".join(["ls"])\n \n subprocess.run(cmd, shell=True)\n-subprocess.run([cmd, "-l"])\n+safe_command.run(subprocess.run, [cmd, "-l"])\n \n subprocess.call(cmd, shell=True)\n subprocess.call([cmd, "-l"])\n',
+        '--- \n+++ \n@@ -1,11 +1,12 @@\n import subprocess\n+from security import safe_command\n \n cmd = " ".join(["ls"])\n \n subprocess.run(cmd, shell=True)\n subprocess.run([cmd, "-l"])\n \n-subprocess.call(cmd, shell=True)\n+safe_command.run(subprocess.call, cmd, shell=True)\n subprocess.call([cmd, "-l"])\n \n subprocess.check_output([cmd, "-l"])\n',
+        '--- \n+++ \n@@ -1,4 +1,5 @@\n import subprocess\n+from security import safe_command\n \n cmd = " ".join(["ls"])\n \n@@ -6,7 +7,7 @@\n subprocess.run([cmd, "-l"])\n \n subprocess.call(cmd, shell=True)\n-subprocess.call([cmd, "-l"])\n+safe_command.run(subprocess.call, [cmd, "-l"])\n \n subprocess.check_output([cmd, "-l"])\n \n',
     ]
-    expected_diff = '--- \n+++ \n@@ -1,12 +1,13 @@\n import subprocess\n+from security import safe_command\n \n cmd = " ".join(["ls"])\n \n-subprocess.run(cmd, shell=True)\n-subprocess.run([cmd, "-l"])\n+safe_command.run(subprocess.run, cmd, shell=True)\n+safe_command.run(subprocess.run, [cmd, "-l"])\n \n-subprocess.call(cmd, shell=True)\n-subprocess.call([cmd, "-l"])\n+safe_command.run(subprocess.call, cmd, shell=True)\n+safe_command.run(subprocess.call, [cmd, "-l"])\n \n subprocess.check_output([cmd, "-l"])\n \n'
-    expected_line_change = "5"
+
+    expected_lines_changed = [5, 6, 8, 9]
     num_changes = 4
-    num_changed_files = 2
     change_description = ProcessSandbox.change_description
 
     requirements_file_name = "requirements.txt"

--- a/integration_tests/test_request_verify.py
+++ b/integration_tests/test_request_verify.py
@@ -1,10 +1,10 @@
 from requests import exceptions
 
-from codemodder.codemods.test import BaseIntegrationTest
+from codemodder.codemods.test.integration_utils import BaseRemediationIntegrationTest
 from core_codemods.requests_verify import RequestsVerify
 
 
-class TestRequestsVerify(BaseIntegrationTest):
+class TestRequestsVerify(BaseRemediationIntegrationTest):
     codemod = RequestsVerify
     original_code = """
     import requests
@@ -14,15 +14,12 @@ class TestRequestsVerify(BaseIntegrationTest):
     var = "hello"
     """
 
-    replacement_lines = [
-        (3, """requests.get("https://www.google.com", verify=True)\n"""),
-        (
-            4,
-            """requests.post("https://some-api/", json={"id": 1234, "price": 18}, verify=True)\n""",
-        ),
+    expected_diff_per_change = [
+        '--- \n+++ \n@@ -1,5 +1,5 @@\n import requests\n \n-requests.get("https://www.google.com", verify=False)\n+requests.get("https://www.google.com", verify=True)\n requests.post("https://some-api/", json={"id": 1234, "price": 18}, verify=False)\n var = "hello"',
+        '--- \n+++ \n@@ -1,5 +1,5 @@\n import requests\n \n requests.get("https://www.google.com", verify=False)\n-requests.post("https://some-api/", json={"id": 1234, "price": 18}, verify=False)\n+requests.post("https://some-api/", json={"id": 1234, "price": 18}, verify=True)\n var = "hello"',
     ]
-    expected_diff = '--- \n+++ \n@@ -1,5 +1,5 @@\n import requests\n \n-requests.get("https://www.google.com", verify=False)\n-requests.post("https://some-api/", json={"id": 1234, "price": 18}, verify=False)\n+requests.get("https://www.google.com", verify=True)\n+requests.post("https://some-api/", json={"id": 1234, "price": 18}, verify=True)\n var = "hello"\n'
-    expected_line_change = "3"
+
+    expected_lines_changed = [3, 4]
     num_changes = 2
     change_description = RequestsVerify.change_description
     # expected because when executing the output code it will make a request which fails, which is OK.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -82,7 +82,7 @@ test = [
     "flask_wtf~=1.2.0",
     "fickling~=0.1.0,>=0.1.3",
     "graphql-server~=3.0.0b7",
-    "unidiff>=0.75",
+    "unidiff>=0.7.5",
 ]
 complexity = [
     "radon==6.0.*",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,7 +46,7 @@ Repository = "https://github.com/pixee/codemodder-python"
 
 [project.scripts]
 codemodder = "codemodder.codemodder:main"
-codemodder_hardening = "codemodder.codemodder:harden"
+codemodder-remediation = "codemodder.codemodder:remediate"
 generate-docs = 'codemodder.scripts.generate_docs:main'
 get-hashes = 'codemodder.scripts.get_hashes:main'
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -82,6 +82,7 @@ test = [
     "flask_wtf~=1.2.0",
     "fickling~=0.1.0,>=0.1.3",
     "graphql-server~=3.0.0b7",
+    "unidiff>=0.75",
 ]
 complexity = [
     "radon==6.0.*",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,7 @@ dependencies = [
     "isort>=5.12,<6.1",
     "libcst>=1.7,<1.8",
     "packaging>=23.2,<25.0",
-    "pydantic~=2.11.1",
+    "pydantic~=2.10.6",
     "pylint>=3.3,<3.4",
     "python-json-logger~=3.3.0",
     "PyYAML~=6.0.0",
@@ -25,7 +25,7 @@ dependencies = [
     "tomlkit~=0.13.0",
     "wrapt~=1.17.0",
     "chardet~=5.2.0",
-    "sarif-pydantic~=0.5.0",
+    "sarif-pydantic~=0.5.1",
     "setuptools~=78.1",
 ]
 keywords = ["codemod", "codemods", "security", "fix", "fixes"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,6 +46,7 @@ Repository = "https://github.com/pixee/codemodder-python"
 
 [project.scripts]
 codemodder = "codemodder.codemodder:main"
+codemodder_hardening = "codemodder.codemodder:harden"
 generate-docs = 'codemodder.scripts.generate_docs:main'
 get-hashes = 'codemodder.scripts.get_hashes:main'
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -133,7 +133,7 @@ extend-exclude = '''
 '''
 
 [coverage-threshold]
-line_coverage_min = 93
+line_coverage_min = 92
 [coverage-threshold.modules."src/core_codemods/"]
 # Detect if a codemod is missing unit or integration tests
 file_line_coverage_min = 50

--- a/src/codemodder/codemodder.py
+++ b/src/codemodder/codemodder.py
@@ -73,6 +73,7 @@ def log_report(context, output, elapsed_ms, files_to_analyze, token_usage):
 def apply_codemods(
     context: CodemodExecutionContext,
     codemods_to_run: Sequence[BaseCodemod],
+    hardening: bool,
 ) -> TokenUsage:
     log_section("scanning")
     token_usage = TokenUsage()
@@ -89,7 +90,7 @@ def apply_codemods(
     for codemod in codemods_to_run:
         # NOTE: this may be used as a progress indicator by upstream tools
         logger.info("running codemod %s", codemod.id)
-        if codemod_token_usage := codemod.apply(context):
+        if codemod_token_usage := codemod.apply(context, hardening):
             log_token_usage(f"Codemod {codemod.id}", codemod_token_usage)
             token_usage += codemod_token_usage
 
@@ -135,6 +136,7 @@ def run(
     sast_only: bool = False,
     ai_client: bool = True,
     log_matched_files: bool = False,
+    hardening: bool = False,
 ) -> tuple[CodeTF | None, int, TokenUsage]:
     start = datetime.datetime.now()
 
@@ -206,7 +208,7 @@ def run(
         context.find_and_fix_paths,
     )
 
-    token_usage = apply_codemods(context, codemods_to_run)
+    token_usage = apply_codemods(context, codemods_to_run, hardening)
 
     elapsed = datetime.datetime.now() - start
     elapsed_ms = int(elapsed.total_seconds() * 1000)
@@ -231,7 +233,7 @@ def run(
     return codetf, 0, token_usage
 
 
-def _run_cli(original_args) -> int:
+def _run_cli(original_args, hardening=False) -> int:
     codemod_registry = registry.load_registered_codemods()
     argv = parse_args(original_args, codemod_registry)
     if not os.path.exists(argv.directory):
@@ -270,7 +272,8 @@ def _run_cli(original_args) -> int:
 
     _, status, _ = run(
         argv.directory,
-        argv.dry_run,
+        # Force dry-run if not hardening
+        argv.dry_run if hardening else True,
         argv.output,
         argv.output_format,
         argv.verbose,
@@ -284,8 +287,24 @@ def _run_cli(original_args) -> int:
         codemod_registry=codemod_registry,
         sast_only=argv.sonar_issues_json or argv.sarif,
         log_matched_files=True,
+        hardening=hardening,
     )
     return status
+
+
+"""
+Hardens a project. The application will write all the fixes into the files.
+"""
+
+
+def harden():
+    sys_argv = sys.argv[1:]
+    sys.exit(_run_cli(sys_argv, True))
+
+
+"""
+Remediates a project. The application will suggest fix for each separate issue found. No files will be written.
+"""
 
 
 def main():

--- a/src/codemodder/codemodder.py
+++ b/src/codemodder/codemodder.py
@@ -292,21 +292,17 @@ def _run_cli(original_args, hardening=False) -> int:
     return status
 
 
-"""
-Hardens a project. The application will write all the fixes into the files.
-"""
-
-
 def harden():
+    """
+    Hardens a project. The application will write all the fixes into the files.
+    """
     sys_argv = sys.argv[1:]
     sys.exit(_run_cli(sys_argv, True))
 
 
-"""
-Remediates a project. The application will suggest fix for each separate issue found. No files will be written.
-"""
-
-
 def main():
+    """
+    Remediates a project. The application will suggest fix for each separate issue found. No files will be written.
+    """
     sys_argv = sys.argv[1:]
     sys.exit(_run_cli(sys_argv))

--- a/src/codemodder/codemods/base_codemod.py
+++ b/src/codemodder/codemods/base_codemod.py
@@ -212,8 +212,7 @@ class BaseCodemod(metaclass=ABCMeta):
         if results:
             for result in results.results_for_rules(rules):
                 # this need to be the same type of ResultSet as results
-                singleton = results.__class__()
-                singleton.add_result(result)
+                singleton = results.from_single_result(result)
                 result_locations = self.get_files_to_analyze(context, singleton)
                 # We do an execution for each location in the result
                 # So we duplicate the resultset argument for each location

--- a/src/codemodder/codemods/base_codemod.py
+++ b/src/codemodder/codemods/base_codemod.py
@@ -189,7 +189,7 @@ class BaseCodemod(metaclass=ABCMeta):
         self,
         context: CodemodExecutionContext,
         rules: list[str],
-        hardening: bool,
+        remediation: bool,
     ) -> None | TokenUsage:
         if self.provider and (
             not (provider := context.providers.get_provider(self.provider))
@@ -228,7 +228,7 @@ class BaseCodemod(metaclass=ABCMeta):
             return None
 
         # Do each result independently and outputs the diffs
-        if not hardening:
+        if remediation:
             # gather positional arguments for the map
             resultset_arguments: list[ResultSet | None] = []
             path_arguments = []
@@ -283,7 +283,7 @@ class BaseCodemod(metaclass=ABCMeta):
         return None
 
     def apply(
-        self, context: CodemodExecutionContext, hardening: bool = False
+        self, context: CodemodExecutionContext, remediation: bool = False
     ) -> None | TokenUsage:
         """
         Apply the codemod with the given codemod execution context
@@ -300,7 +300,7 @@ class BaseCodemod(metaclass=ABCMeta):
 
         :param context: The codemod execution context
         """
-        return self._apply(context, [self._internal_name], hardening)
+        return self._apply(context, [self._internal_name], remediation)
 
     def _process_file(
         self,
@@ -399,9 +399,9 @@ class RemediationCodemod(BaseCodemod, metaclass=ABCMeta):
             self.requested_rules.extend(requested_rules)
 
     def apply(
-        self, context: CodemodExecutionContext, hardening: bool = False
+        self, context: CodemodExecutionContext, remediation: bool = False
     ) -> None | TokenUsage:
-        return self._apply(context, self.requested_rules, hardening)
+        return self._apply(context, self.requested_rules, remediation)
 
     def get_files_to_analyze(
         self,

--- a/src/codemodder/codemods/base_codemod.py
+++ b/src/codemodder/codemods/base_codemod.py
@@ -436,7 +436,6 @@ class RemediationCodemod(BaseCodemod, metaclass=ABCMeta):
         self, context: CodemodExecutionContext, remediation: bool = False
     ) -> None | TokenUsage:
         if remediation:
-            print("0000000000000000000000000000000000000000000000000000000000")
             return self._apply_remediation(context, self.requested_rules)
         return self._apply_hardening(context, self.requested_rules)
 

--- a/src/codemodder/codemods/base_visitor.py
+++ b/src/codemodder/codemods/base_visitor.py
@@ -58,6 +58,21 @@ class UtilsMixin(MetadataDependent):
             pos_to_match
         )
 
+    def node_is_selected_by_line_only(self, node) -> bool:
+        pos_to_match = self.node_position(node)
+        return self.filter_by_result_line_only(
+            pos_to_match
+        ) and self.filter_by_path_includes_or_excludes(pos_to_match)
+
+    def filter_by_result_line_only(self, pos_to_match) -> bool:
+        # Codemods with detectors will only run their transformations if there are results.
+        return self.results is None or any(
+            pos_to_match.start.line >= location.start.line
+            and pos_to_match.end.line <= location.end.line
+            for r in self.results
+            for location in r.locations
+        )
+
     def node_position(self, node):
         # See https://github.com/Instagram/LibCST/blob/main/libcst/_metadata_dependent.py#L112
         match node:

--- a/src/codemodder/codemods/test/integration_utils.py
+++ b/src/codemodder/codemods/test/integration_utils.py
@@ -90,8 +90,9 @@ class BaseIntegrationTestMixin:
             for ref in self.codemod_instance.references
         ]
 
-        assert ("detectionTool" in result) == bool(self.sonar_issues_json)
-        assert ("detectionTool" in result) == bool(self.sonar_hotspots_json)
+        assert ("detectionTool" in result) == bool(self.sonar_issues_json) or (
+            "detectionTool" in result
+        ) == bool(self.sonar_hotspots_json)
 
         # TODO: if/when we add description for each url
         for reference in result["references"][

--- a/src/codemodder/codemods/test/integration_utils.py
+++ b/src/codemodder/codemods/test/integration_utils.py
@@ -139,6 +139,7 @@ class BaseRemediationIntegrationTest:
 
         assert len(changes) == self.num_changes
         lines_changed = [c["changes"][0]["lineNumber"] for c in changes]
+        print(lines_changed)
         assert lines_changed == self.expected_lines_changed
         assert {c["changes"][0]["description"] for c in changes} == {
             self.change_description

--- a/src/codemodder/codemods/test/integration_utils.py
+++ b/src/codemodder/codemods/test/integration_utils.py
@@ -134,12 +134,10 @@ class BaseRemediationIntegrationTest:
         assert {c["path"] for c in changes} == {output_path}
 
         changes_diff = [c["diff"] for c in changes]
-        print(changes_diff)
         assert changes_diff == self.expected_diff_per_change
 
         assert len(changes) == self.num_changes
         lines_changed = [c["changes"][0]["lineNumber"] for c in changes]
-        print(lines_changed)
         assert lines_changed == self.expected_lines_changed
         assert {c["changes"][0]["description"] for c in changes} == {
             self.change_description
@@ -529,7 +527,6 @@ class SonarRemediationIntegrationTest(BaseRemediationIntegrationTest):
         else:
             with open(cls.code_path, "r", encoding="utf-8") as f:  # type: ignore
                 cls.original_code = f.read()
-            print(cls.original_code)
 
         # TODO: support sonar integration tests that add a dependency to
         # `requirements_file_name`. These tests would not be able to run

--- a/src/codemodder/codemods/test/integration_utils.py
+++ b/src/codemodder/codemods/test/integration_utils.py
@@ -69,11 +69,6 @@ class BaseRemediationIntegrationTest:
             manage_py_path = parent_dir / "manage.py"
             manage_py_path.touch()
 
-    @classmethod
-    def teardown_class(cls):
-        """Ensure any re-written file is undone after integration test class"""
-        pass
-
     def _assert_run_fields(self, run, output_path):
         assert run["vendor"] == "pixee"
         assert run["tool"] == "codemodder-python"
@@ -161,6 +156,10 @@ class BaseRemediationIntegrationTest:
         """
         Tests correct codetf output.
         """
+
+        with open(self.code_path, "r", encoding="utf-8") as f:  # type: ignore
+            original_code = f.read()
+
         command = [
             "codemodder",
             self.code_dir,
@@ -186,6 +185,11 @@ class BaseRemediationIntegrationTest:
         self._assert_codetf_output(codetf_schema)
         patched_codes = self._get_patched_code_for_each_change()
         self._check_code_after(patched_codes)
+
+        # check that the original file is not rewritten
+        with open(self.code_path, "r", encoding="utf-8") as f:
+            original_file_code = f.read()
+            assert original_file_code == original_code
 
     def apply_hunk_to_lines(self, lines, hunk):
         # The hunk target line numbers are 1-indexed.

--- a/src/codemodder/codemods/test/integration_utils.py
+++ b/src/codemodder/codemods/test/integration_utils.py
@@ -37,6 +37,30 @@ class DependencyTestMixin:
 
 
 class BaseIntegrationTestMixin:
+
+    @classmethod
+    def setup_class(cls):
+        codemod_id = (
+            cls.codemod().id if isinstance(cls.codemod, type) else cls.codemod.id
+        )
+        cls.codemod_instance = validate_codemod_registration(codemod_id)
+
+        cls.output_path = tempfile.mkstemp()[1]
+        cls.code_dir = tempfile.mkdtemp()
+
+        if not hasattr(cls, "code_filename"):
+            # Only a few codemods require the analyzed file to have a specific filename
+            # All others can just be `code.py`
+            cls.code_filename = "code.py"
+
+        cls.code_path = os.path.join(cls.code_dir, cls.code_filename)
+
+        if cls.code_filename == "settings.py" and "Django" in str(cls):
+            # manage.py must be in the directory above settings.py for this codemod to run
+            parent_dir = Path(cls.code_dir).parent
+            manage_py_path = parent_dir / "manage.py"
+            manage_py_path.touch()
+
     def _assert_sonar_fields(self, result):
         del result
 
@@ -107,26 +131,7 @@ class BaseRemediationIntegrationTest(BaseIntegrationTestMixin):
 
     @classmethod
     def setup_class(cls):
-        codemod_id = (
-            cls.codemod().id if isinstance(cls.codemod, type) else cls.codemod.id
-        )
-        cls.codemod_instance = validate_codemod_registration(codemod_id)
-
-        cls.output_path = tempfile.mkstemp()[1]
-        cls.code_dir = tempfile.mkdtemp()
-
-        if not hasattr(cls, "code_filename"):
-            # Only a few codemods require the analyzed file to have a specific filename
-            # All others can just be `code.py`
-            cls.code_filename = "code.py"
-
-        cls.code_path = os.path.join(cls.code_dir, cls.code_filename)
-
-        if cls.code_filename == "settings.py" and "Django" in str(cls):
-            # manage.py must be in the directory above settings.py for this codemod to run
-            parent_dir = Path(cls.code_dir).parent
-            manage_py_path = parent_dir / "manage.py"
-            manage_py_path.touch()
+        super().setup_class()
 
         if cls.original_code is not NotImplementedError:
             # Some tests are easier to understand with the expected new code provided
@@ -319,27 +324,7 @@ class BaseIntegrationTest(BaseIntegrationTestMixin, DependencyTestMixin):
 
     @classmethod
     def setup_class(cls):
-        codemod_id = (
-            cls.codemod().id if isinstance(cls.codemod, type) else cls.codemod.id
-        )
-        cls.codemod_instance = validate_codemod_registration(codemod_id)
-
-        cls.output_path = tempfile.mkstemp()[1]
-        cls.code_dir = tempfile.mkdtemp()
-
-        if not hasattr(cls, "code_filename"):
-            # Only a few codemods require the analyzed file to have a specific filename
-            # All others can just be `code.py`
-            cls.code_filename = "code.py"
-
-        cls.code_path = os.path.join(cls.code_dir, cls.code_filename)
-
-        if cls.code_filename == "settings.py" and "Django" in str(cls):
-            # manage.py must be in the directory above settings.py for this codemod to run
-            parent_dir = Path(cls.code_dir).parent
-            manage_py_path = parent_dir / "manage.py"
-            manage_py_path.touch()
-
+        super().setup_class()
         if hasattr(cls, "expected_new_code"):
             # Some tests are easier to understand with the expected new code provided
             # instead of calculated

--- a/src/codemodder/codemods/test/integration_utils.py
+++ b/src/codemodder/codemods/test/integration_utils.py
@@ -144,7 +144,7 @@ class BaseRemediationIntegrationTest(BaseIntegrationTestMixin):
     def _assert_command_line(self, run, output_path):
         assert run[
             "commandLine"
-        ] == f'codemodder {self.code_dir} --output {output_path} --codemod-include={self.codemod_instance.id} --path-include={self.code_filename} --path-exclude=""' + (
+        ] == f'codemodder-remediation {self.code_dir} --output {output_path} --codemod-include={self.codemod_instance.id} --path-include={self.code_filename} --path-exclude=""' + (
             f" --sonar-issues-json={self.sonar_issues_json}"
             if self.sonar_issues_json
             else ""
@@ -184,7 +184,7 @@ class BaseRemediationIntegrationTest(BaseIntegrationTestMixin):
         """
 
         command = [
-            "codemodder",
+            "codemodder-remediation",
             self.code_dir,
             "--output",
             self.output_path,
@@ -350,7 +350,7 @@ class BaseIntegrationTest(BaseIntegrationTestMixin, DependencyTestMixin):
     def _assert_command_line(self, run, output_path):
         assert run[
             "commandLine"
-        ] == f'codemodder_hardening {self.code_dir} --output {output_path} --codemod-include={self.codemod_instance.id} --path-include={self.code_filename} --path-exclude=""' + (
+        ] == f'codemodder {self.code_dir} --output {output_path} --codemod-include={self.codemod_instance.id} --path-include={self.code_filename} --path-exclude=""' + (
             f" --sonar-issues-json={self.sonar_issues_json}"
             if self.sonar_issues_json
             else ""
@@ -396,7 +396,7 @@ class BaseIntegrationTest(BaseIntegrationTestMixin, DependencyTestMixin):
         output files
         """
         command = [
-            "codemodder_hardening",
+            "codemodder",
             self.code_dir,
             "--output",
             self.output_path,

--- a/src/codemodder/codemods/test/utils.py
+++ b/src/codemodder/codemods/test/utils.py
@@ -94,7 +94,9 @@ class BaseCodemodTest:
             assert not changes
             return
 
-        self.assert_num_changes(changes, num_changes, min_num_changes)
+        self.assert_num_changes(
+            changes, num_changes, expected_diff_per_change, min_num_changes
+        )
 
         self.assert_changes(
             tmpdir,
@@ -106,16 +108,25 @@ class BaseCodemodTest:
             changes,
         )
 
-    def assert_num_changes(self, changes, expected_num_changes, min_num_changes):
+    def assert_num_changes(
+        self, changes, expected_num_changes, expected_diff_per_change, min_num_changes
+    ):
         print("expected_diff_per_change = [")
         for c in changes:
             print('"""\\')
-            print(c.diff.replace("\t", "    "), end="")
+            diff_lines = c.diff.replace("\t", "    ").splitlines()
+            for line in diff_lines:
+                print(line)
             print('""",')
         print("]")
-        assert len(changes) == expected_num_changes
+        if expected_diff_per_change:
+            assert len(changes) == expected_num_changes
+            actual_num = len(changes)
+        else:
+            assert len(changes[0].changes) == expected_num_changes
+            actual_num = len(changes[0].changes)
 
-        actual_num = len(changes)
+        # actual_num = len(changes)
 
         if min_num_changes is not None:
             assert (
@@ -142,7 +153,7 @@ class BaseCodemodTest:
         assert all(c.description for change in changes for c in change.changes)
 
         # assert each change individually
-        if num_changes > 1:
+        if expected_diff_per_change and num_changes > 1:
             assert num_changes == len(expected_diff_per_change)
             for change, diff in zip(changes, expected_diff_per_change):
                 print(change.diff)
@@ -248,7 +259,9 @@ class BaseSASTCodemodTest(BaseCodemodTest):
             assert not changes
             return
 
-        self.assert_num_changes(changes, num_changes, min_num_changes)
+        self.assert_num_changes(
+            changes, num_changes, expected_diff_per_change, min_num_changes
+        )
 
         self.assert_findings(changes)
 

--- a/src/codemodder/codemods/test/utils.py
+++ b/src/codemodder/codemods/test/utils.py
@@ -118,8 +118,6 @@ class BaseCodemodTest:
             assert len(changes[0].changes) == expected_num_changes
             actual_num = len(changes[0].changes)
 
-        # actual_num = len(changes)
-
         if min_num_changes is not None:
             assert (
                 actual_num >= min_num_changes

--- a/src/codemodder/codemods/test/utils.py
+++ b/src/codemodder/codemods/test/utils.py
@@ -1,4 +1,3 @@
-import difflib
 import os
 from pathlib import Path
 from textwrap import dedent
@@ -111,14 +110,6 @@ class BaseCodemodTest:
     def assert_num_changes(
         self, changes, expected_num_changes, expected_diff_per_change, min_num_changes
     ):
-        print("expected_diff_per_change = [")
-        for c in changes:
-            print('"""\\')
-            diff_lines = c.diff.replace("\t", "    ").splitlines()
-            for line in diff_lines:
-                print(line)
-            print('""",')
-        print("]")
         if expected_diff_per_change:
             assert len(changes) == expected_num_changes
             actual_num = len(changes)
@@ -156,17 +147,6 @@ class BaseCodemodTest:
         if expected_diff_per_change and num_changes > 1:
             assert num_changes == len(expected_diff_per_change)
             for change, diff in zip(changes, expected_diff_per_change):
-                print(change.diff)
-                print("-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-")
-                print(diff)
-                print("+++++++++++++++++++++++++++++++")
-                print(
-                    "\n".join(
-                        difflib.ndiff(diff.splitlines(), change.diff.splitlines())
-                    )
-                    .replace(" ", "␣")
-                    .replace("\t", "→")
-                )
                 assert change.diff == diff
         else:
             # generate diff from expected code

--- a/src/codemodder/codemods/test/utils.py
+++ b/src/codemodder/codemods/test/utils.py
@@ -73,9 +73,10 @@ class BaseCodemodTest:
 
         path_exclude = [f"{tmp_file_path}:{line}" for line in lines_to_exclude or []]
 
+        print(expected_diff_per_change)
         self.execution_context = CodemodExecutionContext(
             directory=root,
-            dry_run=False,
+            dry_run=True if expected_diff_per_change else False,
             verbose=False,
             registry=mock.MagicMock(),
             providers=load_providers(),
@@ -220,9 +221,10 @@ class BaseSASTCodemodTest(BaseCodemodTest):
 
         path_exclude = [f"{tmp_file_path}:{line}" for line in lines_to_exclude or []]
 
+        print(expected_diff_per_change)
         self.execution_context = CodemodExecutionContext(
             directory=root,
-            dry_run=False,
+            dry_run=True if expected_diff_per_change else False,
             verbose=False,
             tool_result_files_map={self.tool: [tmp_results_file_path]},
             registry=mock.MagicMock(),

--- a/src/codemodder/codemods/test/utils.py
+++ b/src/codemodder/codemods/test/utils.py
@@ -164,9 +164,9 @@ class BaseCodemodTest:
                 dedent(expected).splitlines(keepends=True),
             )
             try:
-                assert expected_diff == changes.diff
+                assert expected_diff == changes[0].diff
             except AssertionError:
-                raise DiffError(expected_diff, changes.diff)
+                raise DiffError(expected_diff, changes[0].diff)
 
             output_code = file_path.read_bytes().decode("utf-8")
 

--- a/src/codemodder/codemods/test/utils.py
+++ b/src/codemodder/codemods/test/utils.py
@@ -73,7 +73,6 @@ class BaseCodemodTest:
 
         path_exclude = [f"{tmp_file_path}:{line}" for line in lines_to_exclude or []]
 
-        print(expected_diff_per_change)
         self.execution_context = CodemodExecutionContext(
             directory=root,
             dry_run=True if expected_diff_per_change else False,
@@ -85,7 +84,10 @@ class BaseCodemodTest:
             path_exclude=path_exclude,
         )
 
-        self.codemod.apply(self.execution_context)
+        self.codemod.apply(
+            self.execution_context,
+            remediation=True if expected_diff_per_change else False,
+        )
         changes = self.execution_context.get_changesets(self.codemod.id)
 
         self.changeset = changes
@@ -219,7 +221,6 @@ class BaseSASTCodemodTest(BaseCodemodTest):
 
         path_exclude = [f"{tmp_file_path}:{line}" for line in lines_to_exclude or []]
 
-        print(expected_diff_per_change)
         self.execution_context = CodemodExecutionContext(
             directory=root,
             dry_run=True if expected_diff_per_change else False,
@@ -232,7 +233,10 @@ class BaseSASTCodemodTest(BaseCodemodTest):
             path_exclude=path_exclude,
         )
 
-        self.codemod.apply(self.execution_context)
+        self.codemod.apply(
+            self.execution_context,
+            remediation=True if expected_diff_per_change else False,
+        )
         changes = self.execution_context.get_changesets(self.codemod.id)
 
         if input_code == expected:

--- a/src/codemodder/codemods/test/utils.py
+++ b/src/codemodder/codemods/test/utils.py
@@ -8,7 +8,7 @@ import mock
 
 from codemodder import registry
 from codemodder.codemods.api import BaseCodemod
-from codemodder.codetf import Change
+from codemodder.codetf.v2.codetf import ChangeSet
 from codemodder.context import CodemodExecutionContext
 from codemodder.diff import create_diff
 from codemodder.providers import load_providers
@@ -107,10 +107,12 @@ class BaseCodemodTest:
         )
 
     def assert_num_changes(self, changes, expected_num_changes, min_num_changes):
-        print(len(changes))
-        print(changes)
+        print("expected_diff_per_change = [")
         for c in changes:
-            print(c.diff)
+            print('"""\\')
+            print(c.diff.replace("\t", "    "), end="")
+            print('""",')
+        print("]")
         assert len(changes) == expected_num_changes
 
         actual_num = len(changes)
@@ -248,7 +250,7 @@ class BaseSASTCodemodTest(BaseCodemodTest):
 
         self.assert_num_changes(changes, num_changes, min_num_changes)
 
-        self.assert_findings(changes[0].changes)
+        self.assert_findings(changes)
 
         self.assert_changes(
             tmpdir,
@@ -262,7 +264,7 @@ class BaseSASTCodemodTest(BaseCodemodTest):
 
         return changes
 
-    def assert_findings(self, changes: list[Change]):
+    def assert_findings(self, changes: list[ChangeSet]):
         assert all(
-            x.fixedFindings for x in changes
+            c.fixedFindings for a in changes for c in a.changes
         ), f"Expected all changes to have findings: {changes}"

--- a/src/codemodder/result.py
+++ b/src/codemodder/result.py
@@ -284,6 +284,15 @@ class ResultSet(dict[str, dict[Path, list[ResultType]]]):
     def all_rule_ids(self) -> list[str]:
         return list(self.keys())
 
+    @classmethod
+    def from_single_result(cls, result: ResultType) -> Self:
+        """
+        Creates a new ResultSet of the same type with a give result.
+        """
+        new = cls()
+        new.add_result(result)
+        return new
+
     def __or__(self, other):
         result = self.__class__()
         for k in self.keys() | other.keys():

--- a/src/core_codemods/defectdojo/api.py
+++ b/src/core_codemods/defectdojo/api.py
@@ -76,9 +76,11 @@ class DefectDojoCodemod(SASTCodemod):
     def apply(
         self,
         context: CodemodExecutionContext,
+        hardening: bool = False,
     ) -> None:
         self._apply(
             context,
             # We know this has a tool because we created it with `from_core_codemod`
             cast(ToolMetadata, self._metadata.tool).rule_ids,
+            hardening,
         )

--- a/src/core_codemods/defectdojo/api.py
+++ b/src/core_codemods/defectdojo/api.py
@@ -76,11 +76,11 @@ class DefectDojoCodemod(SASTCodemod):
     def apply(
         self,
         context: CodemodExecutionContext,
-        hardening: bool = False,
+        remediation: bool = False,
     ) -> None:
         self._apply(
             context,
             # We know this has a tool because we created it with `from_core_codemod`
             cast(ToolMetadata, self._metadata.tool).rule_ids,
-            hardening,
+            remediation,
         )

--- a/src/core_codemods/defectdojo/api.py
+++ b/src/core_codemods/defectdojo/api.py
@@ -8,6 +8,7 @@ from typing_extensions import override
 from codemodder.codemods.api import Metadata, Reference, ToolMetadata, ToolRule
 from codemodder.codemods.base_detector import BaseDetector
 from codemodder.context import CodemodExecutionContext
+from codemodder.llm import TokenUsage
 from codemodder.result import ResultSet
 from core_codemods.api import CoreCodemod, SASTCodemod
 
@@ -77,10 +78,15 @@ class DefectDojoCodemod(SASTCodemod):
         self,
         context: CodemodExecutionContext,
         remediation: bool = False,
-    ) -> None:
-        self._apply(
+    ) -> None | TokenUsage:
+        if remediation:
+            return self._apply_remediation(
+                context,
+                # We know this has a tool because we created it with `from_core_codemod`
+                cast(ToolMetadata, self._metadata.tool).rule_ids,
+            )
+        return self._apply_hardening(
             context,
             # We know this has a tool because we created it with `from_core_codemod`
             cast(ToolMetadata, self._metadata.tool).rule_ids,
-            remediation,
         )

--- a/src/core_codemods/semgrep/semgrep_no_csrf_exempt.py
+++ b/src/core_codemods/semgrep/semgrep_no_csrf_exempt.py
@@ -26,14 +26,15 @@ class RemoveCsrfExemptTransformer(LibcstResultTransformer, NameResolutionMixin):
             self.node_position(original_node)
         ):
             return updated_node
-
-        if (
-            self.find_base_name(original_node.decorator)
-            == "django.views.decorators.csrf.csrf_exempt"
-        ):
-            self.report_change(original_node)
-            return cst.RemovalSentinel.REMOVE
-        return original_node
+        # Due to semgrep's odd way of reporting the position for this (decorators + functiondef), we match by line only
+        if self.node_is_selected_by_line_only(original_node):
+            if (
+                self.find_base_name(original_node.decorator)
+                == "django.views.decorators.csrf.csrf_exempt"
+            ):
+                self.report_change(original_node)
+                return cst.RemovalSentinel.REMOVE
+        return updated_node
 
 
 SemgrepNoCsrfExempt = SemgrepCodemod(

--- a/src/core_codemods/semgrep/semgrep_no_csrf_exempt.py
+++ b/src/core_codemods/semgrep/semgrep_no_csrf_exempt.py
@@ -27,13 +27,12 @@ class RemoveCsrfExemptTransformer(LibcstResultTransformer, NameResolutionMixin):
         ):
             return updated_node
         # Due to semgrep's odd way of reporting the position for this (decorators + functiondef), we match by line only
-        if self.node_is_selected_by_line_only(original_node):
-            if (
-                self.find_base_name(original_node.decorator)
-                == "django.views.decorators.csrf.csrf_exempt"
-            ):
-                self.report_change(original_node)
-                return cst.RemovalSentinel.REMOVE
+        if self.node_is_selected_by_line_only(original_node) and (
+            self.find_base_name(original_node.decorator)
+            == "django.views.decorators.csrf.csrf_exempt"
+        ):
+            self.report_change(original_node)
+            return cst.RemovalSentinel.REMOVE
         return updated_node
 
 

--- a/tests/codemods/defectdojo/semgrep/test_avoid_insecure_deserialization.py
+++ b/tests/codemods/defectdojo/semgrep/test_avoid_insecure_deserialization.py
@@ -62,7 +62,6 @@ class TestDjangoAvoidInsecureDeserialization(BaseSASTCodemodTest):
 
         result = fickling.load("data")
         """
-
         findings = {
             "results": [
                 {
@@ -100,6 +99,31 @@ class TestDjangoAvoidInsecureDeserialization(BaseSASTCodemodTest):
         result = fickling.load("data")
         result = yaml.load("data", Loader=yaml.SafeLoader)
         """
+        expected_diff_per_change = [
+            """\
+--- 
++++ 
+@@ -1,6 +1,6 @@
+ 
+-import pickle
+ import yaml
++import fickling
+ 
+-result = pickle.load("data")
++result = fickling.load("data")
+ result = yaml.load("data")
+""",
+            """\
+--- 
++++ 
+@@ -3,4 +3,4 @@
+ import yaml
+ 
+ result = pickle.load("data")
+-result = yaml.load("data")
++result = yaml.load("data", Loader=yaml.SafeLoader)
+""",
+        ]
 
         findings = {
             "results": [
@@ -122,6 +146,7 @@ class TestDjangoAvoidInsecureDeserialization(BaseSASTCodemodTest):
             tmpdir,
             input_code,
             expected,
+            expected_diff_per_change,
             results=json.dumps(findings),
             num_changes=2,
         )
@@ -129,11 +154,11 @@ class TestDjangoAvoidInsecureDeserialization(BaseSASTCodemodTest):
 
         assert changes is not None
         assert changes[0].changes[0].fixedFindings is not None
-        assert changes[0].changes[0].fixedFindings[0].id == "4"
+        assert changes[0].changes[0].fixedFindings[0].id == "3"
         assert changes[0].changes[0].fixedFindings[0].rule.id == RULE_ID
-        assert changes[0].changes[1].fixedFindings is not None
-        assert changes[0].changes[1].fixedFindings[0].id == "3"
-        assert changes[0].changes[1].fixedFindings[0].rule.id == RULE_ID
+        assert changes[1].changes[0].fixedFindings is not None
+        assert changes[1].changes[0].fixedFindings[0].id == "4"
+        assert changes[1].changes[0].fixedFindings[0].rule.id == RULE_ID
 
     @mock.patch("codemodder.codemods.api.FileContext.add_dependency")
     def test_pickle_loads(self, adds_dependency, tmpdir):

--- a/tests/codemods/semgrep/test_semgrep_nan_injection.py
+++ b/tests/codemods/semgrep/test_semgrep_nan_injection.py
@@ -67,7 +67,6 @@ class TestSemgrepNanInjection(BaseSASTCodemodTest):
             input_code,
             expected_output,
             results=json.dumps(results),
-            num_changes=4,
         )
 
     def test_multiple(self, tmpdir):
@@ -228,7 +227,6 @@ class TestSemgrepNanInjection(BaseSASTCodemodTest):
             input_code,
             expected_output,
             results=json.dumps(results),
-            num_changes=16,
         )
 
     def test_once_nested(self, tmpdir):
@@ -287,7 +285,6 @@ class TestSemgrepNanInjection(BaseSASTCodemodTest):
             input_code,
             expected_output,
             results=json.dumps(results),
-            num_changes=4,
         )
 
     def test_twice_nested(self, tmpdir):
@@ -345,7 +342,6 @@ class TestSemgrepNanInjection(BaseSASTCodemodTest):
             input_code,
             expected_output,
             results=json.dumps(results),
-            num_changes=4,
         )
 
     def test_direct_source(self, tmpdir):
@@ -401,7 +397,6 @@ class TestSemgrepNanInjection(BaseSASTCodemodTest):
             input_code,
             expected_output,
             results=json.dumps(results),
-            num_changes=4,
         )
 
     def test_binop(self, tmpdir):
@@ -459,7 +454,6 @@ class TestSemgrepNanInjection(BaseSASTCodemodTest):
             input_code,
             expected_output,
             results=json.dumps(results),
-            num_changes=4,
         )
 
 

--- a/tests/codemods/semgrep/test_semgrep_nan_injection.py
+++ b/tests/codemods/semgrep/test_semgrep_nan_injection.py
@@ -66,6 +66,7 @@ class TestSemgrepNanInjection(BaseSASTCodemodTest):
             tmpdir,
             input_code,
             expected_output,
+            num_changes=4,
             results=json.dumps(results),
         )
 
@@ -108,6 +109,68 @@ class TestSemgrepNanInjection(BaseSASTCodemodTest):
             else:
                 return [1, 2, float(tid), 3]
         """
+        expected_diff_per_change = [
+            """\
+--- 
++++ 
+@@ -2,7 +2,10 @@
+     tid = request.POST.get("tid")
+     some_list = [1, 2, 3, float('nan')]
+ 
+-    float(tid) in some_list
++    if tid.lower() == "nan":
++        raise ValueError
++    else:
++        float(tid) in some_list
+ 
+     z = [1, 2, complex(tid), 3]
+ 
+""",
+            """\
+--- 
++++ 
+@@ -4,7 +4,10 @@
+ 
+     float(tid) in some_list
+ 
+-    z = [1, 2, complex(tid), 3]
++    if tid.lower() == "nan":
++        raise ValueError
++    else:
++        z = [1, 2, complex(tid), 3]
+ 
+     x = [float(tid), 1.0, 2.0]
+ 
+""",
+            """\
+--- 
++++ 
+@@ -6,6 +6,9 @@
+ 
+     z = [1, 2, complex(tid), 3]
+ 
+-    x = [float(tid), 1.0, 2.0]
++    if tid.lower() == "nan":
++        raise ValueError
++    else:
++        x = [float(tid), 1.0, 2.0]
+ 
+     return [1, 2, float(tid), 3]
+""",
+            """\
+--- 
++++ 
+@@ -8,4 +8,7 @@
+ 
+     x = [float(tid), 1.0, 2.0]
+ 
+-    return [1, 2, float(tid), 3]
++    if tid.lower() == "nan":
++        raise ValueError
++    else:
++        return [1, 2, float(tid), 3]
+""",
+        ]
 
         results = {
             "runs": [
@@ -226,6 +289,8 @@ class TestSemgrepNanInjection(BaseSASTCodemodTest):
             tmpdir,
             input_code,
             expected_output,
+            expected_diff_per_change,
+            num_changes=4,
             results=json.dumps(results),
         )
 
@@ -284,6 +349,7 @@ class TestSemgrepNanInjection(BaseSASTCodemodTest):
             tmpdir,
             input_code,
             expected_output,
+            num_changes=4,
             results=json.dumps(results),
         )
 
@@ -341,6 +407,7 @@ class TestSemgrepNanInjection(BaseSASTCodemodTest):
             tmpdir,
             input_code,
             expected_output,
+            num_changes=4,
             results=json.dumps(results),
         )
 
@@ -396,6 +463,7 @@ class TestSemgrepNanInjection(BaseSASTCodemodTest):
             tmpdir,
             input_code,
             expected_output,
+            num_changes=4,
             results=json.dumps(results),
         )
 
@@ -453,6 +521,7 @@ class TestSemgrepNanInjection(BaseSASTCodemodTest):
             tmpdir,
             input_code,
             expected_output,
+            num_changes=4,
             results=json.dumps(results),
         )
 

--- a/tests/codemods/semgrep/test_semgrep_no_csrf_exempt.py
+++ b/tests/codemods/semgrep/test_semgrep_no_csrf_exempt.py
@@ -48,7 +48,31 @@ class TestSemgrepNoCsrfExempt(BaseSASTCodemodTest):
         def foo():
             pass
         """
-
+        expected_diff_per_change = [
+            """\
+--- 
++++ 
+@@ -3,7 +3,6 @@
+ from django.dispatch import receiver
+ from django.core.signals import request_finished
+ 
+-@csrf_exempt
+ def ssrf_code_checker(request):
+     if request.user.is_authenticated:
+         if request.method == 'POST':
+""",
+            """\
+--- 
++++ 
+@@ -12,6 +12,5 @@
+ 
+ 
+ @receiver(request_finished)
+-@csrf_exempt
+ def foo():
+     pass
+""",
+        ]
         results = {
             "runs": [
                 {
@@ -114,6 +138,7 @@ class TestSemgrepNoCsrfExempt(BaseSASTCodemodTest):
             tmpdir,
             input_code,
             expected_output,
+            expected_diff_per_change,
             results=json.dumps(results),
             num_changes=2,
         )

--- a/tests/codemods/semgrep/test_semgrep_sql_parametrization.py
+++ b/tests/codemods/semgrep/test_semgrep_sql_parametrization.py
@@ -46,6 +46,37 @@ class TestSemgrepSQLParameterization(BaseSASTCodemodTest):
             conn = sqlite3.connect("example")
             conn.cursor().execute(sql, ((user), ))
         '''
+        expected_diff_per_change = [
+            '''\
+--- 
++++ 
+@@ -8,7 +8,7 @@
+ @app.route("/example")
+ def f():
+     user = request.args["user"]
+-    sql = """SELECT user FROM users WHERE user = '%s'"""
++    sql = """SELECT user FROM users WHERE user = ?"""
+ 
+     conn = sqlite3.connect("example")
+-    conn.cursor().execute(sql % (user))
++    conn.cursor().execute(sql, ((user), ))
+''',
+            '''\
+--- 
++++ 
+@@ -8,7 +8,7 @@
+ @app.route("/example")
+ def f():
+     user = request.args["user"]
+-    sql = """SELECT user FROM users WHERE user = '%s'"""
++    sql = """SELECT user FROM users WHERE user = ?"""
+ 
+     conn = sqlite3.connect("example")
+-    conn.cursor().execute(sql % (user))
++    conn.cursor().execute(sql, ((user), ))
+''',
+        ]
+
         results = {
             "runs": [
                 {
@@ -190,12 +221,11 @@ class TestSemgrepSQLParameterization(BaseSASTCodemodTest):
                 }
             ]
         }
-        changes = self.run_and_assert(
+        self.run_and_assert(
             tmpdir,
             input_code,
             expexted_output,
+            expected_diff_per_change,
             results=json.dumps(results),
-        )
-        assert len(changes[0].changes[0].fixedFindings) == len(
-            results["runs"][0]["results"]
+            num_changes=2,
         )

--- a/tests/codemods/sonar/test_sonar_django_receiver_on_top.py
+++ b/tests/codemods/sonar/test_sonar_django_receiver_on_top.py
@@ -13,8 +13,8 @@ class TestSonarDjangoReceiverOnTop(BaseSASTCodemodTest):
 
     def assert_findings(self, changes):
         # For now we can only link the finding to the line with the receiver decorator
-        assert changes[0].fixedFindings
-        assert not changes[1].fixedFindings
+        assert changes[0].changes[0].fixedFindings
+        assert not changes[0].changes[1].fixedFindings
 
     def test_simple(self, tmpdir):
         input_code = """

--- a/tests/codemods/sonar/test_sonar_enable_jinja2_autoescape.py
+++ b/tests/codemods/sonar/test_sonar_enable_jinja2_autoescape.py
@@ -24,6 +24,29 @@ class TestEnableJinja2Autoescape(BaseSASTCodemodTest):
         env = Environment(autoescape=True)
         env = Environment(autoescape=True)
         """
+        expected_diff_per_change = [
+            """\
+--- 
++++ 
+@@ -1,4 +1,4 @@
+ 
+ from jinja2 import Environment
+-env = Environment()
++env = Environment(autoescape=True)
+ env = Environment(autoescape=False)
+""",
+            """\
+--- 
++++ 
+@@ -1,4 +1,4 @@
+ 
+ from jinja2 import Environment
+ env = Environment()
+-env = Environment(autoescape=False)
++env = Environment(autoescape=True)
+""",
+        ]
+
         hotspots = {
             "hotspots": [
                 {
@@ -54,6 +77,7 @@ class TestEnableJinja2Autoescape(BaseSASTCodemodTest):
             tmpdir,
             input_code,
             expected_output,
+            expected_diff_per_change,
             results=json.dumps(hotspots),
             num_changes=2,
         )

--- a/tests/codemods/sonar/test_sonar_fix_assert_tuple.py
+++ b/tests/codemods/sonar/test_sonar_fix_assert_tuple.py
@@ -13,9 +13,9 @@ class TestSonarFixAssertTuple(BaseSASTCodemodTest):
 
     def assert_findings(self, changes):
         # For now we can only link the finding to the first line changed
-        assert changes[0].fixedFindings
-        assert not changes[1].fixedFindings
-        assert not changes[2].fixedFindings
+        assert changes[0].changes[0].fixedFindings
+        assert not changes[0].changes[1].fixedFindings
+        assert not changes[0].changes[2].fixedFindings
 
     def test_simple(self, tmpdir):
         input_code = """

--- a/tests/codemods/sonar/test_sonar_fix_missing_self_or_cls.py
+++ b/tests/codemods/sonar/test_sonar_fix_missing_self_or_cls.py
@@ -30,6 +30,32 @@ class TestSonarFixMissingSelfOrCls(BaseSASTCodemodTest):
             def class_method(cls):
                 pass
         """
+        expected_diff_per_change = [
+            """\
+--- 
++++ 
+@@ -1,6 +1,6 @@
+ 
+ class A:
+-    def instance_method():
++    def instance_method(self):
+         pass
+ 
+     @classmethod
+""",
+            """\
+--- 
++++ 
+@@ -4,5 +4,5 @@
+         pass
+ 
+     @classmethod
+-    def class_method():
++    def class_method(cls):
+         pass
+""",
+        ]
+
         issues = {
             "issues": [
                 {
@@ -60,6 +86,7 @@ class TestSonarFixMissingSelfOrCls(BaseSASTCodemodTest):
             tmpdir,
             input_code,
             expected_output,
+            expected_diff_per_change,
             results=json.dumps(issues),
             num_changes=2,
         )

--- a/tests/codemods/sonar/test_sonar_invert_boolean_check.py
+++ b/tests/codemods/sonar/test_sonar_invert_boolean_check.py
@@ -20,6 +20,27 @@ class TestSonarInvertedBooleanCheck(BaseSASTCodemodTest):
         if a != 2:
             b = i >= 10
         """
+        expected_diff_per_change = [
+            """\
+--- 
++++ 
+@@ -1,3 +1,3 @@
+ 
+-if not a == 2:
++if a != 2:
+     b = not i < 10
+""",
+            """\
+--- 
++++ 
+@@ -1,3 +1,3 @@
+ 
+ if not a == 2:
+-    b = not i < 10
++    b = i >= 10
+""",
+        ]
+
         issues = {
             "issues": [
                 {
@@ -50,6 +71,7 @@ class TestSonarInvertedBooleanCheck(BaseSASTCodemodTest):
             tmpdir,
             input_code,
             expected_output,
+            expected_diff_per_change,
             results=json.dumps(issues),
             num_changes=2,
         )

--- a/tests/codemods/sonar/test_sonar_jwt_decode_verify.py
+++ b/tests/codemods/sonar/test_sonar_jwt_decode_verify.py
@@ -38,6 +38,31 @@ class TestSonarJwtDecodeVerify(BaseSASTCodemodTest):
         decoded_payload = jwt.decode(encoded_jwt, SECRET_KEY, algorithms=["HS256"], verify=True)
         decoded_payload = jwt.decode(encoded_jwt, SECRET_KEY, algorithms=["HS256"], options={"verify_signature": True})
         """
+
+        expected_diff_per_change = [
+            """\
+--- 
++++ 
+@@ -8,5 +8,5 @@
+ }
+ 
+ encoded_jwt = jwt.encode(payload, SECRET_KEY, algorithm="HS256")
+-decoded_payload = jwt.decode(encoded_jwt, SECRET_KEY, algorithms=["HS256"], verify=False)
++decoded_payload = jwt.decode(encoded_jwt, SECRET_KEY, algorithms=["HS256"], verify=True)
+ decoded_payload = jwt.decode(encoded_jwt, SECRET_KEY, algorithms=["HS256"], options={"verify_signature": False})
+""",
+            """\
+--- 
++++ 
+@@ -9,4 +9,4 @@
+ 
+ encoded_jwt = jwt.encode(payload, SECRET_KEY, algorithm="HS256")
+ decoded_payload = jwt.decode(encoded_jwt, SECRET_KEY, algorithms=["HS256"], verify=False)
+-decoded_payload = jwt.decode(encoded_jwt, SECRET_KEY, algorithms=["HS256"], options={"verify_signature": False})
++decoded_payload = jwt.decode(encoded_jwt, SECRET_KEY, algorithms=["HS256"], options={"verify_signature": True})
+""",
+        ]
+
         issues = {
             "issues": [
                 {
@@ -65,5 +90,10 @@ class TestSonarJwtDecodeVerify(BaseSASTCodemodTest):
             ]
         }
         self.run_and_assert(
-            tmpdir, input_code, expected, results=json.dumps(issues), num_changes=2
+            tmpdir,
+            input_code,
+            expected,
+            expected_diff_per_change,
+            results=json.dumps(issues),
+            num_changes=2,
         )

--- a/tests/codemods/sonar/test_sonar_secure_cookie.py
+++ b/tests/codemods/sonar/test_sonar_secure_cookie.py
@@ -34,6 +34,55 @@ class TestSonarSecureCookie(BaseSASTCodemodTest):
         var = "hello"
         response2.set_cookie("name", "value", secure=True, httponly=True, samesite='Lax')
         """
+        expected_diff_per_change = [
+            """\
+--- 
++++ 
+@@ -3,7 +3,7 @@
+ 
+ response = flask.make_response()
+ var = "hello"
+-response.set_cookie("name", "value")
++response.set_cookie("name", "value", secure=True, httponly=True, samesite='Lax')
+ 
+ response2 = flask.Response()
+ var = "hello"
+""",
+            """\
+--- 
++++ 
+@@ -7,4 +7,4 @@
+ 
+ response2 = flask.Response()
+ var = "hello"
+-response2.set_cookie("name", "value")
++response2.set_cookie("name", "value", secure=True, httponly=True, samesite='Lax')
+""",
+            """\
+--- 
++++ 
+@@ -3,7 +3,7 @@
+ 
+ response = flask.make_response()
+ var = "hello"
+-response.set_cookie("name", "value")
++response.set_cookie("name", "value", secure=True, httponly=True, samesite='Lax')
+ 
+ response2 = flask.Response()
+ var = "hello"
+""",
+            """\
+--- 
++++ 
+@@ -7,4 +7,4 @@
+ 
+ response2 = flask.Response()
+ var = "hello"
+-response2.set_cookie("name", "value")
++response2.set_cookie("name", "value", secure=True, httponly=True, samesite='Lax')
+""",
+        ]
+
         issues = {
             "hotspots": [
                 {
@@ -83,5 +132,10 @@ class TestSonarSecureCookie(BaseSASTCodemodTest):
             ],
         }
         self.run_and_assert(
-            tmpdir, input_code, expected, results=json.dumps(issues), num_changes=2
+            tmpdir,
+            input_code,
+            expected,
+            expected_diff_per_change,
+            results=json.dumps(issues),
+            num_changes=4,
         )

--- a/tests/codemods/sonar/test_sonar_secure_random.py
+++ b/tests/codemods/sonar/test_sonar_secure_random.py
@@ -26,6 +26,48 @@ class TestSonarSecureRandom(BaseSASTCodemodTest):
         secrets.SystemRandom().randint(0, 9)
         secrets.SystemRandom().random()
         """
+        expected_diff_per_change = [
+            """\
+--- 
++++ 
+@@ -1,6 +1,7 @@
+ 
+ import random
++import secrets
+ 
+-random.getrandbits(1)
++secrets.SystemRandom().getrandbits(1)
+ random.randint(0, 9)
+ random.random()
+""",
+            """\
+--- 
++++ 
+@@ -1,6 +1,7 @@
+ 
+ import random
++import secrets
+ 
+ random.getrandbits(1)
+-random.randint(0, 9)
++secrets.SystemRandom().randint(0, 9)
+ random.random()
+""",
+            """\
+--- 
++++ 
+@@ -1,6 +1,7 @@
+ 
+ import random
++import secrets
+ 
+ random.getrandbits(1)
+ random.randint(0, 9)
+-random.random()
++secrets.SystemRandom().random()
+""",
+        ]
+
         hotspots = {
             "hotspots": [
                 {
@@ -67,6 +109,7 @@ class TestSonarSecureRandom(BaseSASTCodemodTest):
             tmpdir,
             input_code,
             expected_output,
+            expected_diff_per_change,
             results=json.dumps(hotspots),
             num_changes=3,
         )

--- a/tests/codemods/sonar/test_sonar_timezone_aware_datetime.py
+++ b/tests/codemods/sonar/test_sonar_timezone_aware_datetime.py
@@ -4,7 +4,7 @@ from codemodder.codemods.test import BaseSASTCodemodTest
 from core_codemods.sonar.sonar_timezone_aware_datetime import SonarTimezoneAwareDatetime
 
 
-class TestSonarSQLParameterization(BaseSASTCodemodTest):
+class TestSonarTimezoneAwareDatetime(BaseSASTCodemodTest):
     codemod = SonarTimezoneAwareDatetime
     tool = "sonar"
 
@@ -26,6 +26,30 @@ class TestSonarSQLParameterization(BaseSASTCodemodTest):
         timestamp = 1571595618.0
         datetime.datetime.fromtimestamp(timestamp, tz=datetime.timezone.utc)
         """
+        expected_diff_per_change = [
+            """\
+--- 
++++ 
+@@ -1,5 +1,5 @@
+ import datetime
+ 
+-datetime.datetime.utcnow()
++datetime.datetime.now(tz=datetime.timezone.utc)
+ timestamp = 1571595618.0
+ datetime.datetime.utcfromtimestamp(timestamp)
+""",
+            """\
+--- 
++++ 
+@@ -2,4 +2,4 @@
+ 
+ datetime.datetime.utcnow()
+ timestamp = 1571595618.0
+-datetime.datetime.utcfromtimestamp(timestamp)
++datetime.datetime.fromtimestamp(timestamp, tz=datetime.timezone.utc)
+""",
+        ]
+
         issues = {
             "issues": [
                 {
@@ -60,5 +84,10 @@ class TestSonarSQLParameterization(BaseSASTCodemodTest):
             ]
         }
         self.run_and_assert(
-            tmpdir, input_code, expected, results=json.dumps(issues), num_changes=2
+            tmpdir,
+            input_code,
+            expected,
+            expected_diff_per_change,
+            results=json.dumps(issues),
+            num_changes=2,
         )

--- a/tests/codemods/test_base_codemod.py
+++ b/tests/codemods/test_base_codemod.py
@@ -81,7 +81,7 @@ def test_core_codemod_filter_apply_by_extension(mocker, ext, call_count):
         Path("file2.py"),
     ]
 
-    codemod.apply(context)
+    codemod.apply(context, hardening=True)
 
     assert process_file.call_count == call_count
 

--- a/tests/codemods/test_base_codemod.py
+++ b/tests/codemods/test_base_codemod.py
@@ -81,7 +81,7 @@ def test_core_codemod_filter_apply_by_extension(mocker, ext, call_count):
         Path("file2.py"),
     ]
 
-    codemod.apply(context, hardening=True)
+    codemod.apply(context)
 
     assert process_file.call_count == call_count
 

--- a/tests/codemods/test_combine_isinstance_issubclass.py
+++ b/tests/codemods/test_combine_isinstance_issubclass.py
@@ -60,7 +60,7 @@ class TestCombineIsinstanceIssubclass(BaseCodemodTest):
             tmpdir,
             input_code.replace("{func}", func),
             expected.replace("{func}", func),
-            num_changes,
+            num_changes=num_changes,
         )
 
     @each_func

--- a/tests/codemods/test_combine_startswith_endswith.py
+++ b/tests/codemods/test_combine_startswith_endswith.py
@@ -62,7 +62,7 @@ class TestCombineStartswithEndswith(BaseCodemodTest):
             tmpdir,
             input_code.replace("{func}", func),
             expected.replace("{func}", func),
-            num_changes,
+            num_changes=num_changes,
         )
 
     @each_func

--- a/tests/codemods/test_fix_hasattr_call.py
+++ b/tests/codemods/test_fix_hasattr_call.py
@@ -37,7 +37,75 @@ class TestTransformFixHasattrCall(BaseCodemodTest):
         if callable(obj):
             print(1)
         """
-        self.run_and_assert(tmpdir, input_code, expected, num_changes=5)
+        expected_diff_per_change = [
+            """\
+--- 
++++ 
+@@ -2,7 +2,7 @@
+ class Test:
+     pass
+ 
+-hasattr(Test(), "__call__")
++callable(Test())
+ hasattr("hi", '__call__')
+ 
+ assert hasattr(1, '__call__')
+""",
+            """\
+--- 
++++ 
+@@ -3,7 +3,7 @@
+     pass
+ 
+ hasattr(Test(), "__call__")
+-hasattr("hi", '__call__')
++callable("hi")
+ 
+ assert hasattr(1, '__call__')
+ obj = Test()
+""",
+            """\
+--- 
++++ 
+@@ -5,7 +5,7 @@
+ hasattr(Test(), "__call__")
+ hasattr("hi", '__call__')
+ 
+-assert hasattr(1, '__call__')
++assert callable(1)
+ obj = Test()
+ var = hasattr(obj, "__call__")
+ 
+""",
+            """\
+--- 
++++ 
+@@ -7,7 +7,7 @@
+ 
+ assert hasattr(1, '__call__')
+ obj = Test()
+-var = hasattr(obj, "__call__")
++var = callable(obj)
+ 
+ if hasattr(obj, "__call__"):
+     print(1)
+""",
+            """\
+--- 
++++ 
+@@ -9,5 +9,5 @@
+ obj = Test()
+ var = hasattr(obj, "__call__")
+ 
+-if hasattr(obj, "__call__"):
++if callable(obj):
+     print(1)
+""",
+        ]
+
+        self.run_and_assert(
+            tmpdir, input_code, expected, expected_diff_per_change, num_changes=5
+        )
 
     def test_other_hasattr(self, tmpdir):
         code = """

--- a/tests/codemods/test_secure_random.py
+++ b/tests/codemods/test_secure_random.py
@@ -25,8 +25,38 @@ class TestSecureRandom(BaseCodemodTest):
         secrets.SystemRandom().getrandbits(1)
         var = "hello"
         """
+        expected_diff_per_change = [
+            """\
+--- 
++++ 
+@@ -1,6 +1,7 @@
+ 
+ import random
++import secrets
+ 
+-random.random()
++secrets.SystemRandom().random()
+ random.getrandbits(1)
+ var = "hello"
+""",
+            """\
+--- 
++++ 
+@@ -1,6 +1,7 @@
+ 
+ import random
++import secrets
+ 
+ random.random()
+-random.getrandbits(1)
++secrets.SystemRandom().getrandbits(1)
+ var = "hello"
+""",
+        ]
 
-        self.run_and_assert(tmpdir, input_code, expected_output, num_changes=2)
+        self.run_and_assert(
+            tmpdir, input_code, expected_output, expected_diff_per_change, num_changes=2
+        )
 
     def test_from_random(self, tmpdir):
         input_code = """
@@ -109,7 +139,38 @@ class TestSecureRandom(BaseCodemodTest):
         secrets.SystemRandom().randint()
         var = "hello"
         """
-        self.run_and_assert(tmpdir, input_code, expected_output, num_changes=2)
+        expected_diff_per_change = [
+            """\
+--- 
++++ 
+@@ -1,6 +1,7 @@
+ 
+ import random
++import secrets
+ 
+-random.random()
++secrets.SystemRandom().random()
+ random.randint()
+ var = "hello"
+""",
+            """\
+--- 
++++ 
+@@ -1,6 +1,7 @@
+ 
+ import random
++import secrets
+ 
+ random.random()
+-random.randint()
++secrets.SystemRandom().randint()
+ var = "hello"
+""",
+        ]
+
+        self.run_and_assert(
+            tmpdir, input_code, expected_output, expected_diff_per_change, num_changes=2
+        )
 
     @pytest.mark.parametrize(
         "input_code,expected_output",
@@ -217,8 +278,51 @@ class TestSecureRandom(BaseCodemodTest):
         secrets.choice(["a", "b"])
         secrets.SystemRandom().choices(["a", "b"])
         """
+        expected_diff_per_change = [
+            """\
+--- 
++++ 
+@@ -1,6 +1,7 @@
+ 
+ import random
++import secrets
+ 
+-random.sample(["a", "b"], 1)
++secrets.SystemRandom().sample(["a", "b"], 1)
+ random.choice(["a", "b"])
+ random.choices(["a", "b"])
+""",
+            """\
+--- 
++++ 
+@@ -1,6 +1,7 @@
+ 
+ import random
++import secrets
+ 
+ random.sample(["a", "b"], 1)
+-random.choice(["a", "b"])
++secrets.choice(["a", "b"])
+ random.choices(["a", "b"])
+""",
+            """\
+--- 
++++ 
+@@ -1,6 +1,7 @@
+ 
+ import random
++import secrets
+ 
+ random.sample(["a", "b"], 1)
+ random.choice(["a", "b"])
+-random.choices(["a", "b"])
++secrets.SystemRandom().choices(["a", "b"])
+""",
+        ]
 
-        self.run_and_assert(tmpdir, input_code, expected_output, num_changes=3)
+        self.run_and_assert(
+            tmpdir, input_code, expected_output, expected_diff_per_change, num_changes=3
+        )
 
     def test_from_import_choice(self, tmpdir):
         input_code = """

--- a/tests/codemods/test_tempfile_mktemp.py
+++ b/tests/codemods/test_tempfile_mktemp.py
@@ -79,7 +79,7 @@ class TestTempfileMktemp(BaseCodemodTest):
             filename = tf.name
         var = "hello"
         """
-        self.run_and_assert(tmpdir, input_code, expected_output, 5)
+        self.run_and_assert(tmpdir, input_code, expected_output, num_changes=5)
 
     def test_from_import(self, tmpdir):
         input_code = """


### PR DESCRIPTION
## Overview
Adds independent finding behavior for codemods

## Description
Independent finding behavior means that codemods will execute once for each finding (i.e. remediation), as opposed to once for all findings (i.e. hardening). Hardening aims to produce a file with all the changes, while remediation will produce diffs for each finding. Remediation is the default behavior accessible with the `codemodder` command, while hardening is now accessible as `codemodder_hardening`.

## Additional Details
* Remediation won't write any files as the default behavior, this includes the dependencies.
* While find and fix codemods will still be accessible over the remediation behavior, there is no difference over the hardening behavior. The only exception being codemods that use semgrep scans for findings.
* Most tests with 2+ changes are now being tested for remediation behavior. I've found this gives us a healthy balance of testing for both behaviors while avoiding duplicating each test.
