### PR TITLE
make semgrep and optional and test dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,11 @@ The `codemodder` package is available [on PyPI](https://pypi.org/project/codemod
 $ pip install codemodder
 ```
 
+> **WARNING:** You should also install the semgrep optional dependency for now as it isn't deprecated yet:
+ ```
+ $ pip install codemodder[semgrep]
+ ```
+
 To install the package from source, use `pip`:
 
 ```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,6 @@ dependencies = [
     "pylint>=3.3,<3.4",
     "python-json-logger~=3.3.0",
     "PyYAML~=6.0.0",
-    "semgrep>=1.119,<1.120",
     "toml~=0.10.2",
     "tomlkit~=0.13.0",
     "wrapt~=1.17.0",
@@ -52,6 +51,9 @@ generate-docs = 'codemodder.scripts.generate_docs:main'
 get-hashes = 'codemodder.scripts.get_hashes:main'
 
 [project.optional-dependencies]
+semgrep = [
+    "semgrep>=1.119,<1.120",
+]
 test = [
     "azure-ai-inference>=1.0.0b1,<2.0",
     "coverage>=7.8,<7.9",
@@ -84,6 +86,7 @@ test = [
     "fickling~=0.1.0,>=0.1.3",
     "graphql-server~=3.0.0b7",
     "unidiff>=0.7.5",
+    "semgrep>=1.119,<1.120",
 ]
 complexity = [
     "radon==6.0.*",


### PR DESCRIPTION
The Semgrep dependency will soon be deprecated. Allowing for it to be optional helps us install other dependencies with clashes downstream.