### PR TITLE
Use `sarif-pydantic` for SARIF data models

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,7 @@ dependencies = [
     "tomlkit~=0.13.0",
     "wrapt~=1.17.0",
     "chardet~=5.2.0",
-    "sarif-pydantic~=0.1.0",
+    "sarif-pydantic~=0.2.0",
     "setuptools~=78.1",
 ]
 keywords = ["codemod", "codemods", "security", "fix", "fixes"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,7 @@ dependencies = [
     "tomlkit~=0.13.0",
     "wrapt~=1.17.0",
     "chardet~=5.2.0",
-    "sarif-pydantic~=0.2.0",
+    "sarif-pydantic~=0.3.0",
     "setuptools~=78.1",
 ]
 keywords = ["codemod", "codemods", "security", "fix", "fixes"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,6 +25,7 @@ dependencies = [
     "tomlkit~=0.13.0",
     "wrapt~=1.17.0",
     "chardet~=5.2.0",
+    "sarif-pydantic~=0.1.0",
     "setuptools~=78.1",
 ]
 keywords = ["codemod", "codemods", "security", "fix", "fixes"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,7 @@ dependencies = [
     "tomlkit~=0.13.0",
     "wrapt~=1.17.0",
     "chardet~=5.2.0",
-    "sarif-pydantic~=0.4.0",
+    "sarif-pydantic~=0.5.0",
     "setuptools~=78.1",
 ]
 keywords = ["codemod", "codemods", "security", "fix", "fixes"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,7 @@ dependencies = [
     "tomlkit~=0.13.0",
     "wrapt~=1.17.0",
     "chardet~=5.2.0",
-    "sarif-pydantic~=0.3.0",
+    "sarif-pydantic~=0.4.0",
     "setuptools~=78.1",
 ]
 keywords = ["codemod", "codemods", "security", "fix", "fixes"]

--- a/src/codemodder/codeql.py
+++ b/src/codemodder/codeql.py
@@ -4,13 +4,13 @@ from pathlib import Path
 from typing_extensions import Self
 
 from codemodder.result import LineInfo, ResultSet, SarifLocation, SarifResult
-from codemodder.sarifs import AbstractSarifToolDetector
+from codemodder.sarifs import AbstractSarifToolDetector, Run
 
 
 class CodeQLSarifToolDetector(AbstractSarifToolDetector):
     @classmethod
-    def detect(cls, run_data: dict) -> bool:
-        return "tool" in run_data and "CodeQL" in run_data["tool"]["driver"]["name"]
+    def detect(cls, run_data: Run) -> bool:
+        return "CodeQL" in run_data.tool.driver.name
 
 
 class CodeQLLocation(SarifLocation):

--- a/src/codemodder/semgrep.py
+++ b/src/codemodder/semgrep.py
@@ -10,16 +10,13 @@ from typing_extensions import Self, override
 from codemodder.context import CodemodExecutionContext
 from codemodder.logging import logger
 from codemodder.result import Result, ResultSet, SarifLocation, SarifResult
-from codemodder.sarifs import AbstractSarifToolDetector
+from codemodder.sarifs import AbstractSarifToolDetector, Run
 
 
 class SemgrepSarifToolDetector(AbstractSarifToolDetector):
     @classmethod
-    def detect(cls, run_data: dict) -> bool:
-        return (
-            "tool" in run_data
-            and "semgrep" in run_data["tool"]["driver"]["name"].lower()
-        )
+    def detect(cls, run_data: Run) -> bool:
+        return "semgrep" in run_data.tool.driver.name
 
 
 class SemgrepLocation(SarifLocation):

--- a/tests/codemods/semgrep/test_semgrep_django_secure_set_cookie.py
+++ b/tests/codemods/semgrep/test_semgrep_django_secure_set_cookie.py
@@ -38,6 +38,7 @@ class TestSemgrepDjangoSecureSetCookie(BaseSASTCodemodTest):
         results = {
             "runs": [
                 {
+                    "tool": {"driver": {"name": "Semgrep OSS"}},
                     "results": [
                         {
                             "fingerprints": {"matchBasedId/v1": "123"},
@@ -66,7 +67,7 @@ class TestSemgrepDjangoSecureSetCookie(BaseSASTCodemodTest):
                             "properties": {},
                             "ruleId": "python.django.security.audit.secure-cookies.django-secure-set-cookie",
                         }
-                    ]
+                    ],
                 }
             ]
         }

--- a/tests/codemods/semgrep/test_semgrep_enable_jinja2_autoescape.py
+++ b/tests/codemods/semgrep/test_semgrep_enable_jinja2_autoescape.py
@@ -27,6 +27,7 @@ class TestEnableJinja2Autoescape(BaseSASTCodemodTest):
         results = {
             "runs": [
                 {
+                    "tool": {"driver": {"name": "Semgrep OSS"}},
                     "results": [
                         {
                             "fingerprints": {"matchBasedId/v1": "123"},
@@ -55,7 +56,7 @@ class TestEnableJinja2Autoescape(BaseSASTCodemodTest):
                             "properties": {},
                             "ruleId": "python.flask.security.xss.audit.direct-use-of-jinja2.direct-use-of-jinja2",
                         }
-                    ]
+                    ],
                 }
             ]
         }

--- a/tests/codemods/semgrep/test_semgrep_harden_pyyaml.py
+++ b/tests/codemods/semgrep/test_semgrep_harden_pyyaml.py
@@ -26,6 +26,7 @@ class TestSemgrepHardenPyyaml(BaseSASTCodemodTest):
         results = {
             "runs": [
                 {
+                    "tool": {"driver": {"name": "Semgrep OSS"}},
                     "results": [
                         {
                             "fingerprints": {"matchBasedId/v1": "123"},
@@ -54,7 +55,7 @@ class TestSemgrepHardenPyyaml(BaseSASTCodemodTest):
                             "properties": {},
                             "ruleId": "python.lang.security.deserialization.avoid-pyyaml-load.avoid-pyyaml-load",
                         }
-                    ]
+                    ],
                 }
             ]
         }
@@ -84,6 +85,7 @@ class TestSemgrepHardenPyyaml(BaseSASTCodemodTest):
         results = {
             "runs": [
                 {
+                    "tool": {"driver": {"name": "Semgrep OSS"}},
                     "results": [
                         {
                             "fingerprints": {"matchBasedId/v1": "123"},
@@ -112,7 +114,7 @@ class TestSemgrepHardenPyyaml(BaseSASTCodemodTest):
                             "properties": {},
                             "ruleId": "python.django.security.audit.avoid-insecure-deserialization.avoid-insecure-deserialization",
                         }
-                    ]
+                    ],
                 }
             ]
         }

--- a/tests/codemods/semgrep/test_semgrep_jwt_decode_verify.py
+++ b/tests/codemods/semgrep/test_semgrep_jwt_decode_verify.py
@@ -25,6 +25,7 @@ class TestSemgrepJwtDecodeVerify(BaseSASTCodemodTest):
         results = {
             "runs": [
                 {
+                    "tool": {"driver": {"name": "Semgrep OSS"}},
                     "results": [
                         {
                             "fingerprints": {"matchBasedId/v1": "123"},
@@ -52,7 +53,7 @@ class TestSemgrepJwtDecodeVerify(BaseSASTCodemodTest):
                             },
                             "ruleId": "python.jwt.security.unverified-jwt-decode.unverified-jwt-decode",
                         }
-                    ]
+                    ],
                 }
             ]
         }

--- a/tests/codemods/semgrep/test_semgrep_nan_injection.py
+++ b/tests/codemods/semgrep/test_semgrep_nan_injection.py
@@ -38,6 +38,7 @@ class TestSemgrepNanInjection(BaseSASTCodemodTest):
         results = {
             "runs": [
                 {
+                    "tool": {"driver": {"name": "Semgrep OSS"}},
                     "results": [
                         {
                             "fingerprints": {"matchBasedId/v1": "1932"},
@@ -112,6 +113,7 @@ class TestSemgrepNanInjection(BaseSASTCodemodTest):
         results = {
             "runs": [
                 {
+                    "tool": {"driver": {"name": "Semgrep OSS"}},
                     "results": [
                         {
                             "fingerprints": {"matchBasedId/v1": "1fdbd5a"},
@@ -247,6 +249,7 @@ class TestSemgrepNanInjection(BaseSASTCodemodTest):
         results = {
             "runs": [
                 {
+                    "tool": {"driver": {"name": "Semgrep OSS"}},
                     "results": [
                         {
                             "fingerprints": {"matchBasedId/v1": "asdfg"},
@@ -304,6 +307,7 @@ class TestSemgrepNanInjection(BaseSASTCodemodTest):
         results = {
             "runs": [
                 {
+                    "tool": {"driver": {"name": "Semgrep OSS"}},
                     "results": [
                         {
                             "fingerprints": {"matchBasedId/v1": "q324"},
@@ -359,6 +363,7 @@ class TestSemgrepNanInjection(BaseSASTCodemodTest):
         results = {
             "runs": [
                 {
+                    "tool": {"driver": {"name": "Semgrep OSS"}},
                     "results": [
                         {
                             "fingerprints": {"matchBasedId/v1": "asdtg"},
@@ -416,6 +421,7 @@ class TestSemgrepNanInjection(BaseSASTCodemodTest):
         results = {
             "runs": [
                 {
+                    "tool": {"driver": {"name": "Semgrep OSS"}},
                     "results": [
                         {
                             "fingerprints": {"matchBasedId/v1": "asd2"},

--- a/tests/codemods/semgrep/test_semgrep_no_csrf_exempt.py
+++ b/tests/codemods/semgrep/test_semgrep_no_csrf_exempt.py
@@ -52,6 +52,7 @@ class TestSemgrepNoCsrfExempt(BaseSASTCodemodTest):
         results = {
             "runs": [
                 {
+                    "tool": {"driver": {"name": "Semgrep OSS"}},
                     "results": [
                         {
                             "fingerprints": {"matchBasedId/v1": "a3ca2"},

--- a/tests/codemods/semgrep/test_semgrep_rsa_key_size.py
+++ b/tests/codemods/semgrep/test_semgrep_rsa_key_size.py
@@ -15,6 +15,7 @@ class TestSemgrepRsaKeySize(BaseSASTCodemodTest):
         results = {
             "runs": [
                 {
+                    "tool": {"driver": {"name": "Semgrep OSS"}},
                     "results": [
                         {
                             "fingerprints": {"matchBasedId/v1": "123"},
@@ -43,7 +44,7 @@ class TestSemgrepRsaKeySize(BaseSASTCodemodTest):
                             "properties": {},
                             "ruleId": "python.cryptography.security.insufficient-rsa-key-size.insufficient-rsa-key-size",
                         }
-                    ]
+                    ],
                 }
             ]
         }

--- a/tests/codemods/semgrep/test_semgrep_sandbox_process_creation.py
+++ b/tests/codemods/semgrep/test_semgrep_sandbox_process_creation.py
@@ -53,6 +53,7 @@ SARIF = """
 {
   "runs": [
     {
+      "tool": {"driver": {"name": "Semgrep OSS"}},
       "automationDetails": {
         "id": ".github/workflows/semgrep.yml:semgrep_scan/"
       },

--- a/tests/codemods/semgrep/test_semgrep_sql_parametrization.py
+++ b/tests/codemods/semgrep/test_semgrep_sql_parametrization.py
@@ -49,6 +49,7 @@ class TestSemgrepSQLParameterization(BaseSASTCodemodTest):
         results = {
             "runs": [
                 {
+                    "tool": {"driver": {"name": "Semgrep OSS"}},
                     "results": [
                         {
                             "fingerprints": {"matchBasedId/v1": "123"},
@@ -185,7 +186,7 @@ class TestSemgrepSQLParameterization(BaseSASTCodemodTest):
                             "properties": {},
                             "ruleId": "python.flask.security.injection.tainted-sql-string.tainted-sql-string",
                         },
-                    ]
+                    ],
                 }
             ]
         }

--- a/tests/codemods/semgrep/test_semgrep_subprocess_shell_false.py
+++ b/tests/codemods/semgrep/test_semgrep_subprocess_shell_false.py
@@ -26,6 +26,7 @@ class TestSemgrepSubprocessShellFalse(BaseSASTCodemodTest):
         results = {
             "runs": [
                 {
+                    "tool": {"driver": {"name": "Semgrep OSS"}},
                     "results": [
                         {
                             "fingerprints": {"matchBasedId/v1": "123"},
@@ -54,7 +55,7 @@ class TestSemgrepSubprocessShellFalse(BaseSASTCodemodTest):
                             "properties": {},
                             "ruleId": "python.lang.security.audit.subprocess-shell-true.subprocess-shell-true",
                         }
-                    ]
+                    ],
                 }
             ]
         }

--- a/tests/codemods/semgrep/test_semgrep_url_sandbox.py
+++ b/tests/codemods/semgrep/test_semgrep_url_sandbox.py
@@ -41,6 +41,7 @@ class TestSemgrepUrlSandbox(BaseSASTCodemodTest):
         results = {
             "runs": [
                 {
+                    "tool": {"driver": {"name": "Semgrep OSS"}},
                     "results": [
                         {
                             "fingerprints": {"matchBasedId/v1": "370059975f"},

--- a/tests/codemods/semgrep/test_semgrep_use_defused_xml.py
+++ b/tests/codemods/semgrep/test_semgrep_use_defused_xml.py
@@ -31,6 +31,7 @@ class TestSemgrepUseDefusedXml(BaseSASTCodemodTest):
         results = {
             "runs": [
                 {
+                    "tool": {"driver": {"name": "Semgrep OSS"}},
                     "results": [
                         {
                             "fingerprints": {"matchBasedId/v1": "123"},
@@ -58,7 +59,7 @@ class TestSemgrepUseDefusedXml(BaseSASTCodemodTest):
                             },
                             "ruleId": "python.lang.security.use-defused-xml-parse.use-defused-xml-parse",
                         }
-                    ]
+                    ],
                 }
             ]
         }

--- a/tests/test_codeql.py
+++ b/tests/test_codeql.py
@@ -1,6 +1,7 @@
 import json
+import tempfile
 from pathlib import Path
-from unittest import TestCase, mock
+from unittest import TestCase
 
 import pytest
 
@@ -36,9 +37,9 @@ class TestCodeQLResultSet(TestCase):
 
     def test_from_sarif(self):
         sarif_file = Path("/path/to/sarif/file.sarif")
-        with mock.patch(
-            "builtins.open", mock.mock_open(read_data=json.dumps(SARIF_CONTENT))
-        ):
+        with tempfile.TemporaryDirectory() as tempdir:
+            sarif_file = Path(tempdir) / "file.sarif"
+            sarif_file.write_text(json.dumps(SARIF_CONTENT))
             result_set = CodeQLResultSet.from_sarif(sarif_file)
 
             self.assertEqual(len(result_set), 3)
@@ -211,11 +212,12 @@ SARIF_CONTENT = {
                 "driver": {"name": "CodeQL"},
                 "extensions": [
                     {
+                        "name": "CodeQL",
                         "rules": [
                             {"id": "python/sql-injection"},
                             {"id": "cs/web/missing-x-frame-options"},
                             {"id": "cs/web/xss"},
-                        ]
+                        ],
                     },
                 ],
             },

--- a/tests/test_codeql.py
+++ b/tests/test_codeql.py
@@ -36,7 +36,6 @@ def test_from_duplicate_files(codeql_result_set: Path):
 class TestCodeQLResultSet(TestCase):
 
     def test_from_sarif(self):
-        sarif_file = Path("/path/to/sarif/file.sarif")
         with tempfile.TemporaryDirectory() as tempdir:
             sarif_file = Path(tempdir) / "file.sarif"
             sarif_file.write_text(json.dumps(SARIF_CONTENT))

--- a/tests/test_sarif_processing.py
+++ b/tests/test_sarif_processing.py
@@ -1,9 +1,9 @@
-import json
 import subprocess
 from pathlib import Path
 
 import pytest
 from pydantic import ValidationError
+from sarif_pydantic import Sarif
 
 from codemodder.codemods.semgrep import process_semgrep_findings
 from codemodder.sarifs import detect_sarif_tools
@@ -14,11 +14,11 @@ class TestSarifProcessing:
     def test_extract_rule_id_codeql(self):
         sarif_file = Path("tests") / "samples" / "webgoat_v8.2.0_codeql.sarif"
 
-        with open(sarif_file, "r", encoding="utf-8") as f:
-            data = json.load(f)
+        data = Sarif.model_validate_json(sarif_file.read_text())
 
-        sarif_run = data["runs"][0]
-        result = sarif_run["results"][0]
+        sarif_run = data.runs[0]
+        assert sarif_run.results, "No results found in SARIF file"
+        result = sarif_run.results[0]
         rule_id = SemgrepResult.extract_rule_id(
             result, sarif_run, truncate_rule_id=True
         )
@@ -27,11 +27,11 @@ class TestSarifProcessing:
     def test_extract_rule_id_semgrep(self):
         sarif_file = Path("tests") / "samples" / "semgrep.sarif"
 
-        with open(sarif_file, "r", encoding="utf-8") as f:
-            data = json.load(f)
+        data = Sarif.model_validate_json(sarif_file.read_text())
 
-        sarif_run = data["runs"][0]
-        result = sarif_run["results"][0]
+        sarif_run = data.runs[0]
+        assert sarif_run.results, "No results found in SARIF file"
+        result = sarif_run.results[0]
         rule_id = SemgrepResult.extract_rule_id(
             result, sarif_run, truncate_rule_id=True
         )

--- a/tests/test_semgrep.py
+++ b/tests/test_semgrep.py
@@ -1,7 +1,7 @@
-import json
 from pathlib import Path
 
 import pytest
+from sarif_pydantic import Sarif
 
 from codemodder.codemods.semgrep import SemgrepSarifFileDetector
 from codemodder.context import CodemodExecutionContext
@@ -20,8 +20,8 @@ SAMPLE_DATA_PATH = Path(__file__).parent / "samples"
 def test_semgrep_sarif_tool_detector(filename, expected):
     detector = SemgrepSarifToolDetector()
     sarif_path = SAMPLE_DATA_PATH / filename
-    data = json.load(sarif_path.open())
-    assert detector.detect(data["runs"][0]) is expected
+    data = Sarif.model_validate_json(sarif_path.read_text())
+    assert detector.detect(data.runs[0]) is expected
 
 
 def test_semgrep_sarif_codemode_detector(mocker):

--- a/tests/test_xml_transformer.py
+++ b/tests/test_xml_transformer.py
@@ -6,6 +6,7 @@ import mock
 import pytest
 from defusedxml import ExternalReferenceForbidden
 from defusedxml.sax import make_parser
+from sarif_pydantic import Sarif
 
 from codemodder.codemods.xml_transformer import (
     ElementAttributeXMLTransformer,
@@ -127,38 +128,42 @@ class TestElementAttributeXMLTransformer:
           </element>
         </configuration>"""
         name_attr_map = {"element": {"first": "one"}}
-        data = {
-            "runs": [
-                {
-                    "results": [
-                        {
-                            "fingerprints": {"matchBasedId/v1": "123"},
-                            "locations": [
-                                {
-                                    "ruleId": "rule",
-                                    "physicalLocation": {
-                                        "artifactLocation": {
-                                            "uri": "code.py",
-                                            "uriBaseId": "%SRCROOT%",
+        data = Sarif.model_validate(
+            {
+                "runs": [
+                    {
+                        "tool": {"driver": {"name": "Semgrep OSS"}},
+                        "results": [
+                            {
+                                "message": {"text": "message"},
+                                "fingerprints": {"matchBasedId/v1": "123"},
+                                "locations": [
+                                    {
+                                        "ruleId": "rule",
+                                        "physicalLocation": {
+                                            "artifactLocation": {
+                                                "uri": "code.py",
+                                                "uriBaseId": "%SRCROOT%",
+                                            },
+                                            "region": {
+                                                "snippet": {"text": "snip"},
+                                                "endColumn": 1,
+                                                "endLine": 5,
+                                                "startColumn": 1,
+                                                "startLine": 5,
+                                            },
                                         },
-                                        "region": {
-                                            "snippet": {"text": "snip"},
-                                            "endColumn": 1,
-                                            "endLine": 5,
-                                            "startColumn": 1,
-                                            "startLine": 5,
-                                        },
-                                    },
-                                }
-                            ],
-                            "ruleId": "rule",
-                        }
-                    ]
-                }
-            ]
-        }
-        sarif_run = data["runs"]
-        sarif_results = sarif_run[0]["results"]
+                                    }
+                                ],
+                                "ruleId": "rule",
+                            }
+                        ],
+                    }
+                ]
+            }
+        )
+        sarif_run = data.runs[0]
+        sarif_results = sarif_run.results or []
         results = [SemgrepResult.from_sarif(sarif_results[0], sarif_run)]
         self.run_and_assert(name_attr_map, input_code, expected_output, results, True)
 

--- a/tests/test_xml_transformer.py
+++ b/tests/test_xml_transformer.py
@@ -163,7 +163,8 @@ class TestElementAttributeXMLTransformer:
             }
         )
         sarif_run = data.runs[0]
-        sarif_results = sarif_run.results or []
+        assert sarif_run.results
+        sarif_results = sarif_run.results
         results = [SemgrepResult.from_sarif(sarif_results[0], sarif_run)]
         self.run_and_assert(name_attr_map, input_code, expected_output, results, True)
 


### PR DESCRIPTION
## Overview
*Use `sarif-pydantic` for SARIF data models*

## Details
* This enables robust validation and structured data types when working with SARIF objects
* Due to the breaking nature of these changes I believe this is going to require a major version bump
