### PR TITLE
ISS-4459/add blocked and oos

### DIFF
--- a/src/codemodder/codetf/v3/codetf.py
+++ b/src/codemodder/codetf/v3/codetf.py
@@ -43,6 +43,8 @@ class FixStatusType(str, Enum):
     skipped = "skipped"
     failed = "failed"
     wontfix = "wontfix"
+    blocked = "blocked"
+    out_of_scope = "out_of_scope"
 
 
 class FixStatus(BaseModel):


### PR DESCRIPTION
/towards ISS-4459
## Overview
Adds `blocked` and `out_of_scope` as possible fix outcomes.  These will be in favor of `skipped` and `wontfix` for fix analysis but we will keep all statuses for backwards compat.

## Description

* What/WHY/how these changes are needed

## Additional Details
* Any follow up tickets or discussion
* Any specific merge / deploy details
